### PR TITLE
[백엔드] JWT 토큰으로 인증 가드 완료

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { CoreModule } from './core/core.module';
 import { MongodbModule } from './common/shared/database/mongodb/mongodb.module';
 import { NotificationModule } from './notification/notification.module';
 import { BatchModule } from './batch/batch.module';
+import { GlobalScopedJwtGuard } from './auth/application/guard/jwt/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -33,7 +34,8 @@ import { BatchModule } from './batch/batch.module';
   ],
   providers: [
     GlobalScopedValidationPipe,
-    GlobalScopedExceptionFilter
+    GlobalScopedExceptionFilter,
+    GlobalScopedJwtGuard
   ]
 })
 export class AppModule {}

--- a/backend/src/auth/application/decorator/public.decorator.ts
+++ b/backend/src/auth/application/decorator/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
+++ b/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
@@ -1,0 +1,62 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { APP_GUARD, Reflector } from "@nestjs/core";
+import { JwtModuleAsyncOptions } from "@nestjs/jwt";
+import { AuthGuard } from "@nestjs/passport";
+import { SessionService } from "../../service/session.service";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { IS_PUBLIC_KEY } from "../../decorator/public.decorator";
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+    constructor(
+        private readonly sessionService: SessionService,
+        private readonly reflector: Reflector
+    ) {
+        super();
+    };
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        /* Public Api인지 먼저 체크 */
+        if( this.isPublicApi(context) ) return true;
+
+        /* 먼저 request.user의 상태를 확인해서 토큰 검사 통과했는지 확인 */
+        await super.canActivate(context)
+        
+        const { userId } = context.switchToHttp().getRequest().body;
+
+        return await this.isExistUserInSessionList(userId);
+    };
+
+    private isPublicApi(context: ExecutionContext) {
+        return this.reflector.getAllAndOverride(IS_PUBLIC_KEY, [
+            context.getHandler(),
+            context.getClass()
+        ]);
+    }
+
+    /* 
+        토큰은 유효하지만 로그아웃을 진행한 사용자와같이 
+        현재 로그인정보에 없는 사용자의 토큰이면 오류 
+    */
+    private async isExistUserInSessionList(userId: number): Promise<boolean> {
+        if (!await this.sessionService.getUserFromList(userId))
+            throw new UnauthorizedException(ErrorMessage.NotExistUserInSessionList);
+        return true;
+    }
+
+};
+
+/* jwt module options */
+export const jwtRegisterOptions: JwtModuleAsyncOptions = {
+    inject: [ConfigService],
+    useFactory: (configService: ConfigService) => ({
+        secret: configService.get('jwt.accessToken.secret'),
+        signOptions: { expiresIn: configService.get('jwt.accessToken.expiredTime') }
+    })
+};
+
+export const GlobalScopedJwtGuard = {
+    provide: APP_GUARD,
+    useClass: JwtAuthGuard
+}

--- a/backend/src/auth/application/guard/jwt/jwt.strategy.ts
+++ b/backend/src/auth/application/guard/jwt/jwt.strategy.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+import { ExtractJwt, Strategy } from "passport-jwt";
+import { JwtPayload } from "../../type/jwt-payload.type";
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+    constructor( 
+        private readonly configService: ConfigService
+        ) {
+        super({
+            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            ignoreExpiration: false,
+            secretOrKey: configService.get('jwt.accessToken.secret')
+        });
+    }
+
+    async validate(payload: JwtPayload | null) { return payload; };
+}

--- a/backend/src/auth/application/service/session.service.ts
+++ b/backend/src/auth/application/service/session.service.ts
@@ -14,5 +14,9 @@ export class SessionService {
 
     async addUserToList(userId: number, authentication: string) {
         await this.redis.HSET(this.key, userId, authentication);
+    };
+
+    async getUserFromList(userId: number) {
+        return await this.redis.HGET(this.key, userId.toString());
     }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { AuthMapper } from './application/mapper/auth.mapper';
 import { SessionService } from './application/service/session.service';
 import { AuthenticationCodeService } from './application/service/authentication-code.service';
 import { NotificationModule } from 'src/notification/notification.module';
+import { JwtStrategy } from './application/guard/jwt/jwt.strategy';
 
 @Module({
   imports: [
@@ -30,7 +31,8 @@ import { NotificationModule } from 'src/notification/notification.module';
     PhoneAuthenticationCodeGuard,
     AuthMapper,
     AuthenticationCodeService,
-    SessionService
+    SessionService,
+    JwtStrategy
   ],
   exports: [
     TokenService,

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -5,13 +5,16 @@ import { PhoneAuthenticationCodeGuard } from "src/auth/application/guard/authent
 import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
+import { Public } from "src/auth/application/decorator/public.decorator";
 
 @Controller('auth')
 export class AuthController {
     constructor(
         private readonly authService: AuthService
     ) {}
+
     /* 휴대폰으로 회원가입 */
+    @Public()
     @UseGuards(PhoneAuthenticationSendGuard)
     @Post('register')
     async register(@Body('phoneNumber') phoneNumber: string) {
@@ -19,6 +22,7 @@ export class AuthController {
     }
 
     /* 휴대폰 인증코드 검사 */
+    @Public()
     @UseGuards(PhoneAuthenticationCodeGuard)
     @Post('code/sms')
     async validateSmsCode(@AuthenticatedUser() user: User): Promise<ClientDto | void> {
@@ -26,6 +30,7 @@ export class AuthController {
     }
 
     /* 로그인 */
+    @Public()
     @UseGuards(PhoneAuthenticationSendGuard)
     @Post('login')
     async login(@Body('phoneNumber') phoneNumber: string): Promise<'newuser' | 'exist'> {

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -4,5 +4,6 @@ export const enum ErrorMessage {
     ExpiredSmsCode = '인증유효시간이 초과되었습니다. 다시 시도해 주세요.',
     NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.',
     ExceededPhoneDailyLimit = '일일 가능한 인증횟수를 초과하였습니다.',
-    ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.'
+    ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.',
+    NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.'
 }

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -38,7 +38,8 @@ export const MockTokenService = {
 export const MockSessionService = {
     provide: SessionService,
     useValue: {
-        addUserToList: jest.fn()
+        addUserToList: jest.fn(),
+        getUserFromList: jest.fn()
     }
 };
 

--- a/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
@@ -1,0 +1,110 @@
+import { UnauthorizedException } from "@nestjs/common"
+import { ConfigService } from "@nestjs/config"
+import { Reflector } from "@nestjs/core"
+import { Test } from "@nestjs/testing"
+import { JwtAuthGuard } from "src/auth/application/guard/jwt/jwt-auth.guard"
+import { JwtStrategy } from "src/auth/application/guard/jwt/jwt.strategy"
+import { SessionService } from "src/auth/application/service/session.service"
+import { MockSessionService } from "test/unit/__mock__/auth/service.mock"
+
+describe('Jwt인증가드(JwtAuthGuard) Test', () => {
+    let sessionService: SessionService;
+    let reflector: Reflector;
+    let jwtGuard: JwtAuthGuard;
+
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                JwtAuthGuard,
+                JwtStrategy,
+                MockSessionService,
+                {
+                    provide: Reflector,
+                    useValue: {
+                        getAllAndOverride: jest.fn()
+                    }
+                },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn().mockReturnValue('test')
+                    }
+                }
+            ]
+        }).compile();
+
+        sessionService = module.get(SessionService);
+        reflector = module.get(Reflector);
+        jwtGuard = module.get(JwtAuthGuard);
+    });
+
+    it('Public Api이면 True 반환', async () => {
+        jest.spyOn(reflector, 'getAllAndOverride').mockReturnValueOnce('sef');
+        const mockContext: any = {
+            getHandler: jest.fn(),
+            getClass: jest.fn(),
+        };
+        const result = await jwtGuard.canActivate(mockContext);
+        expect(result).toBe(true);
+    });
+
+    describe('Public Api가 아닌 경우', () => {
+
+        beforeAll(() => jest.spyOn(reflector, 'getAllAndOverride').mockReturnValueOnce(false));
+
+        it('헤더에 토큰 정보가 없다면 에러', async () => {
+            const mockContext: any = {
+                getHandler: jest.fn(),
+                getClass: jest.fn(),
+                switchToHttp: () => ({
+                    getResponse: jest.fn(),
+                    getRequest: () => ({
+                        headers: {},
+                        body: { userId: 1 }
+                    })
+                })
+            };
+
+            const result = async () => await jwtGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(UnauthorizedException)
+        });
+
+        it('만료된 토큰이라면 에러', async() => {
+            const mockContext: any = {
+                getHandler: jest.fn(),
+                getClass: jest.fn(),
+                switchToHttp: () => ({
+                    getResponse: jest.fn(),
+                    getRequest: () => ({
+                        headers: {
+                            Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxIiwicm9sZSI6ImNhcmVnaXZlciIsImlhdCI6MTUxNjIzOTAyMn0.j-8NzDc8SkY7mRzgLpllfVdOAPsc2n1dDCkRbZ1EQgI"
+                        },
+                        body: { userId: 1 }
+                    })
+                })
+            };
+
+            const result = async () => await jwtGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(UnauthorizedException)
+
+        })
+
+        it('토큰은 유효하지만 세션리스트에 없는 토큰이면 오류', async () => {
+            const mockContext: any = {
+                getHandler: jest.fn(),
+                getClass: jest.fn(),
+                switchToHttp: () => ({
+                    getResponse: jest.fn(),
+                    getRequest: () => ({
+                        headers: {},
+                        body: { userId: 1 }
+                    })
+                })
+            };
+
+            jest.spyOn(sessionService, 'getUserFromList').mockResolvedValueOnce(null);
+            const result = async () => await jwtGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(UnauthorizedException)
+        });
+    })
+})

--- a/backend/test/unit/auth/application/service/session-service.spec.ts
+++ b/backend/test/unit/auth/application/service/session-service.spec.ts
@@ -41,5 +41,22 @@ describe('토큰 서비스(TokenService) Test', () => {
             
             await redis.HDEL('user:session:list', '1');
         })
+    });
+
+    describe('getUserFromList()', () => {
+        it('찾는 유저가 없으면 Null값이 반환', async() => {
+            const result = await sessionService.getUserFromList(11);
+
+            expect(result).toBe(null);
+        });
+
+        it('현재 세션리스트에 사용자가 있으면 해당 토큰 반환', async() => {
+            await sessionService.addUserToList(40, 'testAccessToken');
+
+            const result = await sessionService.getUserFromList(40);
+            expect(result).toBe('testAccessToken');
+
+            await redis.HDEL('user:session:list', '40');
+        });
     })
 })


### PR DESCRIPTION
**JWT 토큰**으로 Api 인증 수행
- **Public** 데코레이터가 달린 Api들은 Guard에서 바로 Return
- **JwtStrategy**를 통해 토큰의 유효성 검사 
- **JwtGuard**에서는 **AuthGuard**의 **CanActivate**메소드를 호출해 request객체의 user가 설정되어있는지, 헤더에 토큰이 있는지 확인
- 토큰에 문제가 없으면 토큰속에 사용자 **식별번호**를 통해 해당 토큰이 현재 세션리스트에 존재하는지 확인