### PR TITLE
[프론트엔드] 내정보 화면 표시 필요한 데이터 수정

### DIFF
--- a/frontendv2/components/Login/AuthId.jsx
+++ b/frontendv2/components/Login/AuthId.jsx
@@ -80,8 +80,8 @@ export default function AuthId({ navigation }) {
                     reset();
                 }, 200);
             } else {
-                const { accessToken, id } = res.data;  
-                dispatch(saveUser(id));
+                const { accessToken, ...user } = res.data;  
+                dispatch(saveUser(user));
                 await AsyncStorage.setItem('accessToken', accessToken);
                 navigation.dispatch(
                     StackActions.pop()

--- a/frontendv2/functions/Register/requestCreateUser.jsx
+++ b/frontendv2/functions/Register/requestCreateUser.jsx
@@ -18,8 +18,8 @@ export default async function requestCreateUser(RegisterData, navigation) {
             thirdRegister: purpose === 'protector' ? undefined : convertCaregiverThirdRegister(RegisterData.thirdRegister),
             lastRegister: purpose === 'protector' ? RegisterData.patientHelpList : RegisterData.lastRegister,
         });
-        const { accessToken, id } = res.data;
-        store.dispatch(saveUser(id));
+        const { accessToken, ...user } = res.data;
+        store.dispatch(saveUser(user));
         await AsyncStorage.setItem('accessToken', accessToken)
         navigation.dispatch(
             StackActions.push('registerCompletePage')

--- a/frontendv2/redux/reducer/user/userReducer.js
+++ b/frontendv2/redux/reducer/user/userReducer.js
@@ -3,15 +3,17 @@ import { saveUser, logout } from "../../action/user/userAction";
 
 const initialState = {
     id: '',
+    name: ''
 };
 
 const userReducer = createReducer(initialState, (builder) => {
     builder
         .addCase(saveUser, (state, action) => {
-            state.id = action.payload
+            Object.assign(state, action.payload)
         })
         .addCase(logout, (state) => {
             state.id = '';
+            state.name = '';
         })
 });
 

--- a/frontendv2/screens/MyInfo.jsx
+++ b/frontendv2/screens/MyInfo.jsx
@@ -1,44 +1,21 @@
 /* 마이 페이지 */
 
 import React from 'react';
-import { useState } from 'react';
-import { useLayoutEffect } from 'react';
-import { useEffect } from 'react';
 import {
     View,
     SafeAreaView,
     StyleSheet,
-}
-    from 'react-native';
+} from 'react-native';
 import LoginBox from '../components/MyInfo/LoginBox';
 import StatusBarComponent from '../components/StatusBarComponent';
-import { getLoginState, validateToken } from '../functions/Token';
-import Loading from './Loading';
 
 export default function MyInfo({ navigation }) {
-    const [loading, setLoading] = useState(true);
-    useLayoutEffect(() => {
-        async function getState() {
-            const isLogin = await getLoginState();
-            if (isLogin) {
-                await validateToken(navigation);
-            }
-            setLoading(false)
-        }
-        getState();
-    }, [])
-
     return (
         <SafeAreaView style={styles.container}>
             <StatusBarComponent />
-            {loading ?
-                <Loading /> :
-                <>
-                    <LoginBox navigation={navigation} />
-                    <View style={{ flex: 7 }}>
-                    </View>
-                </>
-            }
+            <LoginBox navigation={navigation} />
+            <View style={{ flex: 7 }}>
+            </View>
         </SafeAreaView>
 
     );


### PR DESCRIPTION
내정보 화면에서는 사용자의 이름만이 필요하므로 맞게 수정
기존 **api 조회 -> reducer**에 저장되어 있는 상태값으로 렌더링
- **User Reducer** 상태값에 name 속성 추가
- 로그인, 회원가입시 완료되고 난 후 user 상태값 저장시 **name** 속성 추가