### PR TITLE
보호자용 회원가입 양식들 새로운 API에 맞춰 변경

### DIFF
--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -1,3 +1,4 @@
+import { Time } from "src/common/shared/type/time.type";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
@@ -14,5 +15,5 @@ export class Token {
     private refreshToken: string;
 
     @Column({ name: 'refreshed_at', type: 'timestamp' })
-    private refreshedAt: Date;
+    private refreshedAt: Time;
 }

--- a/backend/src/user-auth-common/domain/entity/user-email.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-email.entity.ts
@@ -1,9 +1,9 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { User } from "./user.entity";
-import { UpdateColumnEntity } from "src/common/shared/entity/base-time.entity";
+import { Time } from "src/common/shared/type/time.type";
 
 @Entity('user_email')
-export class Email extends UpdateColumnEntity {
+export class Email {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
@@ -14,10 +14,6 @@ export class Email extends UpdateColumnEntity {
     @Column({ type: 'varchar', length: 50 })
     private email: string;
 
-    constructor(id: number, userId: number, email: string) {
-        super();
-        this.id = id;
-        this.userId = userId;
-        this.email = email;
-    };
+    @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
+    private updatedAt: Time;
 }

--- a/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
@@ -1,10 +1,10 @@
-import { CreateColumnEntity } from "src/common/shared/entity/base-time.entity";
+import { Time } from "src/common/shared/type/time.type";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 
 @Entity('user_profile')
-export class UserProfile extends CreateColumnEntity {
+export class UserProfile {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
@@ -18,11 +18,7 @@ export class UserProfile extends CreateColumnEntity {
     @Column({ type: 'tinyint' })
     private sex: SEX;
 
-    constructor(id: number, userId: number, birth: number, sex: SEX) {
-        super();
-        this.id = id;
-        this.userId = userId;
-        this.birth = birth;
-        this.sex = sex;
-    }
+    @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
+    private updatedAt: Time;
+
 }

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -1,9 +1,10 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Email } from "./user-email.entity";
+import { Column, CreateDateColumn, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { LOGIN_TYPE, ROLE } from "../enum/user.enum";
 import { Phone } from "./user-phone.entity";
 import { UserProfile } from "./user-profile.entity";
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
+import { Time } from "src/common/shared/type/time.type";
+import { Email } from "./user-email.entity";
 
 @Entity('user')
 export class User {
@@ -18,6 +19,9 @@ export class User {
 
     @Column({ type: 'tinyint' })
     private loginType: LOGIN_TYPE;
+
+    @CreateDateColumn({ name: 'registered_at', type: 'timestamp' })
+    private registeredAt: Time;
 
     @OneToOne(() => Email, (email) => email.userId, { cascade: ['insert', 'update']})
     private email: Promise<Email>;

--- a/frontendv2/components/Btn/BackBtn.jsx
+++ b/frontendv2/components/Btn/BackBtn.jsx
@@ -2,17 +2,22 @@
 import React from 'react';
 import {TouchableHighlight} from 'react-native';
 import Icon from '../Icon';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { secondRegisterReset } from '../../redux/action/register/secondRegisterAction';
 import { confirmRegisterInfoReset, lastRegisterReset } from '../../redux/action/register/lastRegisterAction';
-import { CommonActions, StackActions } from '@react-navigation/native';
+import { StackActions } from '@react-navigation/native';
+import { patientInfoReset } from '../../redux/action/register/patientInfoAction';
 
 export default function BackBtn ({ navigation, type }) {
     const dispatch = useDispatch();
+    const { purpose } = useSelector(
+        state => ({
+            purpose: state.firstRegister.user.purpose,
+    }))
     const onPressBackBtn = () => {
         switch(type) {
             case 'secondRegisterReset' :        //2번째 페이지에서 뒤로가기 버튼( 2번째 작성 전부 리셋 )
-                dispatch(secondRegisterReset());
+                purpose === 'protector' ? dispatch(patientInfoReset()) : dispatch(secondRegisterReset());
             case 'lastRegisterReset' :
                 dispatch(lastRegisterReset());
             case 'confirmRegisterInfoReset' :

--- a/frontendv2/components/LastRegister/Protector/CompleteRegisterBtn.jsx
+++ b/frontendv2/components/LastRegister/Protector/CompleteRegisterBtn.jsx
@@ -1,4 +1,4 @@
-/* 회원가입 완료 버튼 */
+/* 보호자용 회원가입 완료 버튼 */
 
 import { Platform } from "react-native";
 import { StyleSheet, Text, TouchableHighlight, View } from "react-native";
@@ -7,11 +7,11 @@ import { useSelector, shallowEqual } from "react-redux";
 import requestCreateUser from "../../../functions/Register/requestCreateUser";
 
 export default function CompleteRegisterBtn({ navigation }) {
-    const { firstRegister, secondRegister, lastRegister } = useSelector(
+    const { firstRegister, patientInfo, patientHelpList } = useSelector(
         state => ({
             firstRegister: state.firstRegister.user,
-            secondRegister: state.secondRegister,
-            lastRegister: state.lastRegister
+            patientInfo: state.patientInfo,
+            patientHelpList: state.patientHelpList
         }),
         shallowEqual
     )
@@ -31,8 +31,8 @@ export default function CompleteRegisterBtn({ navigation }) {
                     await requestCreateUser(
                         {
                             firstRegister,
-                            secondRegister,
-                            lastRegister
+                            patientInfo,
+                            patientHelpList
                         },
                         navigation
                     )

--- a/frontendv2/components/LastRegister/Protector/Help.jsx
+++ b/frontendv2/components/LastRegister/Protector/Help.jsx
@@ -2,9 +2,16 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useDispatch } from "react-redux";
-import { saveBathChair, saveBedSore, saveMeal, saveSuction, saveToilet, saveWashing } from '../../../redux/action/register/lastRegisterAction'; 
 import helpContentData from "../../../data/Register/LastRegister/helpContent.data";
 import RegisterHelpText from "../../RegisterHelpText";
+import { 
+    saveBathChair, 
+    saveBedSore, 
+    saveMeal, 
+    saveSuction, 
+    saveToilet, 
+    saveWashing 
+} from "../../../redux/action/register/patientHelpListAction";
 
 export default function Help() {
     const dispatch = useDispatch();

--- a/frontendv2/components/SecondRegister/Protector/NextRegisterBtn.jsx
+++ b/frontendv2/components/SecondRegister/Protector/NextRegisterBtn.jsx
@@ -1,5 +1,4 @@
 /* 보호자용 2번째 회원가입 페이지 다음으로 가는 버튼 */
-
 import { useEffect, useState } from "react";
 import { Text, TouchableHighlight, View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
@@ -9,20 +8,20 @@ export default function NextRegisterBtn({ navigation }) {
     const [isFill, setIsFill] = useState(false);
     const {weight, patientSex, diagnosis, startPeriod, place, isNext, patientState} = useSelector(
         state => ({
-            weight: state.secondRegister.weight,
-            patientSex: state.secondRegister.protector.patientSex,
-            diagnosis: state.secondRegister.protector.diagnosis,
-            startPeriod: state.secondRegister.protector.startPeriod,
-            place: state.secondRegister.protector.place,
-            isNext: state.secondRegister.protector.isNext,
-            patientState: state.secondRegister.protector.patientState,
+            weight: state.patientInfo.weight,
+            patientSex: state.patientInfo.patientSex,
+            diagnosis: state.patientInfo.diagnosis,
+            startPeriod: state.patientInfo.startPeriod,
+            place: state.patientInfo.place,
+            isNext: state.patientInfo.isNext,
+            patientState: state.patientInfo.patientState,
         }),
         shallowEqual
     );
 
     useEffect(() => {
         weight && patientSex && diagnosis && place && startPeriod
-            && isNext && patientState ? setIsFill(true) : setIsFill(false)
+            && (isNext == false || isNext == true) && patientState ? setIsFill(true) : setIsFill(false)
     },[ weight, patientSex, diagnosis, startPeriod, place, isNext, patientState ])
 
     return (

--- a/frontendv2/components/SecondRegister/Protector/PatientDiagnosis.jsx
+++ b/frontendv2/components/SecondRegister/Protector/PatientDiagnosis.jsx
@@ -6,7 +6,7 @@ import { TouchableHighlight } from "react-native";
 import { Text, StyleSheet, TextInput, View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useDispatch } from "react-redux";
-import { saveDiagnosis } from "../../../redux/action/register/secondRegisterAction";
+import { saveDiagnosis } from "../../../redux/action/register/patientInfoAction";
 import inputStyle from "../../../styles/Register/inputStyle";
 import Icon from "../../Icon";
 

--- a/frontendv2/components/SecondRegister/Protector/PatientPlaceAndNext.jsx
+++ b/frontendv2/components/SecondRegister/Protector/PatientPlaceAndNext.jsx
@@ -2,13 +2,12 @@
 
 import { useEffect } from "react";
 import { useState } from "react";
-import { StyleSheet, Text, TextInput, TouchableHighlight, View } from "react-native";
+import { StyleSheet, Text, TouchableHighlight, View } from "react-native";
 import { heightPercentageToDP as hp } from "react-native-responsive-screen";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import resetArrayData from "../../../functions/resetArrayData";
-import { saveIsNext, savePlace } from "../../../redux/action/register/secondRegisterAction";
+import { saveIsNext, savePlace } from "../../../redux/action/register/patientInfoAction";
 import isNextData from "../../../data/Register/SecondRegister/isNext.data";
-import inputStyle from "../../../styles/Register/inputStyle";
 import { useNavigation, StackActions, useRoute } from "@react-navigation/native";
 import Icon from "../../Icon";
 

--- a/frontendv2/components/SecondRegister/Protector/PatientSex.jsx
+++ b/frontendv2/components/SecondRegister/Protector/PatientSex.jsx
@@ -1,12 +1,11 @@
 /* 보호자용 2번째 회원가입 환자 성별 입력 */
-
 import { useEffect } from "react";
 import { useState } from "react";
 import { StyleSheet, Text, TouchableHighlight, View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useDispatch } from "react-redux";
 import resetArrayData from "../../../functions/resetArrayData";
-import { savePatientSex } from "../../../redux/action/register/secondRegisterAction";
+import { savePatientSex } from "../../../redux/action/register/patientInfoAction";
 import sexData from "../../../data/Register/sex.data";
 
 export default function PatientSex() {

--- a/frontendv2/components/SecondRegister/Protector/PatientState.jsx
+++ b/frontendv2/components/SecondRegister/Protector/PatientState.jsx
@@ -2,7 +2,7 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useDispatch } from "react-redux";
-import { savePatientState } from "../../../redux/action/register/secondRegisterAction";
+import { savePatientState } from "../../../redux/action/register/patientInfoAction";
 
 export default function PatientState() {
     const dispatch = useDispatch();

--- a/frontendv2/components/SecondRegister/Protector/PatientWeight.jsx
+++ b/frontendv2/components/SecondRegister/Protector/PatientWeight.jsx
@@ -2,7 +2,7 @@
 import { View, Text, TextInput, StyleSheet } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useDispatch } from "react-redux";
-import { saveWeight } from "../../../redux/action/register/secondRegisterAction";
+import { saveWeight } from "../../../redux/action/register/patientInfoAction"; 
 import inputStyle from "../../../styles/Register/inputStyle";
 
 export default function PatientWeight() {

--- a/frontendv2/components/SecondRegister/Protector/SelectCarePeriod.jsx
+++ b/frontendv2/components/SecondRegister/Protector/SelectCarePeriod.jsx
@@ -1,10 +1,8 @@
 /* 케어 기간 날짜 고르기 */
-
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CalendarList, LocaleConfig } from 'react-native-calendars'
 import StatusBarComponent from "../../StatusBarComponent";
-import { heightPercentageToDP as hp } from "react-native-responsive-screen";
 import Icon from "../../Icon";
 import { useState } from "react";
 import { Text } from "react-native";
@@ -13,7 +11,7 @@ import { useEffect } from "react";
 import { TouchableHighlight } from "react-native";
 import { CommonActions } from "@react-navigation/native";
 import { useDispatch } from "react-redux";
-import { saveEndPeriod, saveStartPeriod } from "../../../redux/action/register/secondRegisterAction";
+import { saveEndPeriod, saveStartPeriod, saveTotalPeriod } from "../../../redux/action/register/patientInfoAction";
 
 LocaleConfig.locales['fr'] = {
     monthNames: ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
@@ -74,9 +72,10 @@ export default function SelectCarePeriod({ navigation }) {
         );
         dispatch(
             saveEndPeriod(
-                !!end ? end : null
+                !!end ? end : start
             ),
-        )
+        );
+        dispatch(saveTotalPeriod(period));
     }
 
     const pressDay = (day) => {

--- a/frontendv2/functions/Register/requestCreateUser.jsx
+++ b/frontendv2/functions/Register/requestCreateUser.jsx
@@ -8,10 +8,12 @@ import store from "../../redux/store";
 
 export default async function requestCreateUser(RegisterData, navigation) {
     try {
-        const res = await api.post('auth/register', {
-            firstRegister: RegisterData.firstRegister,
-            secondRegister: RegisterData.secondRegister,
-            lastRegister: RegisterData.lastRegister
+        const firstRegister = RegisterData.firstRegister;
+        /* 가입목적에 따른 Api Body 다르게 요청 */
+        const res = await api.post(`user/register/${firstRegister.purpose}`, {
+            firstRegister,
+            secondRegister: RegisterData.patientInfo,
+            lastRegister: RegisterData.patientHelpList
         });
 
         const accessToken = res.data.accessToken;

--- a/frontendv2/redux/action/register/patientHelpListAction.js
+++ b/frontendv2/redux/action/register/patientHelpListAction.js
@@ -1,0 +1,8 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const saveSuction = createAction('patientHelpList/saveSuction'); // 석션 부분
+export const saveToilet = createAction('patientHelpList/saveToilet'); // 용변 부분
+export const saveBedSore = createAction('patientHelpList/saveBedSore'); // 욕창 부분
+export const saveWashing = createAction('patientHelpList/saveWashing'); // 세면 부분
+export const saveBathChair = createAction('patientHelpList/saveBathChair'); // 휠체어 부분
+export const saveMeal = createAction('patientHelpList/saveMeal'); // 식사 부분

--- a/frontendv2/redux/action/register/patientInfoAction.js
+++ b/frontendv2/redux/action/register/patientInfoAction.js
@@ -1,0 +1,12 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const saveWeight = createAction('patientInfo/saveWeight'); // 환자 몸무게
+export const savePatientSex = createAction('patientInfo/savePatientSex'); // 환자 성별
+export const saveDiagnosis = createAction('patientInfo/saveDiagnosis'); // 환자 진단명
+export const saveStartPeriod = createAction('patientInfo/saveStartPeriod'); // 환자 케어 시작 날짜
+export const saveEndPeriod = createAction('patientInfo/saveEndPeriod'); // 환자 케어 마치는 날짜
+export const saveTotalPeriod = createAction('patientInfo/saveTotalPeriod'); // 환자 케어 총 일수
+export const savePlace = createAction('patientInfo/savePlace'); // 환자 케어하게 될 장소
+export const saveIsNext = createAction('patientInfo/saveIsNext'); // 환자 다음병원 예정 여부
+export const savePatientState = createAction('patientInfo/savePatientState'); // 환자 자세한 몸상태
+export const patientInfoReset = createAction('patientInfo/patientInfoReset'); // 환자 정보 작성 초기화

--- a/frontendv2/redux/action/register/secondRegisterAction.js
+++ b/frontendv2/redux/action/register/secondRegisterAction.js
@@ -1,6 +1,6 @@
 import { createAction } from "@reduxjs/toolkit";
 
-//간병인, 활동보조사 2번째 회원가입 페이지
+//간병인 2번째 회원가입 페이지
 export const saveWeight = createAction('secondRegister/saveWeight');
 export const saveCareer = createAction('secondRegister/saveCareer');
 export const saveFirstPay = createAction('secondRegister/saveFirstPay');
@@ -13,11 +13,3 @@ export const deletePossibleArea = createAction('secondRegister/deletePossibleAre
 export const saveLicense = createAction('secondRegister/saveLicense');
 export const deleteLicense = createAction('secondRegister/deleteLicense');
 export const secondRegisterReset = createAction('secondRegister/secondRegisterReset');
-
-export const savePatientSex = createAction('secondRegister/savePatientSex');
-export const saveDiagnosis = createAction('secondRegister/saveDiagnosis');
-export const saveStartPeriod = createAction('secondRegister/saveStartPeriod');
-export const saveEndPeriod = createAction('secondRegister/saveEndPeriod');
-export const savePlace = createAction('secondRegister/savePlace');
-export const saveIsNext = createAction('secondRegister/saveIsNext');
-export const savePatientState = createAction('secondRegister/savePatientState');

--- a/frontendv2/redux/reducer/register/firstRegisterReducer.js
+++ b/frontendv2/redux/reducer/register/firstRegisterReducer.js
@@ -31,13 +31,14 @@ const firstRegisterReducer = createReducer(initialState, (builder) => {
             state.user.name = action.payload
         })
         .addCase(saveBirth, (state, action) => {
-            state.user.birth = action.payload
+            state.user.birth = Number(action.payload)
         })
         .addCase(saveSex, (state, action) => {
             state.user.sex = action.payload
         })
         .addCase(savePurpose, (state, action) => {
-            state.user.purpose = action.payload
+            state.user.purpose = 
+                action.payload === '간병인' ? 'caregiver' : 'protector'
         })
         .addCase(saveIsAuthed, (state, action) => {
             state.isAuthed = action.payload

--- a/frontendv2/redux/reducer/register/patientHelpListReducer.js
+++ b/frontendv2/redux/reducer/register/patientHelpListReducer.js
@@ -1,0 +1,42 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { 
+    saveBathChair, 
+    saveBedSore, 
+    saveMeal, 
+    saveSuction, 
+    saveToilet, 
+    saveWashing 
+} from "../../action/register/patientHelpListAction";
+
+const initialState = {
+    suction: '',
+    toilet: '',
+    bedsore: '',
+    washing: '',
+    meal: '',
+    bathChair: ''
+};
+
+const patientHelpListReducer = createReducer(initialState, (builder) => {
+    builder
+        .addCase(saveSuction, (state, action) => {
+            state.suction = action.payload
+        })
+        .addCase(saveToilet, (state, action) => {
+            state.toilet = action.payload
+        })
+        .addCase(saveBedSore, (state, action) => {
+            state.bedsore = action.payload
+        })
+        .addCase(saveWashing, (state, action) => {
+            state.washing = action.payload
+        })
+        .addCase(saveMeal, (state, action) => {
+            state.meal = action.payload
+        })
+        .addCase(saveBathChair, (state, action) => {
+            state.bathChair = action.payload
+        })
+});
+
+export default patientHelpListReducer;

--- a/frontendv2/redux/reducer/register/patientInfoReducer.js
+++ b/frontendv2/redux/reducer/register/patientInfoReducer.js
@@ -1,0 +1,62 @@
+import { createReducer } from "@reduxjs/toolkit";
+import { 
+    patientInfoReset,
+    saveDiagnosis,
+    saveEndPeriod, 
+    saveIsNext, 
+    savePatientSex,
+    savePatientState, 
+    savePlace, 
+    saveStartPeriod, 
+    saveTotalPeriod, 
+    saveWeight 
+} from "../../action/register/patientInfoAction";
+
+const initialState = {
+    weight: 0,
+    patientSex: '',
+    diagnosis: '',
+    startPeriod: '',
+    endPeriod: '',
+    totalPeriod: 0,
+    place: '',
+    isNext: '',
+    patientState: ''
+};
+
+const patientInfoReducer = createReducer(initialState, (builder) => {
+    builder
+        .addCase(saveWeight, (state, action) => { // 3명 공통 입력칸인 몸무게 저장
+            state.weight = Number(action.payload)
+        })
+        .addCase(savePatientSex, (state, action) => { // 보호자용 환자의 성별 저장
+            state.patientSex = action.payload
+        })
+        .addCase(saveDiagnosis, (state, action) => { //보호자용 환자가 받은 진단명 저장
+            state.diagnosis = action.payload
+        })
+        .addCase(saveStartPeriod, (state, action) => {
+            state.startPeriod = action.payload;
+        })
+        .addCase(saveEndPeriod, (state, action) => {
+            state.endPeriod = action.payload;
+        })
+        .addCase(saveTotalPeriod, (state, action) => {
+            state.totalPeriod = Number(action.payload);
+        })
+        .addCase(savePlace, (state, action) => { // 보호자용 환자 케어 장소 저장
+            state.place = action.payload
+        })
+        .addCase(saveIsNext, (state, action) => { // 보호자용 환자가 다음 병원 예정되어있는지 저장
+            state.isNext = 
+                action.payload === '예정' ? true : false;
+        })
+        .addCase(savePatientState, (state, action) => { // 보호자용 환자 현재 상태 저장
+            state.patientState = action.payload
+        })
+        .addCase(patientInfoReset, (state) => { // 두번째 회원가입 페이지 초기화
+            Object.assign(state, initialState)
+        })
+});
+
+export default patientInfoReducer;

--- a/frontendv2/redux/reducer/register/secondRegisterReducer.js
+++ b/frontendv2/redux/reducer/register/secondRegisterReducer.js
@@ -12,13 +12,6 @@ import {
     secondRegisterReset,
     saveTime,
     saveTraining,
-    savePatientSex,
-    saveDiagnosis,
-    savePlace,
-    saveIsNext,
-    savePatientState,
-    saveStartPeriod,
-    saveEndPeriod
 } from '../../action/register/secondRegisterAction';
 
 const initialState = {
@@ -35,21 +28,12 @@ const initialState = {
         time: '',
         training: ''
     },
-    protector: {
-        patientSex: '',
-        diagnosis: '',
-        startPeriod: '',
-        endPeriod: '',
-        place: '',
-        isNext: '',
-        patientState: ''
-    }
 }
 
 const secondRegisterReducer = createReducer(initialState, (builder) => {
     builder
         .addCase(saveWeight, (state, action) => { // 3명 공통 입력칸인 몸무게 저장
-            state.weight = action.payload
+            state.weight = Number(action.payload)
         })
         .addCase(saveCareer, (state, action) => { // 간병인, 활동보조사 경력 저장
             state.career = action.payload
@@ -83,27 +67,6 @@ const secondRegisterReducer = createReducer(initialState, (builder) => {
         })
         .addCase(secondRegisterReset, (state) => { // 두번째 회원가입 페이지 초기화
             Object.assign(state, initialState)
-        })
-        .addCase(savePatientSex, (state, action) => { // 보호자용 환자의 성별 저장
-            state.protector.patientSex = action.payload
-        })
-        .addCase(saveDiagnosis, (state, action) => { //보호자용 환자가 받은 진단명 저장
-            state.protector.diagnosis = action.payload
-        })
-        .addCase(saveStartPeriod, (state, action) => {
-            state.protector.startPeriod = action.payload;
-        })
-        .addCase(saveEndPeriod, (state, action) => {
-            state.protector.endPeriod = action.payload;
-        })
-        .addCase(savePlace, (state, action) => { // 보호자용 환자 케어 장소 저장
-            state.protector.place = action.payload
-        })
-        .addCase(saveIsNext, (state, action) => { // 보호자용 환자가 다음 병원 예정되어있는지 저장
-            state.protector.isNext = action.payload
-        })
-        .addCase(savePatientState, (state, action) => { // 보호자용 환자 현재 상태 저장
-            state.protector.patientState = action.payload
         })
 })
 

--- a/frontendv2/redux/store.js
+++ b/frontendv2/redux/store.js
@@ -1,5 +1,6 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import firstRegisterReducer from "./reducer/register/firstRegisterReducer";
+import patientInfoReducer from "./reducer/register/patientInfoReducer";
 import secondRegisterReducer from './reducer/register/secondRegisterReducer';
 import lastRegisterReducer from './reducer/register/lastRegisterReducer';
 import loginReducer from "./reducer/login/loginReducer";
@@ -7,11 +8,13 @@ import userReducer from "./reducer/user/userReducer";
 import profileReducer from "./reducer/profile/profileReducer";
 import searchReducer from "./reducer/search/searchReducer";
 import chatReducer from "./reducer/chat/chatReducer";
+import patientHelpListReducer from "./reducer/register/patientHelpListReducer";
 const store = configureStore ({
     reducer: {
-        //register: registerSlice.reducer
         firstRegister: firstRegisterReducer,
         secondRegister: secondRegisterReducer,
+        patientInfo: patientInfoReducer,
+        patientHelpList: patientHelpListReducer,
         lastRegister: lastRegisterReducer,
         login: loginReducer,
         user: userReducer,

--- a/frontendv2/screens/Register/SecondRegister.jsx
+++ b/frontendv2/screens/Register/SecondRegister.jsx
@@ -11,13 +11,16 @@ import Protector from "./SecondRegister/Protector";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { secondRegisterReset } from "../../../frontendv2/redux/action/register/secondRegisterAction";
+import { patientInfoReset } from "../../redux/action/register/patientInfoAction";
 
 export default function SecondRegister({ navigation }) {
     
     const purpose = useSelector((state) => state.firstRegister.user.purpose); //가입목적
     const dispatch = useDispatch();
     const backAction = () => {
-        dispatch(secondRegisterReset());
+        /* 가입 목적에 따른 양식 초기화 달리 */
+        purpose === 'protector' ? 
+            dispatch(patientInfoReset()) : dispatch(secondRegisterReset());
         navigation.goBack();
         return true;
     }


### PR DESCRIPTION
### 회원가입 순서
1. 보호자와 간병인 공통의 회원가입 양식
2. 환자 정보 입력
3. 환자가 필요로 하는 도움 리스트 작성

### 추가 파일
**redux/reducer/register/patientInfoReducer.js** 
**redux/action/register/patientInfoAction.js**
- 두번째 회원가입 페이지 양식으로 환자 정보 관리

**redux/reducer/register/patientHelpListReducer.js** 
**redux/action/register/patientHelpListAction.js**
- 세번째 회원가입 페이지 양식으로 환자가 필요로 하는 도움 리스트 관리

### 변경 파일
**redux/reducer/register/firstRegisterReducer.js**
- addCase(savePurpose): 가입목적을 한글로 저장하던 것을 영어로 저장(간병인 -> caregiver, 보호자 -> protector)

### 동작영상
https://github.com/JOOYUNHAK/caregiver-project-v2/assets/99117410/6210ca99-afba-454a-82f6-ec501e806a98

