### PR TITLE
[백엔드] 간병인 회원가입 로직 완료

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,6 +30,7 @@
         "class-validator": "^0.14.0",
         "dayjs": "^1.11.6",
         "js-yaml": "^4.1.0",
+        "mongodb": "^5.0.0",
         "mysql2": "^2.3.3",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.0",
@@ -2360,9 +2361,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
-      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2457,6 +2458,20 @@
       "version": "13.7.17",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
       "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.11",
@@ -3374,6 +3389,14 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+      "engines": {
+        "node": ">=14.20.1"
       }
     },
     "node_modules/buffer": {
@@ -5560,6 +5583,11 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6984,6 +7012,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -7112,6 +7146,78 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.0.0.tgz",
+      "integrity": "sha512-WHmlbefKp/iAX2LlSZ56iKt4pRftib/dD3mDaji8R7IJcRoKPc5+/kSn3mIBxKPLVxcl73KdDKBLkQTxj1OjaA==",
+      "dependencies": {
+        "bson": "^5.0.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": "^2.3.0",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ms": {
@@ -7872,7 +7978,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8219,6 +8324,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8449,6 +8566,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/socket.io": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
@@ -8480,6 +8606,19 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/source-map": {
@@ -8515,6 +8654,15 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -11677,9 +11825,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
-      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -11774,6 +11922,20 @@
       "version": "13.7.17",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
       "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.11",
@@ -12463,6 +12625,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -14091,6 +14258,11 @@
         "standard-as-callback": "^2.1.0"
       }
     },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -15188,6 +15360,12 @@
         "fs-monkey": "^1.0.3"
       }
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -15280,6 +15458,50 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
         "minimist": "^1.2.6"
+      }
+    },
+    "mongodb": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.0.0.tgz",
+      "integrity": "sha512-WHmlbefKp/iAX2LlSZ56iKt4pRftib/dD3mDaji8R7IJcRoKPc5+/kSn3mIBxKPLVxcl73KdDKBLkQTxj1OjaA==",
+      "requires": {
+        "bson": "^5.0.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -15856,8 +16078,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.10.3",
@@ -16093,6 +16314,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -16283,6 +16513,11 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
     "socket.io": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
@@ -16308,6 +16543,15 @@
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
+      }
+    },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
       }
     },
     "source-map": {
@@ -16339,6 +16583,15 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "class-validator": "^0.14.0",
     "dayjs": "^1.11.6",
     "js-yaml": "^4.1.0",
+    "mongodb": "^5.0.0",
     "mysql2": "^2.3.3",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
@@ -100,6 +101,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.ts"
+    ]
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { UserAuthCommonModule } from './user-auth-common/user-auth-common.module
 import { GlobalScopedExceptionFilter } from './common/exception/all-exception.filter';
 import { GlobalScopedValidationPipe } from './common/pipe/global-scoped.pipe';
 import { CoreModule } from './core/core.module';
+import { MongodbModule } from './common/shared/database/mongodb/mongodb.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { CoreModule } from './core/core.module';
     CoreModule,
     TypeOrmModule.forRootAsync(TypeOrmOptions),
     RedisModule,
+    MongodbModule,
     AuthModule,
     UserAuthCommonModule,
     UserModule

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './interface/controller/auth.controller';
 import { SmsService } from 'src/notification/sms/infra/service/sms.service';
 import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.service';
 import { UserAuthCommonModule } from 'src/user-auth-common/user-auth-common.module';
+import { TokenService } from './application/service/token.service';
 
 @Module({
   imports: [
@@ -15,7 +16,11 @@ import { UserAuthCommonModule } from 'src/user-auth-common/user-auth-common.modu
   providers: [
     AuthService,
     SmsService,
-    NaverSmsService
+    NaverSmsService,
+    TokenService
   ],
+  exports: [
+    TokenService
+  ]
 })
 export class AuthModule {}

--- a/backend/src/common/pipe/global-scoped.pipe.ts
+++ b/backend/src/common/pipe/global-scoped.pipe.ts
@@ -3,5 +3,5 @@ import { APP_PIPE } from "@nestjs/core";
 
 export const GlobalScopedValidationPipe = {
     provide: APP_PIPE,
-    useValue: new ValidationPipe({ transform: true })
+    useValue: new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
 }

--- a/backend/src/common/shared/database/mongodb/mongodb.module.ts
+++ b/backend/src/common/shared/database/mongodb/mongodb.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { mongodbProvider } from "./mongodb.provider";
+
+@Module({
+    providers: [...mongodbProvider],
+    exports: [...mongodbProvider]
+})
+export class MongodbModule {}

--- a/backend/src/common/shared/database/mongodb/mongodb.provider.ts
+++ b/backend/src/common/shared/database/mongodb/mongodb.provider.ts
@@ -1,0 +1,19 @@
+import { ConfigModule, ConfigService } from "@nestjs/config"
+import { MongoClient } from "mongodb";
+
+export const mongodbProvider = [
+    {
+        provide: 'MONGO_CONNECTION',
+        import: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: async(configService: ConfigService) => {
+            try{
+                const client = await MongoClient.connect(configService.get('db.mongodb.uri'));
+                return client.db(configService.get('db.mongodb.database'));
+            }
+            catch(err) {
+                throw err;
+            }
+        }
+    }
+]

--- a/backend/src/user-auth-common/interface/client.dto.ts
+++ b/backend/src/user-auth-common/interface/client.dto.ts
@@ -1,0 +1,4 @@
+export interface ClientDto { 
+    readonly id: number;
+    readonly accessToken: string; 
+};

--- a/backend/src/user-auth-common/interface/client.interface.ts
+++ b/backend/src/user-auth-common/interface/client.interface.ts
@@ -1,1 +1,0 @@
-export interface ClientDto { accessToken: string; };

--- a/backend/src/user/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/user/application/mapper/caregiver-profile.mapper.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+import { ObjectId } from "mongodb";
+import { CaregiverProfileBuilder } from "src/user/domain/builder/profile.builder";
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
+import { License } from "src/user/domain/entity/caregiver/license.entity";
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto";
+
+@Injectable()
+export class CaregiverProfileMapper {
+    mapFrom(userId: number, caregiverRegisterDto: CaregiverRegisterDto): CaregiverProfile {
+        const { secondRegister, thirdRegister, lastRegister } = caregiverRegisterDto;
+        return new CaregiverProfileBuilder( new ObjectId() )
+            .userId(userId)
+            .weight(secondRegister.weight)
+            .career(secondRegister.career)
+            .pay(secondRegister.pay)
+            .possibleDate(secondRegister.possibleDate)
+            .possibleAreaList(secondRegister.possibleAreaList)
+            .licenseList(this.toLicenseList(secondRegister.licenseList))
+            .nextHosptial(secondRegister.nextHospital)
+            .helpExperience(thirdRegister.helpExperience)
+            .strengthList(thirdRegister.strengthList)
+            .tagList(thirdRegister.tagList)
+            .notice(lastRegister.notice)
+            .additionalChargeCase(lastRegister.additionalChargeCase)
+            .warningList()
+            .build()
+    }
+
+    private toLicenseList(licenseList: string[]): License[] {
+        return licenseList.map(license => new License(license))
+    };
+}

--- a/backend/src/user/application/mapper/protector.mapper.ts
+++ b/backend/src/user/application/mapper/protector.mapper.ts
@@ -4,7 +4,7 @@ import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE } from "src/user-auth-common/domain/enum/user.enum";
-import { ClientDto } from "src/user-auth-common/interface/client.interface";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { CarePeriod } from "src/user/domain/entity/protector/care-period.entity";
 import { Patient } from "src/user/domain/entity/protector/patient.entity";
 import { Protector } from "src/user/domain/entity/protector/protector.entity";

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@nestjs/common";
+import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { LOGIN_TYPE } from "src/user-auth-common/domain/enum/user.enum";
+import { ClientDto } from "src/user-auth-common/interface/client.interface";
+import { CommonRegisterForm } from "src/user/interface/dto/register-page";
+
+@Injectable()
+export class UserMapper {
+    mapFrom(commonRegisterDto: CommonRegisterForm): User {
+        return new User(
+            commonRegisterDto.name,
+            commonRegisterDto.purpose,
+            LOGIN_TYPE.PHONE,
+            this.createEmailByLoginType(LOGIN_TYPE.PHONE),
+            this.createPhoneByLoginType(LOGIN_TYPE.PHONE, commonRegisterDto.id),
+            new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex),
+            null
+        )
+    };
+
+    async toDto(user: User): Promise<ClientDto> {
+        return {
+            id: user.getId(),
+            accessToken: (await user.getAuthentication()).getAccessToken(),
+        };
+    }
+
+     /* 이메일로 회원가입(현재는 휴대폰으로만 제공) */
+     private createEmailByLoginType(loginType: LOGIN_TYPE): null | Email {
+        return loginType == LOGIN_TYPE.PHONE ? null : new Email();
+    };
+
+    /* 휴대폰으로 회원가입  */
+    private createPhoneByLoginType(loginType: LOGIN_TYPE, phoneNumber: string): null | Phone {
+        return loginType == LOGIN_TYPE.PHONE ? new Phone(phoneNumber) : null;
+    }
+}

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -4,7 +4,7 @@ import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE } from "src/user-auth-common/domain/enum/user.enum";
-import { ClientDto } from "src/user-auth-common/interface/client.interface";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { CommonRegisterForm } from "src/user/interface/dto/register-page";
 
 @Injectable()

--- a/backend/src/user/application/service/caregiver-profile.service.ts
+++ b/backend/src/user/application/service/caregiver-profile.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto";
+import { CaregiverProfileMapper } from "../mapper/caregiver-profile.mapper";
+import { CaregiverProfileRepository } from "src/user/infra/repository/caregiver-profile.repository";
+
+@Injectable()
+export class CaregiverProfileService {
+    constructor(
+        private readonly caregiverProfileMapper: CaregiverProfileMapper,
+        private readonly caregiverProfileRepository: CaregiverProfileRepository
+    ) {}
+    /* 회원가입시 새로운 프로필 추가 */
+    async addProfile(userId: number, caregiverRegisterDto: CaregiverRegisterDto): Promise<void> {
+        const caregiverProfile = this.caregiverProfileMapper.mapFrom(userId, caregiverRegisterDto);
+        await this.caregiverProfileRepository.save(caregiverProfile);
+    }  
+}

--- a/backend/src/user/application/service/register.service.ts
+++ b/backend/src/user/application/service/register.service.ts
@@ -5,7 +5,7 @@ import { TokenService } from "src/auth/application/service/token.service";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Protector } from "src/user/domain/entity/protector/protector.entity";
 import { Repository } from "typeorm";
-import { ClientDto } from "src/user-auth-common/interface/client.interface";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
 
 @Injectable()
 export class RegisterService {

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto";
+import { UserMapper } from "../mapper/user.mapper";
+import { InjectRepository } from "@nestjs/typeorm";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { Repository } from "typeorm";
+import { TokenService } from "src/auth/application/service/token.service";
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
+import { CaregiverProfileService } from "./caregiver-profile.service";
+import { ProtectorRegisterDto } from "src/user/interface/dto/protector-register.dto";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userMapper: UserMapper,
+        private readonly tokenService: TokenService,
+        private readonly caregiverProfileService: CaregiverProfileService,
+        @InjectRepository(User)
+        private readonly userRepository: Repository<User>
+    ) {};
+
+    async register(registerDto: CaregiverRegisterDto | ProtectorRegisterDto): Promise<ClientDto> {
+        const user = this.userMapper.mapFrom(registerDto.firstRegister); // 공통회원가입 양식으로부터 사용자 생성
+
+        const authentication = await this.tokenService.generateNewUsersToken(user); // 새로운 인증 생성
+        user.setAuthentication(authentication); 
+
+        const savedUser = await this.userRepository.save(user); // DB에 저장된 User
+        await Promise.all([
+            this.tokenService.addAccessTokenToSessionList(savedUser.getId(), authentication.accessToken), // 세션리스트에 사용자 토큰 추가
+            this.addProfile(savedUser.getId(), registerDto) // 가입목적별 프로필 추가
+        ]); 
+
+        return await this.userMapper.toDto(savedUser)
+    }
+
+    /* 가입 목적별 프로필 추가 */
+    private async addProfile(userId: number, registerDto: CaregiverRegisterDto | ProtectorRegisterDto) {
+        registerDto.firstRegister.purpose == ROLE.CAREGIVER ?
+            await this.caregiverProfileService.addProfile(userId, registerDto as CaregiverRegisterDto) : null
+    }
+}

--- a/backend/src/user/domain/builder/profile.builder.ts
+++ b/backend/src/user/domain/builder/profile.builder.ts
@@ -1,0 +1,87 @@
+import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
+import { License } from "../entity/caregiver/license.entity";
+import { PossibleDate } from "../enum/possible-date.enum";
+import { ObjectId } from "mongodb";
+import { CaregiverProfile } from "../entity/caregiver/caregiver-profile.entity";
+import { Warning } from "../entity/caregiver/warning.entity";
+
+/* 간병인 회원가입 추가 정보 Builder */
+export class CaregiverProfileBuilder {
+    private caregiverProfile: CaregiverProfile;
+
+    constructor(id: ObjectId) { 
+        this.caregiverProfile = new CaregiverProfile(id);
+    };
+
+    userId(userId: number): this {
+        this.caregiverProfile.setUserId(userId);
+        return this;
+    };
+
+    weight(weight: number): this {
+        this.caregiverProfile.setWeight(weight);
+        return this;
+    };
+
+    career(career: number): this {
+        this.caregiverProfile.setCareer(career);
+        return this;
+    };
+
+    pay(pay: number): this {
+        this.caregiverProfile.setPay((pay));
+        return this;
+    };
+
+    possibleDate(date: PossibleDate): this {
+        this.caregiverProfile.setPossibleDate(date);
+        return this;
+    };
+
+    nextHosptial(description: string): this {
+        this.caregiverProfile.setNextHosptail(description);
+        return this;
+    };
+
+    notice(notice: string): this {
+        this.caregiverProfile.setNotice(notice);
+        return this;
+    };
+    
+    helpExperience(list: CaregiverHelpExperience): this {
+        this.caregiverProfile.setHelpExperience(list);
+        return this;
+    };
+
+    additionalChargeCase(situation: string): this {
+        this.caregiverProfile.setAdditionalChargeCase(situation);
+        return this;
+    };
+
+    possibleAreaList(areaList: string []): this {
+        this.caregiverProfile.setPossibleAreaList(areaList);
+        return this;
+    };
+
+    licenseList(licenseList: License []): this {
+        this.caregiverProfile.setLicenseList(licenseList);
+        return this;
+    };
+
+    strengthList(strengthList: string []): this {
+        this.caregiverProfile.setStrengthList(strengthList);
+        return this;
+    };
+
+    tagList(tagList: string []): this {
+        this.caregiverProfile.setTagList(tagList);
+        return this;
+    };
+
+    warningList(warningList: Warning [] = []): this {
+        this.caregiverProfile.setWarning(warningList);
+        return this;
+    }
+
+    build(): CaregiverProfile { return this.caregiverProfile; };
+}

--- a/backend/src/user/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/user/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -1,0 +1,48 @@
+import { ObjectId } from 'mongodb'
+import { Warning } from "./warning.entity";
+import { PossibleDate } from "../../enum/possible-date.enum";
+import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
+import { License } from "./license.entity";
+
+export class CaregiverProfile {
+    readonly _id: ObjectId;
+    private userId: number; // mysql 사용자 계정 ID
+    private weight: number; // 몸무게
+    private career: number; // 경력
+    private pay: number; // 일당
+    private possibleDate: PossibleDate // 가능날짜
+    private nextHosptial: string; // 연장
+    private notice: string; // 공지
+    private helpExperience: CaregiverHelpExperience; //간병 경험
+    private additionalChargeCase: string; //추가 요금 상황
+    private possibleAreaList: string []; // 지역
+    private licenseList: License []; // 자격증
+    private strengthList: string []; // 강점
+    private tagList: string []; // 키워드
+    private warningList: Warning [];
+
+    constructor(id: ObjectId) { this._id = id; };
+
+    /* Setter Method */
+    setUserId(userId: number) { this.userId = userId; };
+    setWeight(weight: number) { this.weight = weight; };
+    setCareer(career: number) { this.career = career; };
+    setPay(pay: number) { this.pay = pay; };
+    setPossibleDate(date: PossibleDate) { this.possibleDate = date; };
+    setNextHosptail(description: string) { this.nextHosptial = description; };
+    setNotice(notice: string) { this.notice = notice; };
+    setHelpExperience(experience: CaregiverHelpExperience) { this.helpExperience = experience; };
+    setAdditionalChargeCase(situation: string) { this.additionalChargeCase = situation; };
+    setPossibleAreaList(areaList: string []) { this.possibleAreaList = areaList; };
+    setLicenseList(licenseList: License []) { this.licenseList = licenseList; };
+    setStrengthList(strengthList: string []) { this.strengthList = strengthList; };
+    setTagList(tagList: string []) { this.tagList = tagList; };
+    setWarning(warningList: Warning []) { this.warningList = warningList; };
+
+    getId(): string { return this._id.toHexString(); };
+    getUserId(): number { return this.userId; };
+    getHelpExperience(): CaregiverHelpExperience { return this.helpExperience; };
+    getLicenseList(): License[] { return this.licenseList; };
+    getStrengthList(): string[] { return this.strengthList; };
+    getWarningList(): Warning[] { return this.warningList; };
+}

--- a/backend/src/user/domain/entity/caregiver/license.entity.ts
+++ b/backend/src/user/domain/entity/caregiver/license.entity.ts
@@ -1,0 +1,7 @@
+export class License {
+    private name: string;
+
+    constructor(name: string) {
+        this.name = name;
+    };
+}

--- a/backend/src/user/domain/entity/caregiver/warning.entity.ts
+++ b/backend/src/user/domain/entity/caregiver/warning.entity.ts
@@ -1,0 +1,6 @@
+import { Time } from "src/common/shared/type/time.type";
+
+export class Warning {
+    private history: string;
+    private reportedAt: Time;
+}

--- a/backend/src/user/domain/enum/possible-date.enum.ts
+++ b/backend/src/user/domain/enum/possible-date.enum.ts
@@ -1,0 +1,7 @@
+export enum PossibleDate {
+    IMMEDATELY = 1,
+    WITHIN1WEEK = 2,
+    WITHIN2WEEK = 3,
+    WITHIN3WEEK = 4,
+    WITHIN1MONTH = 5
+};

--- a/backend/src/user/domain/repository/icaregiver-profile.repository.ts
+++ b/backend/src/user/domain/repository/icaregiver-profile.repository.ts
@@ -1,0 +1,7 @@
+import { CaregiverProfile } from "../entity/caregiver/caregiver-profile.entity";
+
+export interface ICaregiverProfileRepository<T> {
+    save(caregiverProfile: CaregiverProfile): Promise<void>;
+    findById(id: string): Promise<T>;
+    delete(id: string): Promise<void>;
+}

--- a/backend/src/user/infra/repository/caregiver-profile.repository.ts
+++ b/backend/src/user/infra/repository/caregiver-profile.repository.ts
@@ -1,0 +1,39 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { plainToInstance } from "class-transformer";
+import { Db, ObjectId, WithId } from "mongodb";
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
+import { ICaregiverProfileRepository } from "src/user/domain/repository/icaregiver-profile.repository";
+
+@Injectable()
+export class CaregiverProfileRepository implements ICaregiverProfileRepository<WithId<CaregiverProfile>> {
+    private readonly collectionName: string;
+
+    constructor(
+        @Inject('MONGO_CONNECTION')
+        private readonly mongodb: Db,
+        private readonly configService: ConfigService
+    ) {
+        this.collectionName = configService.get('db.mongodb.collection.caregiver_profile');
+    }
+
+    async save(caregiverProfile: CaregiverProfile): Promise<void> {
+        await this.mongodb
+            .collection<CaregiverProfile>(this.collectionName)
+            .insertOne(caregiverProfile);
+    };
+
+    async findById(id: string): Promise<WithId<CaregiverProfile>> {
+        const findProfile = await this.mongodb
+                                .collection<CaregiverProfile>(this.collectionName)
+                                .findOne({ _id: new ObjectId(id) });
+        
+        return plainToInstance(CaregiverProfile, findProfile); 
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.mongodb
+            .collection<CaregiverProfile>(this.collectionName)
+            .deleteOne({ _id: new ObjectId(id) });
+    }
+}

--- a/backend/src/user/interface/controller/user.controller.ts
+++ b/backend/src/user/interface/controller/user.controller.ts
@@ -1,16 +1,24 @@
 import { Body, Controller, Post } from "@nestjs/common";
 import { ProtectorRegisterDto } from "../dto/protector-register.dto";
 import { RegisterService } from "src/user/application/service/register.service";
-import { ClientDto } from "src/user-auth-common/interface/client.interface";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
+import { CaregiverRegisterDto } from "../dto/caregiver-register.dto";
+import { UserService } from "src/user/application/service/user.service";
 
 @Controller('user')
 export class UserController {
     constructor(
+        private readonly userService: UserService,
         private readonly registerService: RegisterService
     ) {}
     /* 보호자로 회원가입 */
     @Post('register/protector')
     async registerAsProtector(@Body() protectorRegisterDto: ProtectorRegisterDto): Promise<ClientDto> {
         return await this.registerService.registerAsProtector(protectorRegisterDto);
+    }
+
+    @Post('register/caregiver')
+    async registerAsCaregiver(@Body() caregiverReigsterDto: CaregiverRegisterDto): Promise<ClientDto> {
+        return await this.userService.register(caregiverReigsterDto)
     }
 }

--- a/backend/src/user/interface/dto/caregiver-register.dto.ts
+++ b/backend/src/user/interface/dto/caregiver-register.dto.ts
@@ -1,0 +1,37 @@
+import { Type } from "class-transformer";
+import { IsObject, ValidateNested } from "class-validator";
+import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto, CommonRegisterForm } from "./register-page";
+
+export class CaregiverRegisterDto {
+    @IsObject()
+    @ValidateNested()
+    @Type(() => CommonRegisterForm)
+    firstRegister: CommonRegisterForm;
+
+    @IsObject()
+    @ValidateNested()
+    @Type(() => CaregiverInfoForm)
+    secondRegister: CaregiverInfoForm;
+
+    @IsObject()
+    @ValidateNested()
+    @Type(() => CaregiverThirdRegisterDto)
+    thirdRegister: CaregiverThirdRegisterDto;
+
+    @IsObject()
+    @ValidateNested()
+    @Type(() => CaregiverLastRegisterDto)
+    lastRegister: CaregiverLastRegisterDto;
+
+    static of( 
+        firstRegister: CommonRegisterForm, 
+        secondRegister: CaregiverInfoForm,
+        thirdRegister: CaregiverThirdRegisterDto,
+        lastRegister: CaregiverLastRegisterDto
+    ) {
+        return {
+            firstRegister, secondRegister, 
+            thirdRegister, lastRegister
+        };
+    }
+}

--- a/backend/src/user/interface/dto/register-page.ts
+++ b/backend/src/user/interface/dto/register-page.ts
@@ -1,13 +1,14 @@
-import { Transform } from "class-transformer";
-import { IsBoolean, IsDate, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Matches, Max, Min } from "class-validator";
+import { Transform, Type } from "class-transformer";
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsBoolean, IsDate, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Matches, Max, Min, ValidateNested } from "class-validator";
 import { Time } from "src/common/shared/type/time.type";
 import { ROLE, SEX, birthRegExp, phoneRegExp } from "src/user-auth-common/domain/enum/user.enum";
+import { PossibleDate } from "src/user/domain/enum/possible-date.enum";
 
 /* 보호자, 간병인 공통 회원가입 작성 페이지 */
 export class CommonRegisterForm {
     @Matches(phoneRegExp)
     readonly id: string; // 아이디( 전화번호 )
-    
+
     @IsNotEmpty()
     @IsString()
     readonly name: string;
@@ -15,7 +16,7 @@ export class CommonRegisterForm {
     @Transform(({ value }) => value.toString())
     @Matches(birthRegExp)
     readonly birth: number;
-    
+
     @IsEnum(SEX)
     readonly sex: SEX;
 
@@ -38,7 +39,7 @@ export class PatientInfoForm {
     @Min(1)
     @Max(300)
     @IsNumber()
-    readonly weight: number; 
+    readonly weight: number;
 
     @IsEnum(SEX)
     readonly patientSex: SEX; // 환자 성별
@@ -73,10 +74,10 @@ export class PatientInfoForm {
     @IsNotEmpty()
     @IsString()
     readonly patientState: string; // 자세한 환자 정보
-    
+
     static of(
         weight: number, patientSex: SEX, diagnosis: string, startDate: Time,
-        endDate: Time, totalPeriod: number, place: string, isNext: boolean, condition: string 
+        endDate: Time, totalPeriod: number, place: string, isNext: boolean, condition: string
     ) {
         return {
             weight,
@@ -92,8 +93,8 @@ export class PatientInfoForm {
     };
 }
 
-/* 보호자 두번째 회원가입 페이지( 환자가 필요로 하는 도움 ) */
-export class PatientHelpListForm {
+/* 간병인, 보호자 공통 도움에 관한 작성 리스트 */ 
+export class CommomHelpList {
     @IsOptional()
     @IsString()
     readonly suction?: string; // 가래 관련
@@ -108,20 +109,128 @@ export class PatientHelpListForm {
 
     @IsOptional()
     @IsString()
-    readonly meal?: string; // 식사 관련
+    readonly washing?: string; // 청결 관련
+};
+
+/* 보호자 두번째 회원가입 페이지( 환자가 필요로 하는 도움 ) */
+export class PatientHelpListForm extends CommomHelpList {
 
     @IsOptional()
     @IsString()
-    readonly washing?: string; // 청결 관련
+    readonly meal?: string; // 식사 관련
 
     @IsOptional()
     @IsString()
     readonly badChair?: string // 휠체어 관련
 
     static of(
-        suction: string, toilet: string, movement: string, 
+        suction: string, toilet: string, movement: string,
         meal: string, washing: string, badChair: string
     ) {
         return { suction, toilet, movement, meal, washing, badChair };
     }
+};
+
+/* 간병인은 공통 작성 문항만 작성 */
+export class CaregiverHelpExperience extends CommomHelpList {
+    static of(
+        suction: string, toilet: string, movement: string, washing: string,
+    ) {
+        return { suction, toilet, movement, washing };
+    }
 }
+
+/* 간병인 정보 양식 */
+export class CaregiverInfoForm {
+    @Min(1)
+    @Max(300)
+    @IsNumber()
+    readonly weight: number;
+
+    @Min(1)
+    @Max(300)
+    @IsNumber()
+    readonly career: number;
+
+    @Min(1)
+    @Max(50)
+    @IsNumber()
+    readonly pay: number;
+
+    @IsNotEmpty()
+    @IsEnum(PossibleDate)
+    readonly possibleDate: PossibleDate;
+
+    @IsNotEmpty()
+    @IsString()
+    readonly nextHospital: string;
+
+    @IsArray()
+    @ArrayMinSize(1)
+    @IsString({ each: true })
+    readonly possibleAreaList: string[];
+
+    @IsArray()
+    @ArrayMinSize(0)
+    @IsString({ each: true })
+    readonly licenseList: string[];
+
+    static of(
+        possibleAreaList: string[] = ['인천', '경기'],
+        licenseList: string[] = ['응급구조사'],
+    ) {
+        return {
+            weight: 60,
+            career: 10,
+            pay: 10,
+            possibleDate: PossibleDate.IMMEDATELY,
+            nextHospital: '다음 병원 예약 여부',
+            possibleAreaList,
+            licenseList,
+        };
+    }
+};
+
+/* 간병인 세번째 회원가입 양식 */
+export class CaregiverThirdRegisterDto {
+    @ValidateNested()
+    @Type(() => CaregiverHelpExperience)
+    readonly helpExperience: CaregiverHelpExperience;
+
+    @IsArray()
+    @ArrayMinSize(0)
+    @IsString({ each: true })
+    readonly strengthList: string[];
+
+    @IsArray()
+    @ArrayMinSize(3)
+    @ArrayMaxSize(3)
+    @IsString({ each: true })
+    readonly tagList: string[];
+
+    static of(
+        helpExperience: CaregiverHelpExperience = { suction: '석션' },
+        strengthList: string[] = ['강점 1, 강점 2'],
+        tagList: string[] = ['태그1', '태그2', '태그3'],
+    ) {
+        return { helpExperience, strengthList, tagList }
+    }
+}
+
+/* 간병인 마지막 회원가입 양식 */
+export class CaregiverLastRegisterDto {
+    @IsNotEmpty()
+    @IsString()
+    readonly notice: string;
+
+    @IsNotEmpty()
+    @IsString()
+    readonly additionalChargeCase: string;
+
+    static of() {
+        return {
+            notice: '공지를 알려드립니다',
+            additionalChargeCase: '추가요금은 없습니다'
+        };
+    };
+};

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -6,11 +6,30 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { CarePeriod } from "./domain/entity/protector/care-period.entity";
 import { Protector } from "./domain/entity/protector/protector.entity";
 import { ProtectorMapper } from "./application/mapper/protector.mapper";
-import { TokenService } from "src/auth/application/service/token.service";
+import { AuthModule } from "src/auth/auth.module";
+import { MongodbModule } from "src/common/shared/database/mongodb/mongodb.module";
+import { UserMapper } from "./application/mapper/user.mapper";
+import { CaregiverProfileMapper } from "./application/mapper/caregiver-profile.mapper";
+import { UserService } from "./application/service/user.service";
+import { CaregiverProfileService } from "./application/service/caregiver-profile.service";
+import { CaregiverProfileRepository } from "./infra/repository/caregiver-profile.repository";
 
 @Module({
-    imports: [UserAuthCommonModule, TypeOrmModule.forFeature([CarePeriod, Protector])],
+    imports: [
+        UserAuthCommonModule, 
+        TypeOrmModule.forFeature([CarePeriod, Protector]), 
+        MongodbModule,
+        AuthModule,
+    ],
     controllers: [UserController],
-    providers: [RegisterService, ProtectorMapper, TokenService]
+    providers: [
+        RegisterService, 
+        ProtectorMapper,
+        UserMapper,
+        CaregiverProfileMapper,
+        UserService,
+        CaregiverProfileService,
+        CaregiverProfileRepository
+    ]
 })
 export class UserModule {}

--- a/backend/test/unit/common/database/datebase-setup.fixture.ts
+++ b/backend/test/unit/common/database/datebase-setup.fixture.ts
@@ -1,0 +1,16 @@
+import { Db, MongoClient } from "mongodb";
+
+let mongodb: Db, mongoClient: MongoClient; // MongoDB
+
+export async function ConnectMongoDB() {
+    const url = 'mongodb://localhost:27017';
+    const dbName = 'test';
+
+    mongoClient = new MongoClient(url);
+    await mongoClient.connect();
+    mongodb = mongoClient.db(dbName);
+}
+
+export function getMongodb() { return mongodb; };
+
+export async function DisconnectMongoDB() { await mongoClient.close(); };

--- a/backend/test/unit/user/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/caregiver-profile-mapper.spec.ts
@@ -1,0 +1,54 @@
+import { CaregiverProfileMapper } from "src/user/application/mapper/caregiver-profile.mapper"
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
+import { License } from "src/user/domain/entity/caregiver/license.entity";
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto";
+import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto, CommonRegisterForm } from "src/user/interface/dto/register-page";
+
+describe('Caregiver Profile Mapper Component Test', () => {
+    const profileMapper = new CaregiverProfileMapper();
+    const userId = 1;
+
+    describe('mapFrom()', () => {
+        it('간병인 회원가입 양식으로부터 프로필로 변환', () => {
+            const mappingResult = profileMapper.mapFrom(userId, CaregiverRegisterDto.of(
+                {} as CommonRegisterForm,
+                createSecondRegisterForm(),
+                createThirdRegisterForm(),
+                createlastRegisterForm()
+            ));
+
+            expect(mappingResult).toBeInstanceOf(CaregiverProfile);
+            expect(mappingResult.getId()).not.toBeNull();
+            expect(mappingResult.getUserId()).toBe(userId);
+
+            mappingResult.getLicenseList()
+                .map( license => expect(license).toBeInstanceOf(License));
+
+            expect(mappingResult.getStrengthList()).toEqual([]);
+            expect(mappingResult.getHelpExperience()).toHaveProperty('suction');
+            expect(mappingResult.getHelpExperience()).toHaveProperty('movement');
+            expect(mappingResult.getHelpExperience()).not.toHaveProperty('meal');
+            expect(mappingResult.getWarningList()).toEqual([]);
+        })
+    });
+    
+})
+
+function createSecondRegisterForm(): CaregiverInfoForm {
+    return CaregiverInfoForm.of(
+        ['지역1', '지역2'],
+        ['자격증'],
+    );
+};
+
+function createThirdRegisterForm(): CaregiverThirdRegisterDto {
+    return CaregiverThirdRegisterDto.of(
+        { suction: '석션', movement: '거동' },
+        [],
+        ['태그1', '태그2', '태그3']
+    );
+};
+
+function createlastRegisterForm(): CaregiverLastRegisterDto {
+    return CaregiverLastRegisterDto.of();
+}

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -1,0 +1,51 @@
+import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum";
+import { UserMapper } from "src/user/application/mapper/user.mapper"
+import { CommonRegisterForm } from "src/user/interface/dto/register-page";
+
+describe('UserMapper Component Test', () => {
+    const userMapper = new UserMapper();
+
+    describe('mapFrom()', () => {
+        it('공통회원가입 양식을 User 객체로 Mapping', async () => {
+            const testCommonRegisterForm = CommonRegisterForm.of(
+                '01011111111',
+                '테스트',
+                19991101,
+                SEX.FEMALE,
+                ROLE.CAREGIVER
+            );
+
+            const mapResult = userMapper.mapFrom(testCommonRegisterForm);
+
+            expect(mapResult).toBeInstanceOf(User);
+            expect(mapResult).toHaveProperty('name');
+            expect(mapResult).toHaveProperty('role');
+            expect(mapResult).toHaveProperty('loginType');
+            expect(mapResult).toHaveProperty('email');
+            expect(mapResult).toHaveProperty('phone');
+            expect(mapResult).toHaveProperty('profile');
+            expect(mapResult).toHaveProperty('authentication');
+        });
+    });
+
+    describe('toDto()', () => {
+        it('User 객체에서 사용자에게 넘겨줄 Dto Mapping', async () => {
+            const testUser = new User(
+                '테스트',
+                ROLE.CAREGIVER,
+                LOGIN_TYPE.PHONE,
+                null,
+                null,
+                null,
+                new Token(null, null)
+            );
+
+            const mapResult = await userMapper.toDto(testUser);
+
+            expect(mapResult).toHaveProperty('id');
+            expect(mapResult).toHaveProperty('accessToken')
+        })
+    })
+});

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -1,0 +1,116 @@
+import { Test } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { TokenService } from "src/auth/application/service/token.service"
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
+import { UserMapper } from "src/user/application/mapper/user.mapper"
+import { CaregiverProfileService } from "src/user/application/service/caregiver-profile.service"
+import { UserService } from "src/user/application/service/user.service"
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto"
+import { CommonRegisterForm } from "src/user/interface/dto/register-page"
+import { Repository } from "typeorm"
+
+describe('UserService Test', () => { 
+    let userService: UserService,
+        userMapper: UserMapper,
+        tokenService: TokenService,
+        caregiverProfileService: CaregiverProfileService,
+        userRepository: Repository<User>;
+
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                UserService,
+                {
+                    provide: UserMapper,
+                    useValue: {
+                        mapFrom: jest.fn().mockReturnValue(createTestUser()),
+                        toDto: jest.fn()
+                    }
+                },
+                {
+                    provide: TokenService,
+                    useValue: {
+                        generateNewUsersToken: jest.fn().mockReturnValue(createTestAuthentication()),
+                        addAccessTokenToSessionList: jest.fn().mockReturnValue(null)
+                    }
+                },
+                {
+                    provide: CaregiverProfileService,
+                    useValue: {
+                        addProfile: jest.fn().mockReturnValue(null)
+                    }
+                },
+                {
+                    provide: getRepositoryToken(User),
+                    useValue: {
+                        save: jest.fn().mockResolvedValue(createTestUser())
+                    }
+                }
+            ]
+        }).compile();
+
+        userService = module.get(UserService);
+        userMapper = module.get(UserMapper);
+        tokenService = module.get(TokenService);
+        userRepository = module.get(getRepositoryToken(User));
+        caregiverProfileService = module.get(CaregiverProfileService);
+    })
+
+    describe('register()', () => {
+        it('회원가입을 진행하면 인증/인가에 필요한 토큰 발급', async () => {
+            const user = userMapper.mapFrom({} as CommonRegisterForm);
+            const authentication = await tokenService.generateNewUsersToken(user);
+            user.setAuthentication(authentication);
+
+            expect(await user.getAuthentication()).toHaveProperty('accessToken');
+            expect((await user.getAuthentication()).getAccessToken()).toBe('testAccessToken');
+            
+            expect(await user.getAuthentication()).toHaveProperty('refreshToken');
+        });
+
+        it('회원가입을 진행했을 때 DB저장, 세션추가 함수 호출', async () => {
+            const [saveSpay, sessionSpy] = [
+                jest.spyOn(userRepository, 'save'),
+                jest.spyOn(tokenService, 'addAccessTokenToSessionList')
+            ];
+            const testRegisterDto = { firstRegister: { purpose: ROLE.CAREGIVER } };
+            await userService.register(testRegisterDto as CaregiverRegisterDto);
+
+            expect(saveSpay).toHaveBeenCalled();
+            expect(sessionSpy).toHaveBeenCalled();
+        });
+
+        it('간병인 회원가입 진행할 때 간병인 프로필 추가 함수 호출', async () => {
+            const profileSpy = jest.spyOn(caregiverProfileService, 'addProfile');
+
+            const testCaregiverRegisterDto = { firstRegister: { purpose: ROLE.CAREGIVER } };
+            await userService.register(testCaregiverRegisterDto as CaregiverRegisterDto);
+
+            expect(profileSpy).toHaveBeenCalled();
+        })
+    })
+})
+
+function createTestUser(): User {
+    return new User(
+        '테스트',
+        ROLE.CAREGIVER,
+        LOGIN_TYPE.PHONE,
+        null,
+        new Phone('01011111111'),
+        new UserProfile(19990101, SEX.MALE),
+        null
+    );
+};
+
+function createTestAuthentication(): NewUserAuthentication {
+    return {
+        accessToken: 'testAccessToken',
+        refreshToken: 'testRefreshToken'
+    }
+};
+

--- a/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
@@ -1,0 +1,107 @@
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+import { ObjectId } from "mongodb";
+import { CaregiverProfileBuilder } from "src/user/domain/builder/profile.builder";
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
+import { License } from "src/user/domain/entity/caregiver/license.entity";
+import { PossibleDate } from "src/user/domain/enum/possible-date.enum";
+import { CaregiverProfileRepository } from "src/user/infra/repository/caregiver-profile.repository";
+import { ConnectMongoDB, DisconnectMongoDB, getMongodb } from "test/unit/common/database/datebase-setup.fixture";
+
+describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test', () => {
+    let testProfile: CaregiverProfile, 
+        caregiverProfileRepository: CaregiverProfileRepository;
+    
+    beforeAll(async () => {
+        await ConnectMongoDB();
+
+        const module = await Test.createTestingModule({
+            imports: [
+                ConfigModule
+            ],
+            providers: [
+                {
+                    provide: 'MONGO_CONNECTION',
+                    useValue: getMongodb()
+                },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn().mockReturnValue('test')                        
+                    }
+                },
+                CaregiverProfileRepository
+            ]
+        }).compile()
+        caregiverProfileRepository = module.get(CaregiverProfileRepository);
+    });
+
+    afterAll(async () => await DisconnectMongoDB());
+
+    it('save() => 빈 배열을 가지는 필드는 DB에 []로 저장.', async () => {
+
+        testProfile = createCommonCaregiverProfile()
+                        .helpExperience({ suction: '석션입니다' })
+                        .licenseList([])
+                        .strengthList([])
+                        .warningList([])
+                        .build()
+
+        await caregiverProfileRepository.save(testProfile);
+        const savedProfile = await caregiverProfileRepository.findById(testProfile.getId());
+
+        expect(savedProfile.getLicenseList()).toEqual([]);
+        expect(savedProfile.getStrengthList()).toEqual([]);
+        expect(savedProfile.getWarningList()).toEqual([]);
+
+        await caregiverProfileRepository.delete(testProfile.getId());
+    });
+
+    it('save() => 간병 경험이 비어있으면 DB에 {}로 저장', async () => {
+        testProfile = createCommonCaregiverProfile()
+                        .helpExperience({})
+                        .licenseList([new License('자격증')])
+                        .strengthList(['강점'])
+                        .warningList(null)
+                        .build()
+
+        await caregiverProfileRepository.save(testProfile);
+        const savedProfile = await caregiverProfileRepository.findById(testProfile.getId());
+
+        expect(savedProfile.getHelpExperience()).toEqual({});
+
+        await caregiverProfileRepository.delete(testProfile.getId());
+    });
+
+    it('delete() => 삭제이후 해당 문서는 존재하면 안된다.', async () => {
+
+        testProfile = createCommonCaregiverProfile()
+                        .helpExperience({ suction: '석션입니다' })
+                        .licenseList([])
+                        .strengthList([])
+                        .warningList([])
+                        .build()
+
+        await caregiverProfileRepository.save(testProfile);
+
+        const beforeDeleteResult = await caregiverProfileRepository.findById(testProfile.getId());
+        expect(beforeDeleteResult).not.toBeNull();
+
+        const afterDeleteResult = await caregiverProfileRepository.delete(testProfile.getId());
+        expect(afterDeleteResult).toBeUndefined();
+    });
+})
+
+function createCommonCaregiverProfile() {
+    return new CaregiverProfileBuilder(new ObjectId())
+        .userId(1)
+        .weight(50)
+        .career(10)
+        .pay(10)
+        .possibleDate(PossibleDate.IMMEDATELY)
+        .possibleAreaList(['인천', '서욿'])
+        .nextHosptial('다음 병원 여부')
+        .tagList(['태그1', '태그2', '태그3'])
+        .notice('공지사항을 알려드립니다')
+        .additionalChargeCase('추가요금이 붙는 상황')
+};

--- a/backend/test/unit/user/interface/dto/caregiver-register.spec.ts
+++ b/backend/test/unit/user/interface/dto/caregiver-register.spec.ts
@@ -1,0 +1,24 @@
+import { plainToInstance } from "class-transformer"
+import { validate } from "class-validator"
+import { ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto, CommonRegisterForm } from "src/user/interface/dto/register-page"
+import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto"
+
+describe('간병인 회원가입 전체 Dto Validator Test', () => {
+    
+    it('각 양식이 맞게 입력되면 Dto가 통과된다', async () => {
+        const testForm = plainToInstance(
+            CaregiverRegisterDto,
+            CaregiverRegisterDto.of(
+                CommonRegisterForm.of('01011111111', '테스트', 19980101, SEX.MALE, ROLE.PROTECTOR),
+                CaregiverInfoForm.of(['인천', '경기'], ['응급구조사']),
+                CaregiverThirdRegisterDto.of({}, ['강점1'], ['태그1', '태그2', '태그3']),
+                CaregiverLastRegisterDto.of()
+            )
+        );
+
+        const result = await validate(testForm);
+
+        expect(result).toEqual([]);
+    });
+})

--- a/backend/test/unit/user/interface/dto/protector-register.spec.ts
+++ b/backend/test/unit/user/interface/dto/protector-register.spec.ts
@@ -3,7 +3,6 @@ import { validate } from "class-validator"
 import { ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
 import { ProtectorRegisterDto } from "src/user/interface/dto/protector-register.dto"
 import { CommonRegisterForm, PatientHelpListForm, PatientInfoForm } from "src/user/interface/dto/register-page"
-import 'reflect-metadata';
 
 describe('보호자 회원가입 전체 Dto Validator Test', () => {
     


### PR DESCRIPTION
### 요약
- 프론트엔드로부터 회원가입 양식에 맞춰 넘어온 데이터들을 가지고 간병인, 보호자와 관계없이 
계정 정보는 **MySQL**에 저장.
- 넘어온 양식을 **Mapper**를 통해 간병인 프로필로 변환하여 프로필에 관한 정보는 **MongoDB**에 저장
- **MongoDB**를 사용한 이유는 비어있는 값들과 모델의 확장성, MySQL로 시도해본결과 많은 **Join**이 발생하였기 때문
- Request의 Body의 유효성 검사를 **class-validator**를 통해 수행
- 하나의 객체안에 많은 필드가 있기에 **builder**를 통해 생성

### 테스트
- 테스트 데이터베이스를 연결하고 끊는 공통 로직을 피하기위해 **Fixture** 생성
- Dto의 유효성 검사 테스트는 **class-validator**의 **validate()**를 이용