### PR TITLE
[백엔드] RefreshToken을 통한 인증 갱신 Api 완료

### DIFF
--- a/backend/src/auth/application/guard/refresh-authentication.guard.ts
+++ b/backend/src/auth/application/guard/refresh-authentication.guard.ts
@@ -1,0 +1,45 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { UserRepository } from "src/user-auth-common/domain/repository/user.repository";
+import { JwtService } from "@nestjs/jwt";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+@Injectable()
+export class RefreshAuthenticationGuard implements CanActivate{
+    constructor(
+        @InjectRepository(User)
+        private readonly userRepository: UserRepository,
+        private readonly jwtService: JwtService,
+    ) {}
+    
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+
+        /* 해당 RefreshKey를 가지고있는 User 조회 */
+        const user = await this.getUserByRefreshKey(request.body.refreshKey); 
+
+        /* 조회된 유저의 RefreshToken 검증 */
+        await this.jwtService.verifyAsync( user.getAuthentication().getRefreshToken());
+
+        request.user = user;
+        return true;
+    };
+
+    private async getUserByRefreshKey(refreshKey: string): Promise<never | User>  {
+        this.validateRefreshKey(refreshKey);
+    
+        const user = await this.userRepository.findByRefreshKey(refreshKey);
+        
+        if( !user )
+            throw new UnauthorizedException(ErrorMessage.InvalidRefreshKey);
+
+        return user;
+    };
+
+    /* 요청에 RefreshKey가 존재하는지 */
+    private validateRefreshKey(refreshKey: string): never | void {
+        if( !refreshKey )
+            throw new UnauthorizedException(ErrorMessage.NotExistRefreshKeyInRequest);
+    }
+}

--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -10,10 +10,16 @@ import { AuthMapper } from "../mapper/auth.mapper";
 import { SessionService } from "./session.service";
 import { AuthenticationCodeService } from "./authentication-code.service";
 import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service";
+import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface";
+import { InjectRepository } from "@nestjs/typeorm";
+import { UserRepository } from "src/user-auth-common/domain/repository/user.repository";
+import { RefreshToken } from "src/user-auth-common/domain/refresh-token";
 
 @Injectable()
 export class AuthService {
     constructor(
+        @InjectRepository(User)
+        private readonly userRepository: UserRepository,
         private readonly userAuthCommonService: UserAuthCommonService,
         private readonly authenticationCodeService: AuthenticationCodeService, // 인증 코드 관리 서비스(email, phone)
         private readonly verificationUsageService: VerificationUsageService, // 인증 사용내역 서비스(email, phone)
@@ -37,16 +43,21 @@ export class AuthService {
         return 'newuser';
     }
 
-    async refreshToken(userId: number) {
-        const user = await this.userAuthCommonService.getUser(userId);
+    /* 새로운 인증 갱신 */
+    async refreshAuthentication(user: User): Promise<ClientDto> {
+        const newAuthentication = await this.tokenService.generateNewUsersToken(user); // 새로운 인증 발급
+        user.setAuthentication(newAuthentication); 
+        await this.userRepository.save(user); // 새로운 갱신토큰, 갱신키 저장
+        await this.sessionService.addUserToList(user.getId(), newAuthentication.refreshToken.getToken()); // 새로운 AccessToken 세션에 추가
+        return this.authMapper.toDto(user);
     }
 
     /* 로그인에 성공한 사용자는 사용할 토큰 발급 */
     async createAuthenticationToUser(user: User): Promise<ClientDto> {
-        const accessToken = await this.tokenService.generateAccessToken(user); // 새로운 AccessToken 발급
-        user.setAuthentication({ accessToken, refreshToken: null }); // RefreshToken은 기존 토큰 사용
-        await this.sessionService.addUserToList(user.getId(), accessToken) // sessionList에 추가
-        return await this.authMapper.toDto(user);
+        const newAccessToken = await this.tokenService.generateAccessToken(user); // 새로운 AccessToken 발급
+        user.changeAuthentication(newAccessToken); // RefreshToken은 기존 토큰 사용
+        await this.sessionService.addUserToList(user.getId(), newAccessToken) // sessionList에 추가
+        return this.authMapper.toDto(user);
     }
 
     /* 문자 발송 이후 발송된 코드 저장 */

--- a/backend/src/auth/application/service/token.service.ts
+++ b/backend/src/auth/application/service/token.service.ts
@@ -39,7 +39,7 @@ export class TokenService {
 
     async generateRefreshToken(user: User): Promise<RefreshToken> {
         const [uuid, refreshToken] = [
-            UUIDUtil.generatedUuidV1(),
+            UUIDUtil.generateOrderedUuid(),
             await this.jwtService.signAsync( this.generateJwtPayload(user), {
                 secret: this.refreshTokenSecret,
                 expiresIn: this.refreshTokenExpiresIn

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { SessionService } from './application/service/session.service';
 import { AuthenticationCodeService } from './application/service/authentication-code.service';
 import { NotificationModule } from 'src/notification/notification.module';
 import { JwtStrategy } from './application/guard/jwt/jwt.strategy';
+import { RefreshAuthenticationGuard } from './application/guard/refresh-authentication.guard';
 
 @Module({
   imports: [
@@ -32,7 +33,8 @@ import { JwtStrategy } from './application/guard/jwt/jwt.strategy';
     AuthMapper,
     AuthenticationCodeService,
     SessionService,
-    JwtStrategy
+    JwtStrategy,
+    RefreshAuthenticationGuard
   ],
   exports: [
     TokenService,

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -6,12 +6,20 @@ import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
 import { Public } from "src/auth/application/decorator/public.decorator";
+import { RefreshAuthenticationGuard } from "src/auth/application/guard/refresh-authentication.guard";
 
 @Controller('auth')
 export class AuthController {
     constructor(
         private readonly authService: AuthService
     ) {}
+
+    @Public()
+    @UseGuards(RefreshAuthenticationGuard)
+    @Post('refresh')
+    async refreshAuthentication(@AuthenticatedUser() user: User): Promise<ClientDto> {
+        return await this.authService.refreshAuthentication(user);
+    }
 
     /* 휴대폰으로 회원가입 */
     @Public()

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -5,5 +5,6 @@ export const enum ErrorMessage {
     NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.',
     ExceededPhoneDailyLimit = '일일 가능한 인증횟수를 초과하였습니다.',
     ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.',
-    NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.'
+    NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
+    InvalidRefreshToken = '유효하지 않은 RefreshToken입니다.'
 }

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -6,5 +6,6 @@ export const enum ErrorMessage {
     ExceededPhoneDailyLimit = '일일 가능한 인증횟수를 초과하였습니다.',
     ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.',
     NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
-    InvalidRefreshToken = '유효하지 않은 RefreshToken입니다.'
+    InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
+    NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.'
 }

--- a/backend/src/user-auth-common/application/user-auth-common.mapper.ts
+++ b/backend/src/user-auth-common/application/user-auth-common.mapper.ts
@@ -2,11 +2,11 @@ import { User } from "../domain/entity/user.entity";
 import { ClientDto } from "../interface/client.dto";
 
 export abstract class UserAuthCommonMapper {
-    async toDto(user: User): Promise<ClientDto> {
+    toDto(user: User): ClientDto {
         return {
-            id: user.getId(),
             name: user.getName(),
-            accessToken: (await user.getAuthentication()).getAccessToken(),
+            accessToken: user.getAuthentication().getAccessToken(),
+            refreshKey: user.getAuthentication().getRefreshKey()
         };
     }
 }

--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -1,6 +1,7 @@
 import { Time } from "src/common/shared/type/time.type";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { UUIDTransformer } from "./transformer";
 
 @Entity('auth_token')
 export class Token {
@@ -11,7 +12,7 @@ export class Token {
     @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
     readonly userId: number;
 
-    @Column({ type: 'binary', length: 16, name: 'refresh_key' })
+    @Column({ type: 'binary', length: 16, name: 'refresh_key', transformer: new UUIDTransformer() })
     private refreshKey: string;
 
     @Column({ type: 'varchar', name: 'refresh_token' })

--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -31,4 +31,5 @@ export class Token {
     getAccessToken(): string { return this.accessToken; };
     getRefreshKey(): string { return this.refreshKey; };
     getRefreshToken(): string { return this.refreshToken; };
+    changeAccessToken(newAccessToken: string): void { this.accessToken = newAccessToken; };
 }

--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -11,6 +11,9 @@ export class Token {
     @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
     readonly userId: number;
 
+    @Column({ type: 'binary', length: 16, name: 'refresh_key' })
+    private refreshKey: string;
+
     @Column({ type: 'varchar', name: 'refresh_token' })
     private refreshToken: string;
 
@@ -19,10 +22,13 @@ export class Token {
 
     private accessToken: string;
 
-    constructor(accessToken: string, refreshToken: string) {
+    constructor(accessToken: string, refreshKey: string, refreshToken: string) {
         this.accessToken = accessToken;
+        this.refreshKey = refreshKey;
         this.refreshToken = refreshToken;
     };
 
     getAccessToken(): string { return this.accessToken; };
+    getRefreshKey(): string { return this.refreshKey; };
+    getRefreshToken(): string { return this.refreshToken; };
 }

--- a/backend/src/user-auth-common/domain/entity/transformer.ts
+++ b/backend/src/user-auth-common/domain/entity/transformer.ts
@@ -1,0 +1,12 @@
+import { UUIDUtil } from "src/util/uuid.util";
+import { ValueTransformer } from "typeorm";
+
+export class UUIDTransformer implements ValueTransformer {
+    to(entityValue: string): Buffer {
+        return UUIDUtil.toBinaray(entityValue);
+    };
+
+    from(databaseValue: Buffer): string {
+        return UUIDUtil.toString(databaseValue);
+    }
+};

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -24,7 +24,7 @@ export class User {
     @CreateDateColumn({ name: 'registered_at', type: 'timestamp' })
     private registeredAt: Time;
 
-    @OneToOne(() => Email, (email) => email.userId, { cascade: ['insert', 'update']})
+    @OneToOne(() => Email, (email) => email.userId, { cascade: ['insert', 'update'] })
     private email: Promise<Email>;
 
     @OneToOne(() => Phone, (phone) => phone.userId, { cascade: ['insert', 'update'] })
@@ -34,30 +34,36 @@ export class User {
     private profile: Promise<UserProfile>;
 
     @OneToOne(() => Token, (token) => token.userId, { cascade: ['insert', 'update'] })
-    private authentication: Promise<Token>;
+    private authentication: Token;
 
-    constructor( name: string, role: ROLE, loginType: LOGIN_TYPE, email: Email, phone: Phone, profile: UserProfile, authentication: Token ) {
+    constructor(name: string, role: ROLE, loginType: LOGIN_TYPE, email: Email, phone: Phone, profile: UserProfile, authentication: Token) {
         this.name = name;
         this.role = role;
         this.loginType = loginType;
+        this.authentication = authentication;
         this.email = Promise.resolve(email);
         this.phone = Promise.resolve(phone);
         this.profile = Promise.resolve(profile);
-        this.authentication = Promise.resolve(authentication);
     };
 
     getId(): number { return this.id; };
     getName(): string { return this.name; };
     getRole(): ROLE { return this.role; };
+    getAuthentication(): Token { return this.authentication; };
 
     async getPhone(): Promise<Phone> { return await this.phone; };
-    async getAuthentication(): Promise<Token> { return await this.authentication; };
-    
+
     /* 회원가입시 새로 발급된 인증 */
-    setAuthentication(newUserAuthentication: NewUserAuthentication) { 
-        this.authentication = Promise.resolve(new Token(
+    setAuthentication(newUserAuthentication: NewUserAuthentication) {
+        this.authentication = new Token(
             newUserAuthentication.accessToken,
-            newUserAuthentication.refreshToken
-        ));
+            newUserAuthentication.refreshToken.getKey(),
+            newUserAuthentication.refreshToken.getToken()
+        );
     };
+
+    /* 로그인에만 성공시 사용할 AccessToken만 변경 */
+    changeAuthentication(newAccessToken: string): void {
+        this.authentication.changeAccessToken(newAccessToken);
+    }
 }

--- a/backend/src/user-auth-common/domain/interface/new-user-authentication.interface.ts
+++ b/backend/src/user-auth-common/domain/interface/new-user-authentication.interface.ts
@@ -1,4 +1,11 @@
-export interface NewUserAuthentication {
-    accessToken: string;
-    refreshToken: string;
+import { RefreshToken } from "../refresh-token";
+
+export class NewUserAuthentication {
+    readonly accessToken: string;
+    readonly refreshToken: RefreshToken
+
+    constructor(accessToken: string, refreshToken: RefreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    };
 }

--- a/backend/src/user-auth-common/domain/refresh-token.ts
+++ b/backend/src/user-auth-common/domain/refresh-token.ts
@@ -1,0 +1,12 @@
+export class RefreshToken {
+    private key: string;
+    private token: string;
+
+    getKey(): string { return this.key; };
+    getToken(): string { return this.token; };
+
+    constructor(key: string, token: string) {
+        this.key = key;
+        this.token = token;
+    };
+}

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -3,13 +3,22 @@ import { User } from "../entity/user.entity";
 import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
 
 export interface UserRepository extends Repository<User> {
+    findByRefreshKey(refreshKey: string): Promise<User>;
     findByPhoneNumber(phoneNumber: string): Promise<User>;
 };
 
 export const customPhoneRepositoryMethods: Pick<
-    UserRepository, 
+    UserRepository,
+    'findByRefreshKey' | 
     'findByPhoneNumber'
     > = {
+        async findByRefreshKey(this: Repository<User>, refreshKey: string)
+        :Promise<User> {
+            return await this.createQueryBuilder('user')
+                .innerJoin('user.auth_token', 'auth')
+                .where('auth.refresh_key = :refreshKey', { refreshKey })
+                .getOne();
+        },
         async findByPhoneNumber(this: Repository<User>, phoneNumber: string)
         : Promise<User> {
             return await this.createQueryBuilder('user')

--- a/backend/src/user-auth-common/interface/client.dto.ts
+++ b/backend/src/user-auth-common/interface/client.dto.ts
@@ -1,5 +1,5 @@
 export interface ClientDto { 
-    readonly id: number;
+    readonly refreshKey: string;
     readonly name: string;
     readonly accessToken: string; 
 };

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -36,7 +36,7 @@ export class UserService {
             this.addProfile(savedUser.getId(), registerDto) // 가입목적별 프로필 추가
         ]); 
 
-        return await this.userMapper.toDto(savedUser)
+        return this.userMapper.toDto(savedUser)
     }
 
     /* 가입 목적별 프로필 추가 */

--- a/backend/src/util/uuid.util.ts
+++ b/backend/src/util/uuid.util.ts
@@ -2,7 +2,17 @@ import * as uuid from 'uuid';
 
 /* UUID관련 Util 모음 */
 export class UUIDUtil {
-    static generatedUuidV1(): string {
-        return uuid.v1();
+    static generateOrderedUuid(): string {
+        const v1 = uuid.v1();
+        const [timeStampHigh, timeStampMiddle, timeStampLow, fourth, fifth] = v1.split('-');
+        return timeStampLow + timeStampMiddle + timeStampHigh + fourth + fifth;
+    }
+
+    static toBinaray(inputString: string): Buffer {
+        return Buffer.from(inputString, 'hex');
+    }
+
+    static toString(inputBuffer: Buffer): string {
+        return inputBuffer.toString('hex')
     }
 }

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -1,3 +1,4 @@
+import { JwtService } from "@nestjs/jwt";
 import { AuthService } from "src/auth/application/service/auth.service";
 import { AuthenticationCodeService } from "src/auth/application/service/authentication-code.service";
 import { SessionService } from "src/auth/application/service/session.service";
@@ -52,5 +53,13 @@ export const MockVerificationUsageService = {
         addPhoneCodeAttemp: jest.fn()
     }
 };
+
+export const MockJwtService = {
+    provide: JwtService,
+    useValue: {
+        signAsync: jest.fn(),
+        verify: jest.fn()
+    }
+}
 
 

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -58,7 +58,7 @@ export const MockJwtService = {
     provide: JwtService,
     useValue: {
         signAsync: jest.fn(),
-        verify: jest.fn()
+        verifyAsync: jest.fn()
     }
 }
 

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -29,7 +29,7 @@ export const MockAuthService = {
 export const MockTokenService = {
     provide: TokenService,
     useValue: {
-        generateNewUserToken: jest.fn(),
+        generateNewUsersToken: jest.fn(),
         generateAccessToken: jest.fn(),
         generateRefreshToken: jest.fn()
     }

--- a/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
@@ -7,6 +7,7 @@ export const MockUserRepository = {
     provide: getRepositoryToken(User),
     useValue: {
         save: jest.fn(),
+        findByRefreshKey: jest.fn(),
         findByPhoneNumber: jest.fn()
     }
 };

--- a/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
@@ -6,6 +6,7 @@ import { User } from "src/user-auth-common/domain/entity/user.entity";
 export const MockUserRepository = {
     provide: getRepositoryToken(User),
     useValue: {
+        save: jest.fn(),
         findByPhoneNumber: jest.fn()
     }
 };

--- a/backend/test/unit/auth/application/guard/refresh-authentication-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/refresh-authentication-guard.spec.ts
@@ -1,0 +1,103 @@
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common"
+import { ConfigService } from "@nestjs/config"
+import { JwtService } from "@nestjs/jwt"
+import { Test } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { RefreshAuthenticationGuard } from "src/auth/application/guard/refresh-authentication.guard"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
+import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { LOGIN_TYPE, ROLE } from "src/user-auth-common/domain/enum/user.enum"
+import { UserRepository } from "src/user-auth-common/domain/repository/user.repository"
+import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
+import { MockUserRepository } from "test/unit/__mock__/user-auth-common/repository.mock"
+
+describe('인증 갱신 가드(RefreshAuthenticationGuard) Test', () => {
+    let userRepository: UserRepository,
+            jwtService: JwtService,
+            refreshAuthenticationGuard: RefreshAuthenticationGuard;
+    
+    beforeAll( async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                MockUserRepository,
+                MockJwtService,
+                RefreshAuthenticationGuard,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string) => {
+                            switch(key) {
+                                case 'jwt.accessToken.secret':
+                                    return 'test_access';
+                                case 'jwt.accessToken.expiresIn':
+                                    return '10s';
+                                case 'jwt.refreshToken.secret':
+                                    return 'test_refresh';
+                                case 'jwt.refreshToken.expiresIn':
+                                    return '1d'
+                            };
+                        })
+                    }
+                },
+            ]
+        }).compile();
+        
+        userRepository = module.get(getRepositoryToken(User));
+        jwtService = module.get(JwtService);
+        refreshAuthenticationGuard = module.get(RefreshAuthenticationGuard);
+    })
+
+    describe('canActivate()', () => {
+        it('요청에 RefreshKey가 없으면 401 에러', async() => {
+            const mockContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        body: {}
+                    })
+                })
+            } as ExecutionContext;
+            
+            const result = async () => await refreshAuthenticationGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.NotExistRefreshKeyInRequest));
+        });
+
+        it('해당 RefreshKey를 가진 사용자가 없으면 401에러', async() => {
+            const mockContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        body: {
+                            refreshKey: 'refreshKey'
+                        }
+                    })
+                })
+            } as ExecutionContext;
+
+            jest.spyOn(userRepository, 'findByRefreshKey').mockResolvedValueOnce(null);
+
+            const result = async () => await refreshAuthenticationGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.InvalidRefreshKey));
+        });
+
+        it('조회된 RefreshToken의 유효성검사를 통과하지 못하면 401 에러', async() => {
+            const mockContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        body: {
+                            refreshKey: 'refreshKey'
+                        }
+                    })
+                })
+            } as ExecutionContext;
+            const userStub = new User('test', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, new Token('access', 'key', 'refresh'));
+
+            jest.spyOn(userRepository, 'findByRefreshKey').mockResolvedValueOnce(userStub);
+            jest.spyOn(jwtService, 'verifyAsync').mockRejectedValueOnce(new UnauthorizedException('검증실패'));
+
+            const result = async () => await refreshAuthenticationGuard.canActivate(mockContext);
+            await expect(result).rejects.toThrowError(new UnauthorizedException('검증실패'))
+        });
+
+
+    })
+})

--- a/backend/test/unit/auth/application/service/token-service.spec.ts
+++ b/backend/test/unit/auth/application/service/token-service.spec.ts
@@ -1,0 +1,99 @@
+import { ConfigService } from "@nestjs/config"
+import { JwtService } from "@nestjs/jwt"
+import { Test } from "@nestjs/testing"
+import { TokenService } from "src/auth/application/service/token.service"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { LOGIN_TYPE, ROLE } from "src/user-auth-common/domain/enum/user.enum"
+import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
+import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
+import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
+
+describe('토큰 서비스(TokenService) Test', () => {
+    let tokenService: TokenService; 
+    let jwtService: JwtService;
+    let userStub: User;
+
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string) => {
+                            switch(key) {
+                                case 'jwt.accessToken.secret':
+                                    return 'test_access';
+                                case 'jwt.accessToken.expiresIn':
+                                    return '10s';
+                                case 'jwt.refreshToken.secret':
+                                    return 'test_refresh';
+                                case 'jwt.refreshToken.expiresIn':
+                                    return '1d'
+                            };
+                        })
+                    }
+                },
+                MockJwtService,
+                TokenService
+            ]
+        }).compile()
+        jwtService = module.get(JwtService);
+        tokenService = module.get(TokenService);
+    });
+
+    beforeEach(() => userStub = new User('test', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, null))
+
+    describe('generateNewUsersToken()', () => {
+        it('반환된 객체는 NewUserAuthentication의 인스턴스여야한다', async() => {
+            jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce('testAccess');
+            jest.spyOn(tokenService, 'generateRefreshToken').mockResolvedValueOnce(null);
+            const result = await tokenService.generateNewUsersToken(userStub);
+
+            expect(result).toBeInstanceOf(NewUserAuthentication);
+        }); 
+
+        it('생성된 토큰들에는 값들이 비어있으면 안된다', async() => {
+            const testAccessToken = 'testAccess';
+            jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce(testAccessToken);
+            
+            const [testKey, testRefreshToken] = ['uuid', 'testRefresh'];
+            const refreshToken = new RefreshToken('uuid', 'testRefresh');
+            jest.spyOn(tokenService, 'generateRefreshToken').mockResolvedValueOnce(refreshToken);
+
+            const result = await tokenService.generateNewUsersToken(userStub);
+            expect(result.accessToken).toBe(testAccessToken);
+            expect(result.refreshToken.getKey()).toBe(testKey);
+            expect(result.refreshToken.getToken()).toBe(testRefreshToken);
+        })
+    })
+
+    describe('generateRefreshToken()',() => {
+        it('반환된 객체는 RefreshToken의 인스턴스여야한다', async() => {
+            jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce('testRefresh');
+            const result = await tokenService.generateRefreshToken(userStub);
+
+            expect(result).toBeInstanceOf(RefreshToken);
+        });
+
+        it('생성된 refreshToken의 토큰은 get으로 조회해보면 같아야 한다.', async() => {
+            const refreshToken = 'testRefreshToken';
+            jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce(refreshToken);
+            const result = await tokenService.generateRefreshToken(userStub);
+
+            expect(result.getToken()).toBe(refreshToken);
+        });
+
+        it('RefreshToken이 생성될때마다 Key값과 토큰값은 달라야한다.', async() => {
+            const beforeRefreshToken = 'beforeToken';
+            const afterRefreshToken = 'afterToken';
+            jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce(beforeRefreshToken)
+                                                .mockResolvedValueOnce(afterRefreshToken);
+
+            const beforeResult = await tokenService.generateRefreshToken(userStub);
+            const afterResult = await tokenService.generateRefreshToken(userStub);
+
+            expect(beforeResult.getKey()).not.toBe(afterResult.getKey());
+            expect(beforeResult.getToken()).not.toBe(afterResult.getToken());
+        });
+    })
+})

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -39,12 +39,12 @@ describe('UserMapper Component Test', () => {
                 null,
                 null,
                 null,
-                new Token(null, null)
+                new Token(null, null, null)
             );
 
-            const mapResult = await userMapper.toDto(testUser);
+            const mapResult = userMapper.toDto(testUser);
 
-            expect(mapResult).toHaveProperty('id');
+            expect(mapResult).toHaveProperty('refreshKey');
             expect(mapResult).toHaveProperty('name');
             expect(mapResult).toHaveProperty('accessToken')
         })

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -7,6 +7,7 @@ import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.ent
 import { User } from "src/user-auth-common/domain/entity/user.entity"
 import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
+import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
 import { UserMapper } from "src/user/application/mapper/user.mapper"
 import { CaregiverProfileService } from "src/user/application/service/caregiver-profile.service"
 import { PatientProfileService } from "src/user/application/service/patient-profile.service"
@@ -81,10 +82,9 @@ describe('UserService Test', () => {
             const authentication = await tokenService.generateNewUsersToken(user);
             user.setAuthentication(authentication);
 
-            expect(await user.getAuthentication()).toHaveProperty('accessToken');
-            expect((await user.getAuthentication()).getAccessToken()).toBe('testAccessToken');
-            
-            expect(await user.getAuthentication()).toHaveProperty('refreshToken');
+            expect(user.getAuthentication().getAccessToken()).toBe('testAccessToken');
+            expect(user.getAuthentication().getRefreshKey()).toBe('uuid');
+            expect(user.getAuthentication().getRefreshToken()).toBe('testRefreshToken');
         });
 
         it('회원가입을 진행했을 때 DB저장, 세션추가 함수 호출', async () => {
@@ -134,7 +134,7 @@ function createTestUser(): User {
 function createTestAuthentication(): NewUserAuthentication {
     return {
         accessToken: 'testAccessToken',
-        refreshToken: 'testRefreshToken'
+        refreshToken: new RefreshToken('uuid', 'testRefreshToken')
     }
 };
 

--- a/backend/test/unit/util/uuid.util.spec.ts
+++ b/backend/test/unit/util/uuid.util.spec.ts
@@ -1,3 +1,4 @@
+import { UUIDUtil } from 'src/util/uuid.util';
 import * as uuid from 'uuid';
 
 describe('UUID Util 클래스 Test', () => {
@@ -6,6 +7,33 @@ describe('UUID Util 클래스 Test', () => {
             const uuidV1Reg = /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
             const uuidV1 = uuid.v1();
             expect(uuidV1).toMatch(uuidV1Reg);
+        })
+    });
+
+    describe('generateOrederedUuid()', () => {
+        it('중간 하이픈이 없는채로 반환되어야 한다.', () => {
+            const uuidV1 = UUIDUtil.generateOrderedUuid();
+            expect(uuidV1.includes('-')).toBe(false);
+        });
+    });
+
+    describe('toBinary()', () => {
+        it('String 문자열을 Buffer객체로 변환하는지 확인', () => {
+            const inputString = '48656c6c6f20576f726c64';
+            const buffer = Buffer.from(inputString, 'hex');
+            const result = UUIDUtil.toBinaray(inputString);
+
+            expect(result).toEqual(buffer);
+        })
+    });
+
+    describe('toString()', () => {
+        it('Buffer객체가 String 문자열로 변환되는지 확인', () => {
+            const inputString = '48656c6c6f20576f726c64';
+            const buffer = UUIDUtil.toBinaray(inputString);
+            const result = UUIDUtil.toString(buffer);
+
+            expect(result).toEqual(inputString);
         })
     })
 })


### PR DESCRIPTION
- **RefreshAuthenticationGuard**를 통해 요청 중간 검사
    - **RefreshKey**가 요청에 없을 때
    - 해당 **RefreshKey**를 가진 사용자가 없을 때
    - 해당 RefreshKey에 해당하는 RefreshToken의 **유효성검사를** 실패했을 때
- User Entity <-> Token 관계 **Lazy Loading -> default**
- RefreshToken 객체를 만들고 key, token값 저장
- Token Entity에 **refreshKey** 컬럼 추가
- RefreshToken을 통해 새로운 토큰 발급할 때마다 **RefreshKey, RefreshToken**도 새로 발급해서 Db에 저장
- uuid를 binary, string으로 변환해주는 메소드 **UUIDUtil** 클래스에 추가
- 디비에 저장할 때 조회할 때 실제로 변환해주는 **UUIDTransformer**추가