### PR TITLE
회원가입시 인증번호 검사하는 로직 완성

### DIFF
--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -1,6 +1,7 @@
-import { ConflictException, Injectable } from "@nestjs/common";
+import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { AuthenticationCodeMessage } from "src/auth/domain/authentication-code-message";
+import { ValidateSmsCodeDto } from "src/auth/interface/dto/validate-code.dto";
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { SmsService } from "src/notification/sms/infra/service/sms.service";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
@@ -17,6 +18,14 @@ export class AuthService {
     async register(phoneNumber: string) {
         await this.checkExistingUserByPhone(phoneNumber); // 가입되어있는 유저인지
         await this.smsService.send(new AuthenticationCodeMessage(phoneNumber)); // 인증코드 발송
+    };
+
+    async validateSmsCode(validateSmsCodeDto: ValidateSmsCodeDto): Promise<void> {
+        /* 전화번호에 해당하는 인증코드 */
+        const existAuthenticationCode = await this.smsService.getAuthenticationCode(validateSmsCodeDto.phoneNumber);
+        /* 비교 */
+        if( !existAuthenticationCode.isEqual(validateSmsCodeDto.code) )
+            throw new UnauthorizedException(ErrorMessage.NotMatchedAuthenticationCode);
     }
 
     private async checkExistingUserByPhone(phoneNumber: string): Promise<void> {

--- a/backend/src/auth/domain/authentication-code.ts
+++ b/backend/src/auth/domain/authentication-code.ts
@@ -1,0 +1,9 @@
+export class AuthenticationCode {
+    private code: number;
+    constructor(code: number) {
+        this.code = code;
+    };
+    
+    isEqual(inputCode: number): boolean { return inputCode == this.code; };
+    getCode(): number { return this.code; };
+}

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post, UsePipes } from "@nestjs/common";
 import { AuthService } from "src/auth/application/service/auth.service";
 import { PhoneValidatorPipe } from "src/user-auth-common/interface/pipe/phone-validator.pipe";
 import { RegisterDto } from "../dto/register.dto";
+import { ValidateSmsCodeDto } from "../dto/validate-code.dto";
 
 @Controller('auth')
 export class AuthController {
@@ -13,5 +14,12 @@ export class AuthController {
     @Post('register')
     async register(@Body() registerDto: RegisterDto) {
         return await this.authService.register(registerDto.phoneNumber);
+    }
+
+    /* 휴대폰 인증코드 검사 */
+    @UsePipes(PhoneValidatorPipe)
+    @Post('code/sms')
+    async validateSmsCode(@Body() validateSmsCodeDto: ValidateSmsCodeDto) {
+        return await this.authService.validateSmsCode(validateSmsCodeDto);
     }
 } 

--- a/backend/src/auth/interface/dto/validate-code.dto.ts
+++ b/backend/src/auth/interface/dto/validate-code.dto.ts
@@ -1,0 +1,4 @@
+export class ValidateSmsCodeDto {
+    phoneNumber: string; 
+    code: number;    
+}

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -1,4 +1,6 @@
 export const enum ErrorMessage {
     PhoneNumberFormat = '휴대폰번호 형식을 확인해주세요',
-    DuplicatedPhoneNumber = '이미 가입된 전화번호입니다.'
+    DuplicatedPhoneNumber = '이미 가입된 전화번호입니다.',
+    ExpiredSmsCode = '인증유효시간이 초과되었습니다. 다시 시도해 주세요.',
+    NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.'
 }

--- a/backend/src/notification/sms/infra/service/sms.service.ts
+++ b/backend/src/notification/sms/infra/service/sms.service.ts
@@ -1,16 +1,29 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { ISMSService } from "../../application/service/isms.service";
 import { NaverSmsService } from "./naver-sms.service";
 import { AuthenticationCodeMessage } from "src/auth/domain/authentication-code-message";
+import { RedisClientType } from "redis";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { AuthenticationCode } from "src/auth/domain/authentication-code";
 
 
 @Injectable()
 export class SmsService implements ISMSService {
     constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
         private readonly naverSmsService: NaverSmsService
     ) {}
 
     async send(smsMessage: AuthenticationCodeMessage) {
         await this.naverSmsService.send(smsMessage);
-    }
+    };
+
+    /* 사용자의 휴대폰 인증 코드 */
+    async getAuthenticationCode(phoneNumber: string): Promise<AuthenticationCode> {
+        const authenticationCode = await this.redis.GET(`phone:${phoneNumber}:code`);
+        if( !authenticationCode )
+            throw new UnauthorizedException(ErrorMessage.ExpiredSmsCode);
+        return new AuthenticationCode(parseInt(authenticationCode));
+    }   
 }

--- a/backend/test/unit/auth/application/service/auth-service.spec.ts
+++ b/backend/test/unit/auth/application/service/auth-service.spec.ts
@@ -1,8 +1,9 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthService } from 'src/auth/application/service/auth.service';
+import { AuthenticationCode } from 'src/auth/domain/authentication-code';
 import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
 import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.service';
 import { SmsService } from 'src/notification/sms/infra/service/sms.service';
@@ -10,6 +11,7 @@ import { Phone } from 'src/user-auth-common/domain/entity/user-phone.entity';
 
 describe('인증 서비스(AuthService) Test', () => {
     let authService: AuthService;
+    let smsService: SmsService;
     beforeAll(async () => {
         const module = await Test.createTestingModule({
             imports: [ConfigModule],
@@ -30,11 +32,30 @@ describe('인증 서비스(AuthService) Test', () => {
             ]
         }).compile();
         authService = module.get(AuthService);
+        smsService = module.get(SmsService);
     })
     describe('register()', () => {
         it('이미 가입되어 있는 전화번호인 경우 409에러를 던진다', async () => {
             const result = async () => await authService.register('01011111111');
             await expect(result).rejects.toThrowError(new ConflictException(ErrorMessage.DuplicatedPhoneNumber));
+        })
+    });
+
+    describe('validateSmsCode()', () => {
+        beforeEach(() => {
+            jest.spyOn(smsService, 'getAuthenticationCode').mockResolvedValueOnce(new AuthenticationCode(222333));
+        })
+
+        it('입력한 인증번호가 다르면 401에러를 던진다.', async () => {
+            const result = authService.validateSmsCode({ phoneNumber: '01011111111', code: 111111});
+            
+            await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.NotMatchedAuthenticationCode));
+        });
+
+        it('입력한 인증번호와 일치하면 반환값이 없다', async () => {
+            const result = authService.validateSmsCode({ phoneNumber: '01011111111', code: 222333});
+            
+            await expect(result).resolves.toBe(undefined);
         })
     })
 })

--- a/backend/test/unit/notification/infra/sms-service.spec.ts
+++ b/backend/test/unit/notification/infra/sms-service.spec.ts
@@ -1,0 +1,49 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config"
+import { Test } from "@nestjs/testing"
+import { RedisClientType } from "redis";
+import { AuthenticationCode } from "src/auth/domain/authentication-code";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { NaverSmsService } from "src/notification/sms/infra/service/naver-sms.service";
+import { SmsService } from "src/notification/sms/infra/service/sms.service"
+
+describe('SMS 서비스(SmsService) Test', () => {
+    let smsService: SmsService;
+    let redis: RedisClientType;
+
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            imports: [ConfigModule],
+            providers: [
+                SmsService,
+                NaverSmsService,
+                {
+                    provide: 'REDIS_CLIENT',
+                    useValue: {
+                        GET: jest.fn()
+                    }
+                }
+            ]
+        }).compile();
+
+        smsService = module.get(SmsService);
+        redis = module.get('REDIS_CLIENT');
+    });
+
+    describe('getAuthenticationCode()', () => {
+        it('코드가 존재하지 않으면 유효시간이 지났다는 에러를 던진다', async () => {
+            jest.spyOn(redis, 'GET').mockReturnValueOnce(null);
+            const result = smsService.getAuthenticationCode('01011111111');
+            
+            await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.ExpiredSmsCode));
+        });
+
+        it('코드가 존재하면 인증코드 객체가 만들어져 반환된다', async () => {
+            jest.spyOn(redis, 'GET').mockResolvedValueOnce('222333');
+            const existAuthenticationCode = await redis.GET('phone:01011111111:code');
+            const authenticationCode = new AuthenticationCode(parseInt(existAuthenticationCode));
+
+            expect(authenticationCode.getCode()).toBe(222333);
+        })
+    })
+})


### PR DESCRIPTION
회원가입을 휴대폰번호로 하기에 인증번호 일치여부를 판단하는 로직 추가

## 추가파일
**src/auth/interface/dto/validate-code.dto.ts**
- 인증번호 검사요청 Dto 추가

**src/auth/domain/authentication-code.ts**
- 인증번호 값 객체 추가
    - isEqual(): 기존 인증번호와 일치하는지 여부 판단 메소드

## 수정파일
**src/auth/application/service/auth.service.ts**
- validateSmsCode(): 인증코드의 일치여부를 확인하기 위한 로직 수행

**src/common/shared/enum/error-message.enum.ts**
- 인증번호 유효시간 초과, 불일치시 에러 메시지 추가

## 테스트
**test/unit/auth/application/service/auth-service.spec.ts**
- service의 validate() Test

**test/unit/notification/infra/sms-service.spec.ts**
- service의 getAuthenticatitonCode() Test