### PR TITLE
[프론트엔드] RefreshToken을 위한 RefreshKey 저장

### DIFF
--- a/frontendv2/components/Login/AuthId.jsx
+++ b/frontendv2/components/Login/AuthId.jsx
@@ -80,9 +80,9 @@ export default function AuthId({ navigation }) {
                     reset();
                 }, 200);
             } else {
-                const { accessToken, ...user } = res.data;  
-                dispatch(saveUser(user));
-                await AsyncStorage.setItem('accessToken', accessToken);
+                const { accessToken, refreshKey, name } = res.data;  
+                dispatch(saveUser(name));
+                await AsyncStorage.multiSet([['accessToken', accessToken], ['refreshToken', refreshKey]]);
                 navigation.dispatch(
                     StackActions.pop()
                 )

--- a/frontendv2/functions/Register/requestCreateUser.jsx
+++ b/frontendv2/functions/Register/requestCreateUser.jsx
@@ -18,9 +18,9 @@ export default async function requestCreateUser(RegisterData, navigation) {
             thirdRegister: purpose === 'protector' ? undefined : convertCaregiverThirdRegister(RegisterData.thirdRegister),
             lastRegister: purpose === 'protector' ? RegisterData.patientHelpList : RegisterData.lastRegister,
         });
-        const { accessToken, ...user } = res.data;
-        store.dispatch(saveUser(user));
-        await AsyncStorage.setItem('accessToken', accessToken)
+        const { accessToken, refreshKey, name } = res.data;
+        store.dispatch(saveUser(name));
+        await AsyncStorage.setItem([['accessToken', accessToken], ['refreshToken', refreshKey]]);
         navigation.dispatch(
             StackActions.push('registerCompletePage')
         );

--- a/frontendv2/redux/reducer/user/userReducer.js
+++ b/frontendv2/redux/reducer/user/userReducer.js
@@ -2,7 +2,6 @@ import { createReducer } from "@reduxjs/toolkit";
 import { saveUser, logout } from "../../action/user/userAction";
 
 const initialState = {
-    id: '',
     name: ''
 };
 
@@ -12,7 +11,6 @@ const userReducer = createReducer(initialState, (builder) => {
             Object.assign(state, action.payload)
         })
         .addCase(logout, (state) => {
-            state.id = '';
             state.name = '';
         })
 });

--- a/frontendv2/screens/FindHelper.jsx
+++ b/frontendv2/screens/FindHelper.jsx
@@ -1,72 +1,14 @@
 /* 가게 홍보 리스트가 있는 페이지 */
 
-import React, { useEffect } from 'react';
-import { useState } from 'react';
-import { useRef } from 'react';
-import { AppState } from 'react-native';
+import React from 'react';
 import {
   StyleSheet,
   SafeAreaView,
 } from 'react-native';
 import HelperList from '../components/FindHelper/HelperList';
 import StatusBarComponent from '../components/StatusBarComponent';
-import { getLoginState, validateToken } from '../functions/Token';
-import { socket, socketEvent } from '../module/socket';
 
 export default function FindHelper({ navigation }) {
-
-  const appState = useRef(AppState.currentState);
-  const [appStateVisible, setAppStateVisible] = useState(appState.current);
-
-  //앱 초기화면이 현재 페이지이므로
-  //초기 로딩시에만 로그인 토큰 유효성 검사
-  useEffect(() => {
-
-    const subscription = AppState.addEventListener('change', nextAppState => {
-      //app이 처음 실행 혹은 다시 켰을 때
-      if (nextAppState === 'active') {
-        refreshLoginState();
-      } 
-      else {
-        console.log('disconnect')
-        socketEvent(socket, 'disconnect');
-      }
-      appState.current = nextAppState;
-      setAppStateVisible(appState.current);
-    })
-
-    async function refreshLoginState() {
-      //로그인이 성공적으로 이루어졌으면
-      if( 
-        await getLoginState() &&  
-        await validateToken(navigation)
-      ) {
-          //socket 등록
-          socketEvent(socket, 'reconnect');
-          socketEvent(socket, 'off_new_message');
-          socketEvent(socket, 'new_message');
-          socketEvent(socket, 'check_application');
-          socketEvent(socket, 'response_application');
-          socketEvent(socket, 'newroom')
-          socketEvent(socket, 'opponentJoin')
-      }
-    }
-
-    return () => { subscription.remove() }
-
-  }, []);
-  /* useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', async () => {
-      const history = useNavigationState(state => state.history)  
-      const isLogin = await getLoginState();
-        
-        if (isLogin) {
-            await validateToken(navigation);
-        }
-    })
-    return unsubscribe
-  }, [navigation]) */
-
   return (
     <SafeAreaView style={styles.container}>
       <StatusBarComponent />


### PR DESCRIPTION
- 백엔드로부터 받은 refreshKey를 통해 async storage에 저장했다가 요청
- 메인페이지 로딩시 토큰 검사 로직 삭제
- UserReducer에 id필드 삭제