### PR TITLE
일일 휴대폰인증 사용내역 초기화 Task 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { GlobalScopedValidationPipe } from './common/pipe/global-scoped.pipe';
 import { CoreModule } from './core/core.module';
 import { MongodbModule } from './common/shared/database/mongodb/mongodb.module';
 import { NotificationModule } from './notification/notification.module';
+import { BatchModule } from './batch/batch.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { NotificationModule } from './notification/notification.module';
     TypeOrmModule.forRootAsync(TypeOrmOptions),
     RedisModule,
     MongodbModule,
+    BatchModule,
     AuthModule,
     NotificationModule,
     UserAuthCommonModule,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -34,7 +34,8 @@ import { NotificationModule } from 'src/notification/notification.module';
   ],
   exports: [
     TokenService,
-    SessionService
+    SessionService,
+    PhoneVerificationRepository
   ]
 })
 export class AuthModule implements NestModule{

--- a/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
+++ b/backend/src/auth/domain/entity/phone-verification-usage.entity.ts
@@ -9,7 +9,7 @@ export class PhoneVerificationUsage {
 
     private codeAttemp: number;
 
-    constructor(dayAttemp: number = 0, codeAttemp: number = 0, blockedAt: string = null) {
+    constructor(dayAttemp: number = 0, codeAttemp: number = 0) {
         this.dayAttemp = dayAttemp;
         this.codeAttemp = codeAttemp;
     }

--- a/backend/src/auth/infra/repository/phone-verification.repository.ts
+++ b/backend/src/auth/infra/repository/phone-verification.repository.ts
@@ -1,31 +1,27 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
 import { plainToInstance } from "class-transformer";
 import { RedisClientType } from "redis";
 import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
 import { IPhoneVerificationRepository } from "src/auth/domain/repository/iphone-verification.repository";
+import { DateTime } from "src/util/datetime.util";
 
 @Injectable()
 export class PhoneVerificationRepository implements IPhoneVerificationRepository {
-    private key: string // redis hash key
     constructor(
         @Inject('REDIS_CLIENT')
         private readonly redis: RedisClientType,
-        private readonly configService: ConfigService
-    ) {
-        this.key = configService.get('db.redis.key.phone_verification_usage');
-    }
+    ) {}
 
     async save(phoneNumber: string, phoneVerificationUsage: PhoneVerificationUsage): Promise<void> {
-        await this.redis.HSET(this.key, phoneNumber, phoneVerificationUsage.toSerializedString());
+        await this.redis.HSET(`phone:auth:${DateTime.getToday()}:usage`, phoneNumber, phoneVerificationUsage.toSerializedString());
     };
     
     async findByPhoneNumber(phoneNumber: string): Promise<PhoneVerificationUsage | null> {
-        return this.parseToInstance( await this.redis.HGET(this.key, phoneNumber) );
+        return this.parseToInstance( await this.redis.HGET(`phone:auth:${DateTime.getToday()}:usage`, phoneNumber) );
     };
 
     async delete(phoneNumber: string): Promise<void> {
-        await this.redis.HDEL(this.key, phoneNumber);
+        await this.redis.HDEL(`phone:auth:${DateTime.getToday()}:usage`, phoneNumber);
     }
 
     /* 문자열로 저장된 객체 파싱 후 인스턴스로 */

--- a/backend/src/batch/batch.module.ts
+++ b/backend/src/batch/batch.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { ScheduleModule } from "@nestjs/schedule";
+import { TaskService } from "./task.service";
+import { AuthModule } from "src/auth/auth.module";
+
+@Module({
+    imports: [
+        ScheduleModule.forRoot(),
+        AuthModule
+    ],
+    providers: [
+        TaskService
+    ]
+})
+export class BatchModule {}

--- a/backend/src/batch/task.service.ts
+++ b/backend/src/batch/task.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { RedisClientType } from "redis";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+import { DateTime } from "src/util/datetime.util";
+
+@Injectable()
+export class TaskService {
+    private readonly PHONE_AUTH_KEY_EXPIRED_TIME = 86400;
+    constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
+        private readonly phoneVerificationUsageRepository: PhoneVerificationRepository
+    ) {};
+
+    /* 매일 자정 하루동안 유지되는 그날의 휴대폰 인증 사용량 Key 만료시간 설정 */
+    @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+    async DailyPhoneAuthUsageExpiredTask() {
+        const today = DateTime.getToday();
+
+        /* Key가 없을 경우 임의의 값을 넣고 저장 후 만료시간 설정 */
+        if( !await this.setDailyPhoneAuthUsageExpired(today) ) {
+            await this.phoneVerificationUsageRepository.save('default', new PhoneVerificationUsage());
+            await this.setDailyPhoneAuthUsageExpired(today);
+        }
+    };
+
+    private async setDailyPhoneAuthUsageExpired(today: number): Promise<boolean> {
+        return await this.redis.EXPIRE(`phone:auth:${today}:usage`, this.PHONE_AUTH_KEY_EXPIRED_TIME)
+    }
+}

--- a/backend/src/util/datetime.util.ts
+++ b/backend/src/util/datetime.util.ts
@@ -1,0 +1,7 @@
+/* 날짜관련 Util함수 모음 */
+export class DateTime {
+    /* 오늘 날짜 */
+    static getToday(): number {
+        return new Date().getDate();
+    };
+}

--- a/backend/test/unit/batch/task-service.spec.ts
+++ b/backend/test/unit/batch/task-service.spec.ts
@@ -1,0 +1,50 @@
+import { Test } from "@nestjs/testing";
+import { TaskService } from "src/batch/task.service"
+import { MockPhoneVerificationRepository } from "../__mock__/auth/repository.mock";
+import { RedisClientType } from "redis";
+import { PhoneVerificationRepository } from "src/auth/infra/repository/phone-verification.repository";
+import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
+
+describe('TaskService Test', () => {
+    let phoneVerificationRepository: PhoneVerificationRepository;
+    let taskService: TaskService;
+    let redis: RedisClientType;
+
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                TaskService,
+                MockPhoneVerificationRepository,
+                {
+                    provide: 'REDIS_CLIENT',
+                    useValue: {
+                        EXPIRE: jest.fn()
+                    }
+                }
+            ]
+        }).compile();
+
+        phoneVerificationRepository = module.get(PhoneVerificationRepository);
+        taskService = module.get(TaskService);
+        redis = module.get('REDIS_CLIENT');
+    });
+
+    describe('DailyPhoneAuthUsageExpiredTask()', () => {
+        it('정상적으로 Key에 만료시간이 설정되었다면 임의의값이 추가되지 않는다.', async () => {
+            jest.spyOn(redis, 'EXPIRE').mockResolvedValueOnce(true);
+            const saveSpy = jest.spyOn(phoneVerificationRepository, 'save');
+
+            await taskService.DailyPhoneAuthUsageExpiredTask();
+            expect(saveSpy).not.toBeCalled();
+        });
+
+        it('Key가 존재하지 않아 설정에 실패했다면 임의의값을 추가한다.', async () => {
+            const testUsage = new PhoneVerificationUsage();
+            jest.spyOn(redis, 'EXPIRE').mockResolvedValueOnce(false);
+            const saveSpy = jest.spyOn(phoneVerificationRepository, 'save');
+
+            await taskService.DailyPhoneAuthUsageExpiredTask()
+            expect(saveSpy).toBeCalledWith('default', testUsage);
+        });
+    })
+})


### PR DESCRIPTION
- 고정되어있던 redis key값을 날짜별로 저장하고 이전 날짜내역을 삭제하기 위해 동적인 key 생성으로 변경
- 매일 밤 자정에 이전 날짜의 휴대폰인증 사용내역을 Task로 삭제
- 직접 삭제하는 로직이 아닌 Key에 EXPIRE TIME 걸어둠
- 존재하지 않는 Key에 EXPIRE명령어를 수행하면 실패하므로 이 경우에는 임의의데이터를 넣고 수행