### PR TITLE
[백엔드] 내정보 화면 출력에 필요한 데이터 로직 완료

### DIFF
--- a/backend/src/batch/batch.module.ts
+++ b/backend/src/batch/batch.module.ts
@@ -2,11 +2,13 @@ import { Module } from "@nestjs/common";
 import { ScheduleModule } from "@nestjs/schedule";
 import { TaskService } from "./task.service";
 import { AuthModule } from "src/auth/auth.module";
+import { RedisModule } from "src/common/shared/database/redis/redis.module";
 
 @Module({
     imports: [
         ScheduleModule.forRoot(),
-        AuthModule
+        AuthModule,
+        RedisModule
     ],
     providers: [
         TaskService

--- a/backend/src/user-auth-common/application/user-auth-common.mapper.ts
+++ b/backend/src/user-auth-common/application/user-auth-common.mapper.ts
@@ -5,6 +5,7 @@ export abstract class UserAuthCommonMapper {
     async toDto(user: User): Promise<ClientDto> {
         return {
             id: user.getId(),
+            name: user.getName(),
             accessToken: (await user.getAuthentication()).getAccessToken(),
         };
     }

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -47,6 +47,7 @@ export class User {
     };
 
     getId(): number { return this.id; };
+    getName(): string { return this.name; };
     getRole(): ROLE { return this.role; };
 
     async getPhone(): Promise<Phone> { return await this.phone; };

--- a/backend/src/user-auth-common/interface/client.dto.ts
+++ b/backend/src/user-auth-common/interface/client.dto.ts
@@ -1,4 +1,5 @@
 export interface ClientDto { 
     readonly id: number;
+    readonly name: string;
     readonly accessToken: string; 
 };

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -45,6 +45,7 @@ describe('UserMapper Component Test', () => {
             const mapResult = await userMapper.toDto(testUser);
 
             expect(mapResult).toHaveProperty('id');
+            expect(mapResult).toHaveProperty('name');
             expect(mapResult).toHaveProperty('accessToken')
         })
     })


### PR DESCRIPTION
내정보 화면에는 로그인 여부에 따라 **사용자의 이름**만이 필요
기존 Api를 조회하던 로직 -> 로그인, 회원가입에 성공하면 넘겨주는 user 객체에 **name **필드 추가
- **UserEntity** name 필드에 **getter** 추가
- 사용자에게 반환하는 **clientDto**에 **name** 필드 추가
- **mapper**에 사용자의 name get 추가
