### PR TITLE
[백엔드] 로그인 로직 완성

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -100,9 +100,6 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jest.setup.ts"
-    ]
+    "testEnvironment": "node"
   }
 }

--- a/backend/src/auth/application/decorator/user.decorator.ts
+++ b/backend/src/auth/application/decorator/user.decorator.ts
@@ -1,0 +1,8 @@
+import { ExecutionContext, createParamDecorator } from "@nestjs/common";
+
+export const AuthenticatedUser = createParamDecorator(
+    (data: unknown, ctx: ExecutionContext) => {
+        const request = ctx.switchToHttp().getRequest();
+        return request.user;
+    }
+)

--- a/backend/src/auth/application/guard/authentication-code.guard.ts
+++ b/backend/src/auth/application/guard/authentication-code.guard.ts
@@ -1,0 +1,38 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { VerificationUsageService } from "../service/verification-usage.service";
+import { UserRepository } from "src/user-auth-common/domain/repository/user.repository";
+import { InjectRepository } from "@nestjs/typeorm";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { AuthenticationCodeService } from "../service/authentication-code.service";
+
+@Injectable()
+export class PhoneAuthenticationCodeGuard implements CanActivate {
+    constructor(
+        @InjectRepository(User)
+        private readonly userRepository: UserRepository,
+        private readonly verificationUsageService: VerificationUsageService,
+        private readonly authenticationCodeService: AuthenticationCodeService
+    ) {};
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const { phoneNumber, code, isNewUser } = request.body;
+
+        const existCode = await this.authenticationCodeService.getPhoneCode(phoneNumber); // 코드 유효시간 체크
+
+        const phoneVerificationUsage = await this.verificationUsageService.getPhoneUsageHistory(phoneNumber);
+        phoneVerificationUsage.codeAttempCheck(); // 인증번호 시도횟수 체크
+        await this.verificationUsageService.addPhoneCodeAttemp(phoneNumber, phoneVerificationUsage); // 인증번호 시도횟수 추가
+        
+        existCode.verify(code, phoneVerificationUsage.remainChancePerCode()); // 인증번호 일치하는지 체크
+        return await this.succededAuthentication(request, phoneNumber, isNewUser);
+    };
+
+    private async succededAuthentication(request: any, phoneNumber: string, isNewUser: boolean): Promise<boolean> {
+        if( !isNewUser ) {
+            const user = await this.userRepository.findByPhoneNumber(phoneNumber); // 기존 사용자
+            request.user = user;
+        }   
+        return true;
+    }
+}

--- a/backend/src/auth/application/guard/authentication-send.guard.ts
+++ b/backend/src/auth/application/guard/authentication-send.guard.ts
@@ -1,31 +1,20 @@
 import { CanActivate, ExecutionContext } from "@nestjs/common";
-import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
-import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+import { VerificationUsageService } from "../service/verification-usage.service";
 
 /* 휴대폰 인증 일일 발송 횟수 제한 */
 export class PhoneAuthenticationSendGuard implements CanActivate {
     constructor(
-        private readonly phoneVerificationRepository: PhoneVerificationRepository
+        private readonly verificationUsageService: VerificationUsageService
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
-        const request = context.switchToHttp().getRequest();
-        const { phoneNumber } = request.body;
+        const { phoneNumber } = context.switchToHttp().getRequest().body;
 
-        let phoneVerificationUsage = await this.getUsageByPhoneNumber(phoneNumber);
+        const phoneVerificationUsage = await this.verificationUsageService.getPhoneUsageHistory(phoneNumber);
 
         if( phoneVerificationUsage )
             phoneVerificationUsage.dayAttempCheck(); // 일일 인증 횟수 체크
-        else phoneVerificationUsage = new PhoneVerificationUsage();
 
-        // request 객체에 인증횟수 정보 담아서 보냄 
-        // 발송하고 난 이후 객체의 값을 변경해야되기 때문
-        request.authenticationUsage = phoneVerificationUsage; 
         return true;
-    }
-
-    /* 해당 휴대폰의 인증 사용내역 */
-    private async getUsageByPhoneNumber(phoneNumber: string): Promise<PhoneVerificationUsage> {
-        return await this.phoneVerificationRepository.findByPhoneNumber(phoneNumber);
     }
 }

--- a/backend/src/auth/application/guard/authentication-send.guard.ts
+++ b/backend/src/auth/application/guard/authentication-send.guard.ts
@@ -1,0 +1,31 @@
+import { CanActivate, ExecutionContext } from "@nestjs/common";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+
+/* 휴대폰 인증 일일 발송 횟수 제한 */
+export class PhoneAuthenticationSendGuard implements CanActivate {
+    constructor(
+        private readonly phoneVerificationRepository: PhoneVerificationRepository
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const { phoneNumber } = request.body;
+
+        let phoneVerificationUsage = await this.getUsageByPhoneNumber(phoneNumber);
+
+        if( phoneVerificationUsage )
+            phoneVerificationUsage.dayAttempCheck(); // 일일 인증 횟수 체크
+        else phoneVerificationUsage = new PhoneVerificationUsage();
+
+        // request 객체에 인증횟수 정보 담아서 보냄 
+        // 발송하고 난 이후 객체의 값을 변경해야되기 때문
+        request.authenticationUsage = phoneVerificationUsage; 
+        return true;
+    }
+
+    /* 해당 휴대폰의 인증 사용내역 */
+    private async getUsageByPhoneNumber(phoneNumber: string): Promise<PhoneVerificationUsage> {
+        return await this.phoneVerificationRepository.findByPhoneNumber(phoneNumber);
+    }
+}

--- a/backend/src/auth/application/guard/authentication-send.guard.ts
+++ b/backend/src/auth/application/guard/authentication-send.guard.ts
@@ -1,7 +1,8 @@
-import { CanActivate, ExecutionContext } from "@nestjs/common";
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
 import { VerificationUsageService } from "../service/verification-usage.service";
 
 /* 휴대폰 인증 일일 발송 횟수 제한 */
+@Injectable()
 export class PhoneAuthenticationSendGuard implements CanActivate {
     constructor(
         private readonly verificationUsageService: VerificationUsageService
@@ -9,7 +10,6 @@ export class PhoneAuthenticationSendGuard implements CanActivate {
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const { phoneNumber } = context.switchToHttp().getRequest().body;
-
         const phoneVerificationUsage = await this.verificationUsageService.getPhoneUsageHistory(phoneNumber);
 
         if( phoneVerificationUsage )

--- a/backend/src/auth/application/mapper/auth.mapper.ts
+++ b/backend/src/auth/application/mapper/auth.mapper.ts
@@ -1,0 +1,5 @@
+import { Injectable } from "@nestjs/common";
+import { UserAuthCommonMapper } from "src/user-auth-common/application/user-auth-common.mapper";
+
+@Injectable()
+export class AuthMapper extends UserAuthCommonMapper {}

--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConflictException, Inject, Injectable, UnauthorizedException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { AuthenticationCodeMessage } from "src/auth/domain/authentication-code-message";
 import { ValidateSmsCodeDto } from "src/auth/interface/dto/validate-code.dto";
@@ -7,42 +7,71 @@ import { SmsService } from "src/notification/sms/infra/service/sms.service";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { PhoneRepository } from "src/user-auth-common/domain/repository/user-phone.repository";
 import { VerificationUsageService } from "./verification-usage.service";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
+import { TokenService } from "./token.service";
+import { AuthMapper } from "../mapper/auth.mapper";
+import { SessionService } from "./session.service";
+import { AuthenticationCodeService } from "./authentication-code.service";
 
 @Injectable()
 export class AuthService {
     constructor(
         @InjectRepository(Phone)
         private readonly phoneRepository: PhoneRepository,
-        private readonly verificationUsageService: VerificationUsageService,
-        private readonly smsService: SmsService
+        private readonly authenticationCodeService: AuthenticationCodeService, // 인증 코드 관리 서비스(email, phone)
+        private readonly verificationUsageService: VerificationUsageService, // 인증 사용내역 서비스(email, phone)
+        private readonly tokenService: TokenService, // 토큰 서비스(access, refresh)
+        private readonly smsService: SmsService, // sms 발송 서비스
+        private readonly sessionService: SessionService, // session 관리 서비스
+        private readonly authMapper: AuthMapper
     ) {}
 
     async register(phoneNumber: string) {
         /* 이미 가입된 전화번호 인지 확인 이후 인증번호 발송 */
-        if( await this.checkExistingUserByPhone(phoneNumber) )
+        if (await this.checkExistingUserByPhone(phoneNumber))
             throw new ConflictException(ErrorMessage.DuplicatedPhoneNumber);
+        /* @Todo 수정 요망 */
         await this.smsService.send(new AuthenticationCodeMessage(phoneNumber));
     };
 
     /* 신규회원이면 인증에 성공하면 바로 회원가입창으로 이동 */
     async login(phoneNumber: string): Promise<'newuser' | 'exist'> {
-        await this.smsService.send(new AuthenticationCodeMessage(phoneNumber)); // 인증번호 발송
+        await this.sendPhoneAuthCode(phoneNumber); // 발송 이후 코드 저장
         await this.verificationUsageService.addPhoneUsageHistory(phoneNumber); // 발송 내역 추가
-        if( await this.checkExistingUserByPhone(phoneNumber) ) return 'exist'; // 가입 사용자인지 체크
+        if (await this.checkExistingUserByPhone(phoneNumber)) return 'exist'; // 가입 사용자인지 체크
         return 'newuser';
     }
 
+    /* 로그인에 성공한 사용자는 사용할 토큰 발급 */
+    async createAuthenticationToUser(user: User): Promise<ClientDto> {
+        const accessToken = await this.tokenService.generateAccessToken(user); // 새로운 AccessToken 발급
+        user.setAuthentication({ accessToken, refreshToken: null }); // RefreshToken은 기존 토큰 사용
+        await this.sessionService.addUserToList(user.getId(), accessToken) // sessionList에 추가
+        return await this.authMapper.toDto(user);
+    }
+
+    /* @Todo 수정 요망 */
     async validateSmsCode(validateSmsCodeDto: ValidateSmsCodeDto): Promise<void> {
         /* 전화번호에 해당하는 인증코드 */
         const existAuthenticationCode = await this.smsService.getAuthenticationCode(validateSmsCodeDto.phoneNumber);
         /* 비교 */
-        if( !existAuthenticationCode.isEqual(validateSmsCodeDto.code) )
+        if (!existAuthenticationCode.isEqual(validateSmsCodeDto.code))
             throw new UnauthorizedException(ErrorMessage.NotMatchedAuthenticationCode);
+    }
+
+    /* 문자 발송 이후 발송된 코드 저장 */
+    private async sendPhoneAuthCode(phoneNumber: string) {
+        const authenticationCodeMessage = new AuthenticationCodeMessage(phoneNumber); // 메시지 생성
+        await this.smsService.send(authenticationCodeMessage); // 문자 발송
+        await this.authenticationCodeService.addPhoneCode(
+            phoneNumber, authenticationCodeMessage.getAuthenticationCode().toString()
+        )
     }
 
     /* 가입된 휴대폰인지 여부 */
     private async checkExistingUserByPhone(phoneNumber: string): Promise<boolean> {
-        if( await this.phoneRepository.findByPhoneNumber(phoneNumber) )
+        if (await this.phoneRepository.findByPhoneNumber(phoneNumber))
             return true;
         return false;
     }

--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -6,19 +6,31 @@ import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { SmsService } from "src/notification/sms/infra/service/sms.service";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { PhoneRepository } from "src/user-auth-common/domain/repository/user-phone.repository";
+import { VerificationUsageService } from "./verification-usage.service";
 
 @Injectable()
 export class AuthService {
     constructor(
         @InjectRepository(Phone)
         private readonly phoneRepository: PhoneRepository,
+        private readonly verificationUsageService: VerificationUsageService,
         private readonly smsService: SmsService
     ) {}
 
     async register(phoneNumber: string) {
-        await this.checkExistingUserByPhone(phoneNumber); // 가입되어있는 유저인지
-        await this.smsService.send(new AuthenticationCodeMessage(phoneNumber)); // 인증코드 발송
+        /* 이미 가입된 전화번호 인지 확인 이후 인증번호 발송 */
+        if( await this.checkExistingUserByPhone(phoneNumber) )
+            throw new ConflictException(ErrorMessage.DuplicatedPhoneNumber);
+        await this.smsService.send(new AuthenticationCodeMessage(phoneNumber));
     };
+
+    /* 신규회원이면 인증에 성공하면 바로 회원가입창으로 이동 */
+    async login(phoneNumber: string): Promise<'newuser' | 'exist'> {
+        await this.smsService.send(new AuthenticationCodeMessage(phoneNumber)); // 인증번호 발송
+        await this.verificationUsageService.addPhoneUsageHistory(phoneNumber); // 발송 내역 추가
+        if( await this.checkExistingUserByPhone(phoneNumber) ) return 'exist'; // 가입 사용자인지 체크
+        return 'newuser';
+    }
 
     async validateSmsCode(validateSmsCodeDto: ValidateSmsCodeDto): Promise<void> {
         /* 전화번호에 해당하는 인증코드 */
@@ -28,8 +40,10 @@ export class AuthService {
             throw new UnauthorizedException(ErrorMessage.NotMatchedAuthenticationCode);
     }
 
-    private async checkExistingUserByPhone(phoneNumber: string): Promise<void> {
+    /* 가입된 휴대폰인지 여부 */
+    private async checkExistingUserByPhone(phoneNumber: string): Promise<boolean> {
         if( await this.phoneRepository.findByPhoneNumber(phoneNumber) )
-            throw new ConflictException(ErrorMessage.DuplicatedPhoneNumber);
+            return true;
+        return false;
     }
 }

--- a/backend/src/auth/application/service/authentication-code.service.ts
+++ b/backend/src/auth/application/service/authentication-code.service.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { RedisClientType } from "redis";
+import { AuthenticationCode } from "src/auth/domain/authentication-code";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+@Injectable()
+export class AuthenticationCodeService {
+    constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
+    ) {};
+
+    /* 발송된 휴대폰번호 인증코드 추가 */
+    async addPhoneCode(phoneNumber: string, code: string) {
+        await this.redis.SETEX(`phone:${phoneNumber}:code`, 300, code);
+    }
+
+    /* 해당하는 휴대폰의 인증코드 조회 */
+    async getPhoneCode(phoneNumber: string): Promise<AuthenticationCode> {
+        const existCode =  await this.redis.GET(`phone:${phoneNumber}:code`);
+        if( !existCode )
+            throw new NotFoundException(ErrorMessage.ExpiredSmsCode);
+        return new AuthenticationCode(parseInt(existCode));
+    }
+}

--- a/backend/src/auth/application/service/session.service.ts
+++ b/backend/src/auth/application/service/session.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { RedisClientType } from "redis";
+
+@Injectable()
+export class SessionService {
+    private key: string;
+
+    constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
+        private readonly configService: ConfigService
+    ) { this.key = configService.get('db.redis.key.session_list')};
+
+    async addUserToList(userId: number, authentication: string) {
+        await this.redis.HSET(this.key, userId, authentication);
+    }
+}

--- a/backend/src/auth/application/service/verification-usage.service.ts
+++ b/backend/src/auth/application/service/verification-usage.service.ts
@@ -23,4 +23,10 @@ export class VerificationUsageService {
     async getPhoneUsageHistory(phoneNumber: string): Promise<PhoneVerificationUsage> {
         return await this.phoneVerificationRepository.findByPhoneNumber(phoneNumber);
     };
+
+    /* 휴대폰인증 코드 시도횟수 추가 */
+    async addPhoneCodeAttemp(phoneNumber: string, phoneVerificationUsage: PhoneVerificationUsage) {
+        phoneVerificationUsage.addCodeAttemp();
+        await this.phoneVerificationRepository.save(phoneNumber, phoneVerificationUsage);
+    }
 }

--- a/backend/src/auth/application/service/verification-usage.service.ts
+++ b/backend/src/auth/application/service/verification-usage.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@nestjs/common";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+
+@Injectable()
+export class VerificationUsageService {
+    constructor(
+        private readonly phoneVerificationRepository: PhoneVerificationRepository
+    ) {}
+
+    /* 휴대폰인증 사용횟수 추가 */
+    async addPhoneUsageHistory(phoneNumber: string) {
+        let phoneUsageHistory = await this.getPhoneUsageHistory(phoneNumber);
+
+        if( !phoneUsageHistory ) 
+            phoneUsageHistory = new PhoneVerificationUsage();
+        phoneUsageHistory.addHistory();
+        
+        await this.phoneVerificationRepository.save(phoneNumber, phoneUsageHistory);
+    };
+
+    /* 휴대폰인증 사용횟수 조회 */
+    async getPhoneUsageHistory(phoneNumber: string): Promise<PhoneVerificationUsage> {
+        return await this.phoneVerificationRepository.findByPhoneNumber(phoneNumber);
+    };
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,10 @@ import { phoneValidate } from 'src/common/middleware/phone-validator.middleware'
 import { PhoneAuthenticationSendGuard } from './application/guard/authentication-send.guard';
 import { PhoneVerificationRepository } from './infra/repository/phone-verification.repository';
 import { VerificationUsageService } from './application/service/verification-usage.service';
+import { PhoneAuthenticationCodeGuard } from './application/guard/authentication-code.guard';
+import { AuthMapper } from './application/mapper/auth.mapper';
+import { SessionService } from './application/service/session.service';
+import { AuthenticationCodeService } from './application/service/authentication-code.service';
 
 @Module({
   imports: [
@@ -24,7 +28,11 @@ import { VerificationUsageService } from './application/service/verification-usa
     TokenService,
     PhoneAuthenticationSendGuard,
     PhoneVerificationRepository,
-    VerificationUsageService
+    VerificationUsageService,
+    PhoneAuthenticationCodeGuard,
+    AuthMapper,
+    AuthenticationCodeService,
+    SessionService
   ],
   exports: [
     TokenService

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -29,8 +29,8 @@ export class AuthModule implements NestModule{
     consumer
       .apply(phoneValidate)
       .forRoutes(
-        { path: 'register', 'method': RequestMethod.POST },
-        { path: 'login', 'method': RequestMethod.POST }
+        { path: 'auth/register', 'method': RequestMethod.POST },
+        { path: 'auth/login', 'method': RequestMethod.POST }
       )
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { UserAuthCommonModule } from 'src/user-auth-common/user-auth-common.modu
 import { TokenService } from './application/service/token.service';
 import { phoneValidate } from 'src/common/middleware/phone-validator.middleware';
 import { PhoneAuthenticationSendGuard } from './application/guard/authentication-send.guard';
+import { PhoneVerificationRepository } from './infra/repository/phone-verification.repository';
 
 @Module({
   imports: [
@@ -20,7 +21,8 @@ import { PhoneAuthenticationSendGuard } from './application/guard/authentication
     SmsService,
     NaverSmsService,
     TokenService,
-    PhoneAuthenticationSendGuard
+    PhoneAuthenticationSendGuard,
+    PhoneVerificationRepository
   ],
   exports: [
     TokenService

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { TokenService } from './application/service/token.service';
 import { phoneValidate } from 'src/common/middleware/phone-validator.middleware';
 import { PhoneAuthenticationSendGuard } from './application/guard/authentication-send.guard';
 import { PhoneVerificationRepository } from './infra/repository/phone-verification.repository';
+import { VerificationUsageService } from './application/service/verification-usage.service';
 
 @Module({
   imports: [
@@ -22,7 +23,8 @@ import { PhoneVerificationRepository } from './infra/repository/phone-verificati
     NaverSmsService,
     TokenService,
     PhoneAuthenticationSendGuard,
-    PhoneVerificationRepository
+    PhoneVerificationRepository,
+    VerificationUsageService
   ],
   exports: [
     TokenService

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.se
 import { UserAuthCommonModule } from 'src/user-auth-common/user-auth-common.module';
 import { TokenService } from './application/service/token.service';
 import { phoneValidate } from 'src/common/middleware/phone-validator.middleware';
+import { PhoneAuthenticationSendGuard } from './application/guard/authentication-send.guard';
 
 @Module({
   imports: [
@@ -18,7 +19,8 @@ import { phoneValidate } from 'src/common/middleware/phone-validator.middleware'
     AuthService,
     SmsService,
     NaverSmsService,
-    TokenService
+    TokenService,
+    PhoneAuthenticationSendGuard
   ],
   exports: [
     TokenService

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { RedisModule } from 'src/common/shared/database/redis/redis.module';
 import { AuthService } from './application/service/auth.service';
 import { AuthController } from './interface/controller/auth.controller';
@@ -6,6 +6,7 @@ import { SmsService } from 'src/notification/sms/infra/service/sms.service';
 import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.service';
 import { UserAuthCommonModule } from 'src/user-auth-common/user-auth-common.module';
 import { TokenService } from './application/service/token.service';
+import { phoneValidate } from 'src/common/middleware/phone-validator.middleware';
 
 @Module({
   imports: [
@@ -23,4 +24,13 @@ import { TokenService } from './application/service/token.service';
     TokenService
   ]
 })
-export class AuthModule {}
+export class AuthModule implements NestModule{
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(phoneValidate)
+      .forRoutes(
+        { path: 'register', 'method': RequestMethod.POST },
+        { path: 'login', 'method': RequestMethod.POST }
+      )
+  }
+}

--- a/backend/src/auth/domain/authentication-code.ts
+++ b/backend/src/auth/domain/authentication-code.ts
@@ -1,9 +1,18 @@
+import { UnauthorizedException } from "@nestjs/common";
+
 export class AuthenticationCode {
     private code: number;
     constructor(code: number) {
         this.code = code;
     };
     
+    verify(inputCode: number, remainChance: number): void {
+        if( this.code != inputCode )
+            throw new UnauthorizedException(
+                `인증번호가 일치하지 않습니다.${remainChance}회 남음`
+            );    
+    }
+    /* 수정 요망 */
     isEqual(inputCode: number): boolean { return inputCode == this.code; };
     getCode(): number { return this.code; };
 }

--- a/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
+++ b/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
@@ -1,0 +1,36 @@
+import { ForbiddenException } from "@nestjs/common";
+
+export class PhoneVerificationUsage {
+
+    private dayAttemp: number;
+
+    private codeAttemp: number;
+
+    constructor(dayAttemp: number = 0, codeAttemp: number = 0, blockedAt: string = null) {
+        this.dayAttemp = dayAttemp;
+        this.codeAttemp = codeAttemp;
+    }
+
+    getDayAttemp(): number { return this.dayAttemp; };
+
+    /* 일일 가능횟수 */
+    dayAttempCheck(): void {
+        if( this.dayAttemp == 5 )
+            throw new ForbiddenException(
+                `일일 가능한 인증횟수를 초과하였습니다.`
+            );
+    };
+
+    /* 사용내역 추가 */
+    addHistory() {
+        this.dayAttemp += 1;
+    };
+
+    /* redis에 메소드는 저장될 필요가 없으므로 */
+    toSerializedString(): string {
+        return JSON.stringify({ 
+            dayAttemp: this.dayAttemp,
+            codeAttemp: this.codeAttemp,
+        });
+    };
+};

--- a/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
+++ b/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
@@ -1,7 +1,10 @@
 import { ForbiddenException } from "@nestjs/common";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 
 export class PhoneVerificationUsage {
-
+    private readonly MAX_CHANCE_PER_CODE = 3;
+    private readonly MAX_DAILY_SEND_LIMIT = 5;
+    
     private dayAttemp: number;
 
     private codeAttemp: number;
@@ -12,19 +15,28 @@ export class PhoneVerificationUsage {
     }
 
     getDayAttemp(): number { return this.dayAttemp; };
+    getCodeAttemp(): number { return this.codeAttemp; };
+    remainChancePerCode(): number { return this.MAX_CHANCE_PER_CODE - this.codeAttemp; }; // 현재 인증번호의 남은 시도횟수
 
     /* 일일 가능횟수 */
     dayAttempCheck(): void {
-        if( this.dayAttemp == 5 )
-            throw new ForbiddenException(
-                `일일 가능한 인증횟수를 초과하였습니다.`
-            );
+        if( this.dayAttemp == this.MAX_DAILY_SEND_LIMIT )
+            throw new ForbiddenException(ErrorMessage.ExceededPhoneDailyLimit);
     };
 
     /* 사용내역 추가 */
     addHistory() {
         this.dayAttemp += 1;
+        this.resetCodeAttemp();
     };
+
+    /* 인증번호당 시도횟수 */
+    codeAttempCheck(): void {
+        if( this.codeAttemp == 3 )
+            throw new ForbiddenException(ErrorMessage.ExceededCodeAttempLimit);
+    };
+
+    addCodeAttemp(): void { this.codeAttemp += 1; };
 
     /* redis에 메소드는 저장될 필요가 없으므로 */
     toSerializedString(): string {
@@ -33,4 +45,7 @@ export class PhoneVerificationUsage {
             codeAttemp: this.codeAttemp,
         });
     };
+
+    /* 새로 인증번호를 발송하면 이전 시도횟수 초기화 */
+    private resetCodeAttemp(): void { this.codeAttemp = 0; };
 };

--- a/backend/src/auth/domain/repository/iphone-verification.repository.ts
+++ b/backend/src/auth/domain/repository/iphone-verification.repository.ts
@@ -1,0 +1,7 @@
+import { PhoneVerificationUsage } from "../entity/phone-verification-usage.entity";
+
+export interface IPhoneVerificationRepository {
+    save(phoneNumber: string, phoneVerificationUsage: PhoneVerificationUsage): Promise<void>;
+    findByPhoneNumber(phoneNumber: string): Promise<PhoneVerificationUsage | null>;
+    delete(phoneNumber: string): Promise<void>;
+}

--- a/backend/src/auth/infra/repository/phone-verification.repository.ts
+++ b/backend/src/auth/infra/repository/phone-verification.repository.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { plainToInstance } from "class-transformer";
+import { RedisClientType } from "redis";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { IPhoneVerificationRepository } from "src/auth/domain/repository/iphone-verification.repository";
+
+@Injectable()
+export class PhoneVerificationRepository implements IPhoneVerificationRepository {
+    private key: string // redis hash key
+    constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
+        private readonly configService: ConfigService
+    ) {
+        this.key = configService.get('redis.key.phone_verification_usage');
+    }
+
+    async save(phoneNumber: string, phoneVerificationUsage: PhoneVerificationUsage): Promise<void> {
+        await this.redis.HSET(this.key, phoneNumber, phoneVerificationUsage.toSerializedString());
+    };
+    
+    async findByPhoneNumber(phoneNumber: string): Promise<PhoneVerificationUsage | null> {
+        return this.parseToInstance( await this.redis.HGET(this.key, phoneNumber) );
+    };
+
+    async delete(phoneNumber: string): Promise<void> {
+        await this.redis.HDEL(this.key, phoneNumber);
+    }
+
+    /* 문자열로 저장된 객체 파싱 후 인스턴스로 */
+    private parseToInstance(serializedString: string): PhoneVerificationUsage {
+        return plainToInstance(
+            PhoneVerificationUsage,
+            JSON.parse(serializedString)
+        )
+    }
+}

--- a/backend/src/auth/infra/repository/phone-verification.repository.ts
+++ b/backend/src/auth/infra/repository/phone-verification.repository.ts
@@ -13,7 +13,7 @@ export class PhoneVerificationRepository implements IPhoneVerificationRepository
         private readonly redis: RedisClientType,
         private readonly configService: ConfigService
     ) {
-        this.key = configService.get('redis.key.phone_verification_usage');
+        this.key = configService.get('db.redis.key.phone_verification_usage');
     }
 
     async save(phoneNumber: string, phoneVerificationUsage: PhoneVerificationUsage): Promise<void> {

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -1,8 +1,11 @@
 import { Body, Controller, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "src/auth/application/service/auth.service";
 import { RegisterDto } from "../dto/register.dto";
-import { ValidateSmsCodeDto } from "../dto/validate-code.dto";
 import { PhoneAuthenticationSendGuard } from "src/auth/application/guard/authentication-send.guard";
+import { PhoneAuthenticationCodeGuard } from "src/auth/application/guard/authentication-code.guard";
+import { ClientDto } from "src/user-auth-common/interface/client.dto";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
 
 @Controller('auth')
 export class AuthController {
@@ -16,9 +19,10 @@ export class AuthController {
     }
 
     /* 휴대폰 인증코드 검사 */
+    @UseGuards(PhoneAuthenticationCodeGuard)
     @Post('code/sms')
-    async validateSmsCode(@Body() validateSmsCodeDto: ValidateSmsCodeDto) {
-        return await this.authService.validateSmsCode(validateSmsCodeDto);
+    async validateSmsCode(@AuthenticatedUser() user: User): Promise<ClientDto | void> {
+        if( user ) return await this.authService.createAuthenticationToUser(user);
     }
 
     /* 로그인 */

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Post, UsePipes } from "@nestjs/common";
+import { Body, Controller, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "src/auth/application/service/auth.service";
 import { RegisterDto } from "../dto/register.dto";
 import { ValidateSmsCodeDto } from "../dto/validate-code.dto";
+import { PhoneAuthenticationSendGuard } from "src/auth/application/guard/authentication-send.guard";
 
 @Controller('auth')
 export class AuthController {
@@ -18,5 +19,12 @@ export class AuthController {
     @Post('code/sms')
     async validateSmsCode(@Body() validateSmsCodeDto: ValidateSmsCodeDto) {
         return await this.authService.validateSmsCode(validateSmsCodeDto);
+    }
+
+    /* 로그인 */
+    @UseGuards(PhoneAuthenticationSendGuard)
+    @Post('login')
+    async login(@Body('phoneNumber') phoneNumber: string): Promise<'newuser' | 'exist'> {
+        return await this.authService.login(phoneNumber);
     }
 } 

--- a/backend/src/auth/interface/dto/login.dto.ts
+++ b/backend/src/auth/interface/dto/login.dto.ts
@@ -1,0 +1,1 @@
+export class LoginDto { readonly phoneNumber: string; }

--- a/backend/src/auth/interface/dto/register.dto.ts
+++ b/backend/src/auth/interface/dto/register.dto.ts
@@ -1,8 +1,1 @@
-import { Matches } from 'class-validator';
-import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
-import { phoneRegExp } from 'src/user-auth-common/domain/enum/user.enum';
-
-export class RegisterDto { 
-    @Matches(phoneRegExp, { message: ErrorMessage.PhoneNumberFormat})    
-    readonly phoneNumber: string; 
-};
+export class RegisterDto { readonly phoneNumber: string; };

--- a/backend/src/common/middleware/phone-validator.middleware.ts
+++ b/backend/src/common/middleware/phone-validator.middleware.ts
@@ -1,0 +1,12 @@
+import { BadRequestException } from "@nestjs/common";
+import { NextFunction, Request, Response } from "express";
+import { phoneRegExp } from "src/user-auth-common/domain/enum/user.enum";
+import { ErrorMessage } from "../shared/enum/error-message.enum";
+
+export function phoneValidate(req: Request, res: Response, next: NextFunction) {
+    const { phoneNumber } = req.body;
+    /* 휴대폰 형식 검사이후 400에러 */
+    if( !phoneRegExp.test(phoneNumber) )
+        throw new BadRequestException(ErrorMessage.PhoneNumberFormat);
+    next();
+}

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -2,5 +2,7 @@ export const enum ErrorMessage {
     PhoneNumberFormat = '휴대폰번호 형식을 확인해주세요',
     DuplicatedPhoneNumber = '이미 가입된 전화번호입니다.',
     ExpiredSmsCode = '인증유효시간이 초과되었습니다. 다시 시도해 주세요.',
-    NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.'
+    NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.',
+    ExceededPhoneDailyLimit = '일일 가능한 인증횟수를 초과하였습니다.',
+    ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.'
 }

--- a/backend/src/user-auth-common/application/user-auth-common.mapper.ts
+++ b/backend/src/user-auth-common/application/user-auth-common.mapper.ts
@@ -1,0 +1,11 @@
+import { User } from "../domain/entity/user.entity";
+import { ClientDto } from "../interface/client.dto";
+
+export abstract class UserAuthCommonMapper {
+    async toDto(user: User): Promise<ClientDto> {
+        return {
+            id: user.getId(),
+            accessToken: (await user.getAuthentication()).getAccessToken(),
+        };
+    }
+}

--- a/backend/src/user-auth-common/domain/repository/user-phone.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user-phone.repository.ts
@@ -14,7 +14,7 @@ export const customPhoneRepositoryMethods: Pick<
     > = {
         async findByPhoneNumber(this: Repository<Phone>, phoneNumber: string)
         : Promise<Phone> {
-            return await this.findBy({ phoneNumber })[0];
+            return (await this.findBy({ phoneNumber }))[0];
         },
     }
 

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -1,5 +1,30 @@
-import { Repository } from "typeorm";
+import { DataSource, Repository } from "typeorm";
 import { User } from "../entity/user.entity";
+import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
 
-export interface UserRepository extends Repository<User> {};
+export interface UserRepository extends Repository<User> {
+    findByPhoneNumber(phoneNumber: string): Promise<User>;
+};
 
+export const customPhoneRepositoryMethods: Pick<
+    UserRepository, 
+    'findByPhoneNumber'
+    > = {
+        async findByPhoneNumber(this: Repository<User>, phoneNumber: string)
+        : Promise<User> {
+            return await this.createQueryBuilder('user')
+                .innerJoin('user.phone', 'phone')
+                .where('phone.phone_number = :phoneNumber', { phoneNumber })
+                .getOne();
+        },
+    }
+
+export const UserRepositoryProvider = {
+    provide: getRepositoryToken(User),
+    inject: [getDataSourceToken()],
+    useFactory(dataSource: DataSource) {
+        return dataSource
+            .getRepository(User)
+            .extend(customPhoneRepositoryMethods);
+    }
+}

--- a/backend/src/user-auth-common/user-auth-common.module.ts
+++ b/backend/src/user-auth-common/user-auth-common.module.ts
@@ -6,12 +6,13 @@ import { Email } from "./domain/entity/user-email.entity";
 import { Token } from "./domain/entity/auth-token.entity";
 import { UserProfile } from "./domain/entity/user-profile.entity";
 import { PhoneRepositoryProvider } from "./domain/repository/user-phone.repository";
+import { UserRepositoryProvider } from "./domain/repository/user.repository";
 
 @Module({
     imports: [
         TypeOrmModule.forFeature([User, Phone, Email, UserProfile, Token]),
     ],
-    providers: [PhoneRepositoryProvider],
-    exports: [TypeOrmModule, PhoneRepositoryProvider]
+    providers: [PhoneRepositoryProvider, UserRepositoryProvider],
+    exports: [TypeOrmModule, PhoneRepositoryProvider, UserRepositoryProvider]
 })  
 export class UserAuthCommonModule {}

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -1,14 +1,14 @@
 import { Injectable } from "@nestjs/common";
+import { UserAuthCommonMapper } from "src/user-auth-common/application/user-auth-common.mapper";
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE } from "src/user-auth-common/domain/enum/user.enum";
-import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { CommonRegisterForm } from "src/user/interface/dto/register-page";
 
 @Injectable()
-export class UserMapper {
+export class UserMapper extends UserAuthCommonMapper{
     mapFrom(commonRegisterDto: CommonRegisterForm): User {
         return new User(
             commonRegisterDto.name,
@@ -20,13 +20,6 @@ export class UserMapper {
             null
         )
     };
-
-    async toDto(user: User): Promise<ClientDto> {
-        return {
-            id: user.getId(),
-            accessToken: (await user.getAuthentication()).getAccessToken(),
-        };
-    }
 
      /* 이메일로 회원가입(현재는 휴대폰으로만 제공) */
      private createEmailByLoginType(loginType: LOGIN_TYPE): null | Email {

--- a/backend/test/unit/__mock__/auth/repository.mock.ts
+++ b/backend/test/unit/__mock__/auth/repository.mock.ts
@@ -1,0 +1,10 @@
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+
+export const MockPhoneVerificationRepository = {
+    provide: PhoneVerificationRepository,
+    useValue: {
+        save: jest.fn(),
+        findByPhoneNumber: jest.fn(),
+        delete: jest.fn()
+    }
+}

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -1,0 +1,55 @@
+import { AuthService } from "src/auth/application/service/auth.service";
+import { AuthenticationCodeService } from "src/auth/application/service/authentication-code.service";
+import { SessionService } from "src/auth/application/service/session.service";
+import { TokenService } from "src/auth/application/service/token.service";
+import { VerificationUsageService } from "src/auth/application/service/verification-usage.service";
+
+/* 인증코드관리 서비스(AuthenticationCodeService) */
+export const MockAuthenticationCodeService = {
+    provide: AuthenticationCodeService,
+    useValue: {
+        addPhoneCode: jest.fn(),
+        getPhoneCode: jest.fn()
+    }
+};
+
+/* 인증 서비스(AuthService) */
+export const MockAuthService = {
+    provide: AuthService,
+    useValue: {
+        register: jest.fn(),
+        login: jest.fn(),
+        createAuthenticationToUser: jest.fn(),
+        validateSmsCode: jest.fn()
+    }
+};
+
+/* 토큰 서비스(TokenService) */
+export const MockTokenService = {
+    provide: TokenService,
+    useValue: {
+        generateNewUserToken: jest.fn(),
+        generateAccessToken: jest.fn(),
+        generateRefreshToken: jest.fn()
+    }
+};
+
+/* 세션 서비스(SessionService) */
+export const MockSessionService = {
+    provide: SessionService,
+    useValue: {
+        addUserToList: jest.fn()
+    }
+};
+
+/* 인증사용 내역 서비스(VerificationService) */
+export const MockVerificationUsageService = {
+    provide: VerificationUsageService,
+    useValue: {
+        addPhoneUsageHistory: jest.fn(),
+        getPhoneUsageHistory: jest.fn(),
+        addPhoneCodeAttemp: jest.fn()
+    }
+};
+
+

--- a/backend/test/unit/__mock__/notification/service.mock.ts
+++ b/backend/test/unit/__mock__/notification/service.mock.ts
@@ -1,0 +1,10 @@
+import { SmsService } from "src/notification/sms/infra/service/sms.service";
+
+/* Sms 서비스(SmsService) */
+export const MockSmsService = {
+    provide: SmsService,
+    useValue: {
+        send: jest.fn(),
+        getAuthenticationCode: jest.fn()
+    }
+};

--- a/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
@@ -1,0 +1,19 @@
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+
+/* 사용자 저장소(UserRepository) */
+export const MockUserRepository = {
+    provide: getRepositoryToken(User),
+    useValue: {
+        findByPhoneNumber: jest.fn()
+    }
+};
+
+/* 휴대폰 저장소(PhoneRepository) */
+export const MockPhoneRepository = {
+    provide: getRepositoryToken(Phone),
+    useValue: {
+        findByPhoneNumber: jest.fn()
+    }
+};

--- a/backend/test/unit/auth/application/guard/authentication-code-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/authentication-code-guard.spec.ts
@@ -1,0 +1,77 @@
+import { NotFoundException, UnauthorizedException } from "@nestjs/common"
+import { Test } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { RedisClientType } from "redis"
+import { PhoneAuthenticationCodeGuard } from "src/auth/application/guard/authentication-code.guard"
+import { AuthenticationCodeService } from "src/auth/application/service/authentication-code.service"
+import { VerificationUsageService } from "src/auth/application/service/verification-usage.service"
+import { AuthenticationCode } from "src/auth/domain/authentication-code"
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { UserRepository } from "src/user-auth-common/domain/repository/user.repository"
+import { MockAuthenticationCodeService, MockVerificationUsageService } from "test/unit/__mock__/auth/service.mock"
+import { MockUserRepository } from "test/unit/__mock__/user-auth-common/repository.mock"
+
+describe('인증코드 관련 가드(AuthenticationCodeGuard) Test', () => {
+    let userRepository: UserRepository;
+    let verificationUsgaeService: VerificationUsageService;
+    let authenticationCodeService: AuthenticationCodeService;
+    let guard: PhoneAuthenticationCodeGuard;
+    let redis: RedisClientType;
+
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                MockUserRepository,
+                MockVerificationUsageService,
+                MockAuthenticationCodeService,
+                PhoneAuthenticationCodeGuard,
+                {
+                    provide: 'REDIS_CLIENT',
+                    useValue: {
+                        GET: jest.fn()
+                    }
+                }
+            ]
+        }).compile();
+
+        userRepository = module.get(getRepositoryToken(User));
+        verificationUsgaeService = module.get(VerificationUsageService);
+        authenticationCodeService = module.get(AuthenticationCodeService);
+        guard = module.get(PhoneAuthenticationCodeGuard);
+        redis = module.get('REDIS_CLIENT');
+    });
+
+    const [phoneNumber, code] = ['01012345667', 232222];
+
+    const mockContext: any = {
+        switchToHttp: () => ({
+            getRequest: () => ({
+                body: { phoneNumber, code, isNewUser: false },
+            }),
+        }),
+    };
+    it('현재 인증번호의 시도횟수가 초과됐으면 403에러', async() => {
+        
+        jest.spyOn(verificationUsgaeService, 'getPhoneUsageHistory')
+            .mockResolvedValueOnce(new PhoneVerificationUsage(1, 3));
+        
+        const result = async () => await guard.canActivate(mockContext);
+
+        await expect(result).rejects.toThrowError(new NotFoundException(ErrorMessage.ExceededCodeAttempLimit));
+    });
+
+    it('코드가 일치하지 않으면 401에러', async () => {
+        jest.spyOn(authenticationCodeService, 'getPhoneCode')
+            .mockResolvedValueOnce(new AuthenticationCode(201920));
+        
+        jest.spyOn(verificationUsgaeService, 'getPhoneUsageHistory')
+            .mockResolvedValueOnce(new PhoneVerificationUsage(1, 1));
+        
+        const result = async () => await guard.canActivate(mockContext);
+        await expect(result).rejects.toThrowError(new UnauthorizedException(
+            `인증번호가 일치하지 않습니다.2회 남음`
+        ))
+    });
+})

--- a/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
@@ -1,7 +1,7 @@
 import { ForbiddenException } from "@nestjs/common";
 import { PhoneAuthenticationSendGuard } from "src/auth/application/guard/authentication-send.guard";
+import { VerificationUsageService } from "src/auth/application/service/verification-usage.service";
 import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
-import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
 
 describe('휴대폰인증 발송 가드(PhoneAuthenticationGuard) Test', () => {
     const blockedAt = new Date();
@@ -13,17 +13,17 @@ describe('휴대폰인증 발송 가드(PhoneAuthenticationGuard) Test', () => {
             }),
         }),
     }
-    const mockPhoneVerificationRepo = {
-        findByPhoneNumber: jest.fn()
-                               .mockResolvedValueOnce(new PhoneVerificationUsage(5, 0, blockedAt))
-                               .mockResolvedValueOnce(new PhoneVerificationUsage(0, 0, null))
-    } as unknown as PhoneVerificationRepository;
+    const mockPhoneVerificationService = {
+        getPhoneUsageHistory: jest.fn()
+                               .mockResolvedValueOnce(new PhoneVerificationUsage(5, 0))
+                               .mockResolvedValueOnce(new PhoneVerificationUsage(0, 0))
+    } as unknown as VerificationUsageService;
 
-    const guard = new PhoneAuthenticationSendGuard(mockPhoneVerificationRepo);
+    const guard = new PhoneAuthenticationSendGuard(mockPhoneVerificationService);
 
     it('일일 발송 제한을 넘었다면 403에러', async () => {
         const result = async () => await guard.canActivate(mockContext);
-        await expect(result).rejects.toThrowError(new ForbiddenException(`일일 가능한 인증횟수를 초과하였습니다. ${blockedAt}이후에 다시 시도해 주세요.`))
+        await expect(result).rejects.toThrowError(new ForbiddenException(`일일 가능한 인증횟수를 초과하였습니다.`))
     });
 
     it('일일 발송 제한을 넘지 않았다면 True', async () => {

--- a/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
@@ -1,0 +1,33 @@
+import { ForbiddenException } from "@nestjs/common";
+import { PhoneAuthenticationSendGuard } from "src/auth/application/guard/authentication-send.guard";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+
+describe('휴대폰인증 발송 가드(PhoneAuthenticationGuard) Test', () => {
+    const blockedAt = new Date();
+
+    const mockContext: any = {
+        switchToHttp: () => ({
+            getRequest: () => ({
+                body: { phoneNumber: '01011111111' },
+            }),
+        }),
+    }
+    const mockPhoneVerificationRepo = {
+        findByPhoneNumber: jest.fn()
+                               .mockResolvedValueOnce(new PhoneVerificationUsage(5, 0, blockedAt))
+                               .mockResolvedValueOnce(new PhoneVerificationUsage(0, 0, null))
+    } as unknown as PhoneVerificationRepository;
+
+    const guard = new PhoneAuthenticationSendGuard(mockPhoneVerificationRepo);
+
+    it('일일 발송 제한을 넘었다면 403에러', async () => {
+        const result = async () => await guard.canActivate(mockContext);
+        await expect(result).rejects.toThrowError(new ForbiddenException(`일일 가능한 인증횟수를 초과하였습니다. ${blockedAt}이후에 다시 시도해 주세요.`))
+    });
+
+    it('일일 발송 제한을 넘지 않았다면 True', async () => {
+        const result = await guard.canActivate(mockContext);
+        expect(result).toBe(true);
+    });
+})

--- a/backend/test/unit/auth/application/service/auth-service.spec.ts
+++ b/backend/test/unit/auth/application/service/auth-service.spec.ts
@@ -3,15 +3,20 @@ import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthService } from 'src/auth/application/service/auth.service';
+import { VerificationUsageService } from 'src/auth/application/service/verification-usage.service';
 import { AuthenticationCode } from 'src/auth/domain/authentication-code';
+import { PhoneVerificationRepository } from 'src/auth/infra/repository/phone-verification.repository';
 import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
 import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.service';
 import { SmsService } from 'src/notification/sms/infra/service/sms.service';
 import { Phone } from 'src/user-auth-common/domain/entity/user-phone.entity';
+import { PhoneRepository } from 'src/user-auth-common/domain/repository/user-phone.repository';
 
 describe('인증 서비스(AuthService) Test', () => {
     let authService: AuthService;
     let smsService: SmsService;
+    let phoneRepository: PhoneRepository;
+
     beforeAll(async () => {
         const module = await Test.createTestingModule({
             imports: [ConfigModule],
@@ -20,9 +25,19 @@ describe('인증 서비스(AuthService) Test', () => {
                 SmsService,
                 NaverSmsService,
                 {
+                    provide: VerificationUsageService,
+                    useValue: {
+                        addPhoneUsageHistory: jest.fn()
+                    }
+                },
+                {
+                    provide: PhoneVerificationRepository,
+                    useValue: {}
+                },
+                {
                     provide: getRepositoryToken(Phone),
                     useValue: {
-                        findByPhoneNumber: jest.fn().mockReturnValueOnce(new Phone('01011111111'))
+                        findByPhoneNumber: jest.fn()
                     }
                 },
                 {
@@ -33,9 +48,11 @@ describe('인증 서비스(AuthService) Test', () => {
         }).compile();
         authService = module.get(AuthService);
         smsService = module.get(SmsService);
+        phoneRepository = module.get(getRepositoryToken(Phone));
     })
     describe('register()', () => {
         it('이미 가입되어 있는 전화번호인 경우 409에러를 던진다', async () => {
+            jest.spyOn(phoneRepository, 'findByPhoneNumber').mockResolvedValue(new Phone('01011111111'))
             const result = async () => await authService.register('01011111111');
             await expect(result).rejects.toThrowError(new ConflictException(ErrorMessage.DuplicatedPhoneNumber));
         })
@@ -56,6 +73,24 @@ describe('인증 서비스(AuthService) Test', () => {
             const result = authService.validateSmsCode({ phoneNumber: '01011111111', code: 222333});
             
             await expect(result).resolves.toBe(undefined);
+        })
+    });
+
+    describe('login()', () => {
+        it('이미 가입된 사용자의 휴대폰이면 \'exist\'를 반환한다.', async () => {
+            jest.spyOn(smsService, 'send').mockResolvedValue(null);
+            jest.spyOn(phoneRepository, 'findByPhoneNumber').mockResolvedValue(new Phone('01011112222'));
+            const result = await authService.login('01011112222');
+
+            expect(result).toBe('exist')
+        });
+
+        it('새로 가입된 사용자의 휴대폰이면 \'newuser\'를 반환한다.', async () => {
+            jest.spyOn(smsService, 'send').mockResolvedValue(null);
+            jest.spyOn(phoneRepository, 'findByPhoneNumber').mockResolvedValue(null);
+            const result = await authService.login('01011112222');
+
+            expect(result).toBe('newuser')
         })
     })
 })

--- a/backend/test/unit/auth/application/service/auth-service.spec.ts
+++ b/backend/test/unit/auth/application/service/auth-service.spec.ts
@@ -2,54 +2,64 @@ import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuthMapper } from 'src/auth/application/mapper/auth.mapper';
 import { AuthService } from 'src/auth/application/service/auth.service';
+import { SessionService } from 'src/auth/application/service/session.service';
+import { TokenService } from 'src/auth/application/service/token.service';
 import { VerificationUsageService } from 'src/auth/application/service/verification-usage.service';
 import { AuthenticationCode } from 'src/auth/domain/authentication-code';
-import { PhoneVerificationRepository } from 'src/auth/infra/repository/phone-verification.repository';
 import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
 import { NaverSmsService } from 'src/notification/sms/infra/service/naver-sms.service';
 import { SmsService } from 'src/notification/sms/infra/service/sms.service';
 import { Phone } from 'src/user-auth-common/domain/entity/user-phone.entity';
+import { User } from 'src/user-auth-common/domain/entity/user.entity';
+import { LOGIN_TYPE, ROLE } from 'src/user-auth-common/domain/enum/user.enum';
 import { PhoneRepository } from 'src/user-auth-common/domain/repository/user-phone.repository';
+import { MockPhoneVerificationRepository } from 'test/unit/__mock__/auth/repository.mock';
+import { MockAuthenticationCodeService, MockVerificationUsageService, MockTokenService, MockSessionService } from 'test/unit/__mock__/auth/service.mock';
+import { MockSmsService } from 'test/unit/__mock__/notification/service.mock';
+import { MockPhoneRepository } from 'test/unit/__mock__/user-auth-common/repository.mock';
 
 describe('인증 서비스(AuthService) Test', () => {
     let authService: AuthService;
     let smsService: SmsService;
     let phoneRepository: PhoneRepository;
+    let tokenService: TokenService;
+    let sessionService: SessionService;
+    let verificationUsageService: VerificationUsageService;
 
     beforeAll(async () => {
         const module = await Test.createTestingModule({
             imports: [ConfigModule],
             providers: [
-                AuthService,
-                SmsService,
-                NaverSmsService,
-                {
-                    provide: VerificationUsageService,
-                    useValue: {
-                        addPhoneUsageHistory: jest.fn()
-                    }
-                },
-                {
-                    provide: PhoneVerificationRepository,
-                    useValue: {}
-                },
-                {
-                    provide: getRepositoryToken(Phone),
-                    useValue: {
-                        findByPhoneNumber: jest.fn()
-                    }
-                },
                 {
                     provide: 'REDIS_CLIENT',
                     useValue: {}
-                }
+                },
+                {
+                    provide: AuthMapper,
+                    useValue: { toDto: jest.fn() }
+                },
+                AuthService,
+                MockSmsService,
+                MockTokenService,
+                MockSessionService,
+                NaverSmsService,
+                MockVerificationUsageService,
+                MockPhoneVerificationRepository,
+                MockAuthenticationCodeService,
+                MockPhoneRepository,
             ]
         }).compile();
         authService = module.get(AuthService);
         smsService = module.get(SmsService);
+        tokenService = module.get(TokenService);
+        sessionService = module.get(SessionService);
         phoneRepository = module.get(getRepositoryToken(Phone));
-    })
+        verificationUsageService = module.get(VerificationUsageService);
+    });
+
+    beforeEach( () => jest.clearAllMocks() );
     describe('register()', () => {
         it('이미 가입되어 있는 전화번호인 경우 409에러를 던진다', async () => {
             jest.spyOn(phoneRepository, 'findByPhoneNumber').mockResolvedValue(new Phone('01011111111'))
@@ -91,6 +101,29 @@ describe('인증 서비스(AuthService) Test', () => {
             const result = await authService.login('01011112222');
 
             expect(result).toBe('newuser')
-        })
+        });
+
+        it('휴대폰인증 사용내역을 1회 추가해야 한다.', async () => {
+            const verificationUsageSpy = jest.spyOn(verificationUsageService, 'addPhoneUsageHistory').mockReturnValueOnce(null);
+            await authService.login('01022334444');
+
+            expect(verificationUsageSpy).toBeCalledTimes(1);
+        });
+    });
+
+    describe('createAuthenticationToUser()', () => {
+        it('새로운 AccessToken을 발급받고 Session목록에 추가하기 위해 서비스 호출', async () => {
+            const user = new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, null);
+            expect(await user.getAuthentication()).toBe(null);
+
+            jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce('accessToken');
+            const sessionServiceSpy = jest.spyOn(sessionService, 'addUserToList').mockResolvedValueOnce(null);
+
+            await authService.createAuthenticationToUser(user);
+
+            expect(await user.getAuthentication()).not.toBe(null);
+            expect((await user.getAuthentication()).getAccessToken()).toBe('accessToken');
+            expect(sessionServiceSpy).toBeCalledTimes(1);
+        });
     })
 })

--- a/backend/test/unit/auth/application/service/authentication-code-service.spec.ts
+++ b/backend/test/unit/auth/application/service/authentication-code-service.spec.ts
@@ -1,0 +1,44 @@
+import { NotFoundException } from "@nestjs/common";
+import { Test } from "@nestjs/testing"
+import { RedisClusterType } from "redis"
+import { AuthenticationCodeService } from "src/auth/application/service/authentication-code.service"
+import { AuthenticationCode } from "src/auth/domain/authentication-code";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+describe('인증코드 관리 서비스(AuthenticationCodeService) Test', () => {
+    let authenticationCodeService: AuthenticationCodeService,
+        redis: RedisClusterType;
+
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                AuthenticationCodeService,
+                {
+                    provide: 'REDIS_CLIENT',
+                    useValue:{
+                        GET: jest.fn()
+                    }
+                }
+            ]
+        }).compile();
+        authenticationCodeService = module.get(AuthenticationCodeService);
+        redis = module.get('REDIS_CLIENT');
+    });
+
+    describe('getPhoneCode()', () => {
+        const phoneNumber = '01011123456';
+        it('해당 휴대폰번호의 인증코드가 존재하지 않으면 404에러', async () => {
+            jest.spyOn(redis, 'GET').mockResolvedValueOnce(null);
+            const result = async () => await authenticationCodeService.getPhoneCode(phoneNumber);
+            await expect(result).rejects.toThrowError(new NotFoundException(ErrorMessage.ExpiredSmsCode));
+        });
+
+        it('해당 휴대폰번호의 인증코드가 존재하면 AuthenticationCode객체가 반환', async () => {
+            jest.spyOn(redis, 'GET').mockResolvedValueOnce('242333');
+            const result = await authenticationCodeService.getPhoneCode(phoneNumber);
+            
+            expect(result).toBeInstanceOf(AuthenticationCode);
+            expect(result.getCode()).toBe(242333);
+        });
+    })
+})

--- a/backend/test/unit/auth/application/service/verification-usage-service.spec.ts
+++ b/backend/test/unit/auth/application/service/verification-usage-service.spec.ts
@@ -17,12 +17,25 @@ describe('인증 사용 내역 서비스(VerificationUsageService) Test', () => 
             expect(testUsage.getDayAttemp()).toBe(3);
         });
 
-        it('기존 인증 사용내역이 null이면 새로 내역을 생성하여 저장한다',async () => {
+        it('기존 인증 사용내역이 null이면 새로 내역을 생성하여 횟수를 증가시킨 이후 저장한다',async () => {
+            const phoneNumber = '01012345678';
+            const testUsage = new PhoneVerificationUsage();
+            testUsage.addHistory();
+
             jest.spyOn(verificationUsageService, 'getPhoneUsageHistory').mockResolvedValue(null);
             const saveSpy = jest.spyOn(mockPhoneVerificationRepo, 'save').mockResolvedValue(null);
-            await verificationUsageService.addPhoneUsageHistory('01012345678');
+            await verificationUsageService.addPhoneUsageHistory(phoneNumber);
 
-            expect(saveSpy).toBeCalledWith('01012345678', { codeAttemp: 0, dayAttemp: 1 });
+            expect(saveSpy).toBeCalledWith(phoneNumber, testUsage);
         })
+    });
+
+    describe('addPhoneCodeAttemp()', () => {
+        it('각 인증번호당 시도횟수가 한번 증가해야된다.', () => {
+            const beforeCodeAttemp = 2;
+            const testPhoneVerificationUsage = new PhoneVerificationUsage(0, beforeCodeAttemp);
+            testPhoneVerificationUsage.addCodeAttemp();
+            expect(testPhoneVerificationUsage.getCodeAttemp()).toBe(3);
+        });
     })
 })

--- a/backend/test/unit/auth/application/service/verification-usage-service.spec.ts
+++ b/backend/test/unit/auth/application/service/verification-usage-service.spec.ts
@@ -1,0 +1,28 @@
+import { VerificationUsageService } from "src/auth/application/service/verification-usage.service";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository"
+
+describe('인증 사용 내역 서비스(VerificationUsageService) Test', () => {
+    const mockPhoneVerificationRepo = {
+        save: jest.fn()
+    } as unknown as PhoneVerificationRepository;
+
+    const verificationUsageService = new VerificationUsageService(mockPhoneVerificationRepo);
+
+    describe('addPhoneUsageHistory()', () => {
+        it('휴대폰인증 일일 사용내역이 한번 증가해야된다', () => {
+            const testUsage = new PhoneVerificationUsage(2);
+            testUsage.addHistory();
+
+            expect(testUsage.getDayAttemp()).toBe(3);
+        });
+
+        it('기존 인증 사용내역이 null이면 새로 내역을 생성하여 저장한다',async () => {
+            jest.spyOn(verificationUsageService, 'getPhoneUsageHistory').mockResolvedValue(null);
+            const saveSpy = jest.spyOn(mockPhoneVerificationRepo, 'save').mockResolvedValue(null);
+            await verificationUsageService.addPhoneUsageHistory('01012345678');
+
+            expect(saveSpy).toBeCalledWith('01012345678', { codeAttemp: 0, dayAttemp: 1 });
+        })
+    })
+})

--- a/backend/test/unit/auth/domain/phone-verification-usage.spec.ts
+++ b/backend/test/unit/auth/domain/phone-verification-usage.spec.ts
@@ -1,0 +1,51 @@
+import { ForbiddenException } from "@nestjs/common";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+
+describe('휴대폰인증 사용내역 객체(PhoneVerificationUsage) Test', () => {
+    let testPhoneVerificationUsage: PhoneVerificationUsage;
+
+    it('일일 발송 가능 횟수를 모두 사용했으면 403에러', () => {
+        const sendAttemp = 5;
+        testPhoneVerificationUsage = new PhoneVerificationUsage(sendAttemp);
+
+        expect(() => testPhoneVerificationUsage.dayAttempCheck()).toThrowError(
+            new ForbiddenException(ErrorMessage.ExceededPhoneDailyLimit)
+        );
+    });
+
+    it('발송을 할 때마다 발송횟수는 증가하고 인증코드 시도횟수는 초기화', () => {
+        const sendAttemp = 2, codeAttemp = 3;
+        testPhoneVerificationUsage = new PhoneVerificationUsage(sendAttemp, codeAttemp);
+        testPhoneVerificationUsage.addHistory();
+
+        expect(testPhoneVerificationUsage.getDayAttemp()).toBe(3);
+        expect(testPhoneVerificationUsage.getCodeAttemp()).toBe(0);
+    });
+
+    it('인증번호당 시도가능한 횟수를 초과하면 403에러', () => {
+        const codeAttemp = 3;
+        testPhoneVerificationUsage = new PhoneVerificationUsage(0, codeAttemp);
+
+        expect(() => testPhoneVerificationUsage.codeAttempCheck()).toThrowError(
+            new ForbiddenException(ErrorMessage.ExceededCodeAttempLimit)
+        );
+    });
+
+    it('인증코드 검증을 할 때마다 코드시도 횟수 증가', () => {
+        const codeAttemp = 2;
+        testPhoneVerificationUsage = (new PhoneVerificationUsage(0, codeAttemp));
+        testPhoneVerificationUsage.addCodeAttemp();
+
+        expect(testPhoneVerificationUsage.getCodeAttemp()).toBe(3);
+    });
+
+    it('Plain Object를 문자열로 변경하여 반환', () => {
+        const dayAttemp = 3, codeAttemp = 3;
+        const serializedString = JSON.stringify({ dayAttemp, codeAttemp });
+        testPhoneVerificationUsage = new PhoneVerificationUsage(dayAttemp, codeAttemp);
+        
+        expect(testPhoneVerificationUsage.toSerializedString()).toBe(serializedString);
+    });
+})

--- a/backend/test/unit/auth/infra/repository/phone-verification-repository.spec.ts
+++ b/backend/test/unit/auth/infra/repository/phone-verification-repository.spec.ts
@@ -1,0 +1,58 @@
+import { ConfigService } from "@nestjs/config";
+import { RedisClientType } from "redis";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository"
+import { ConnectRedis, DisconnectRedis, getRedis } from "test/unit/common/database/datebase-setup.fixture"
+
+describe('휴대폰인증 횟수 내역 저장소(PhoneVerificationRepository) Test', () => {
+    let repo: PhoneVerificationRepository, redis: RedisClientType;
+    const phoneNumber = '01011111111', phoneVerificationUsage = new PhoneVerificationUsage();
+
+    const mockConfigService = {
+        get: jest.fn().mockReturnValue('test_phone_verification')
+    } as unknown as ConfigService;
+
+    beforeAll(async () => {
+        await ConnectRedis();
+        repo = new PhoneVerificationRepository(getRedis(), mockConfigService);
+        redis = getRedis();
+    });
+
+    afterEach(async () => await repo.delete(phoneNumber))
+
+    afterAll(async () => await DisconnectRedis() );
+
+    describe('save()', () => {
+
+        it('저장시 클래스의 메소드는 제외하고 필드만 저장되어야 한다.', async () => {
+            await repo.save(phoneNumber, phoneVerificationUsage);
+            const findResult = await redis.HGET(mockConfigService.get(''), phoneNumber);
+
+            expect(findResult).toEqual(phoneVerificationUsage.toSerializedString());
+        });
+    });
+
+    describe('findByPhoneNumber()', () => {
+        it('찾은 결과는 Class Instance로 변환되어 반환되어야 한다.', async () => {
+            await repo.save(phoneNumber, phoneVerificationUsage);
+            const findResult = await repo.findByPhoneNumber(phoneNumber);
+
+            expect(findResult).toBeInstanceOf(PhoneVerificationUsage);
+        });
+    });
+
+    describe('delete()', () => {
+        it('삭제한 이후에는 해당 키로 조회시 존재하지 않아야 한다.', async () => {
+            await repo.save(phoneNumber, phoneVerificationUsage);
+            let findResult = await repo.findByPhoneNumber(phoneNumber);
+
+            expect(findResult).not.toBeNull();
+
+            await repo.delete(phoneNumber);
+            findResult = await repo.findByPhoneNumber(phoneNumber);
+ 
+            expect(findResult).toBe(null);
+        })
+    })
+
+})

--- a/backend/test/unit/common/database/datebase-setup.fixture.ts
+++ b/backend/test/unit/common/database/datebase-setup.fixture.ts
@@ -1,4 +1,5 @@
 import { Db, MongoClient } from "mongodb";
+import { RedisClientType, createClient } from "redis";
 
 let mongodb: Db, mongoClient: MongoClient; // MongoDB
 
@@ -14,3 +15,14 @@ export async function ConnectMongoDB() {
 export function getMongodb() { return mongodb; };
 
 export async function DisconnectMongoDB() { await mongoClient.close(); };
+
+let redisClient: RedisClientType;
+
+export async function ConnectRedis() {
+    redisClient = createClient();
+    await redisClient.connect();
+};
+
+export function getRedis() { return redisClient; };
+
+export async function DisconnectRedis() { await redisClient.disconnect(); };

--- a/backend/test/unit/user/interface/dto/caregiver-register.spec.ts
+++ b/backend/test/unit/user/interface/dto/caregiver-register.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { plainToInstance } from "class-transformer"
 import { validate } from "class-validator"
 import { ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"

--- a/backend/test/unit/user/interface/dto/protector-register.spec.ts
+++ b/backend/test/unit/user/interface/dto/protector-register.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { plainToInstance } from "class-transformer"
 import { validate } from "class-validator"
 import { ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"

--- a/backend/test/unit/user/interface/dto/register-page.spec.ts
+++ b/backend/test/unit/user/interface/dto/register-page.spec.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { plainToInstance } from "class-transformer"
 import { validate } from "class-validator"
 import { ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"


### PR DESCRIPTION
[로그인 로직]

- 휴대폰인증을 통한 로그인
- Controller에 도착하기 전 문자발송시엔 일일 횟수에 관한 Guard, 인증코드 입력시 인증코드에 관한 Guard로 검사
- 가입을 하지 않은 사용자가 로그인을 시도하면 회원가입 페이지로 이동, 기존 사용자는 AccessToken만 발급해서 전달
- 토큰관리, 인증코드, 인증횟수내역, 문자발송의 각 서비스를 책임에 맞게 분리
- 인증코드는 Redis의 String으로 유효시간 설정, 휴대폰인증사용 내역은 Hash를 사용하여 저장