### PR TITLE
[백엔드] 로그아웃 Api 완료

### DIFF
--- a/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
+++ b/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
@@ -21,11 +21,11 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
         if( this.isPublicApi(context) ) return true;
 
         /* 먼저 request.user의 상태를 확인해서 토큰 검사 통과했는지 확인 */
-        await super.canActivate(context)
+        await super.canActivate(context) 
         
-        const { userId } = context.switchToHttp().getRequest().body;
+        const user = context.switchToHttp().getRequest().user;
 
-        return await this.isExistUserInSessionList(userId);
+        return await this.isExistUserInSessionList(user.getId())
     };
 
     private isPublicApi(context: ExecutionContext) {

--- a/backend/src/auth/application/guard/jwt/jwt.strategy.ts
+++ b/backend/src/auth/application/guard/jwt/jwt.strategy.ts
@@ -1,12 +1,16 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { JwtPayload } from "../../type/jwt-payload.type";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-    constructor( 
+    constructor(
+        private readonly userAuthCommonService: UserAuthCommonService,
         private readonly configService: ConfigService
         ) {
         super({
@@ -16,5 +20,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         });
     }
 
-    async validate(payload: JwtPayload | null) { return payload; };
+    async validate(payload: JwtPayload): Promise<User | never> { 
+        const user = await this.userAuthCommonService.findUserByUserId(payload.userId);
+        if( !user )
+            throw new UnauthorizedException(ErrorMessage.NotExistUser);
+        return user;
+    };
 }

--- a/backend/src/auth/application/guard/jwt/jwt.strategy.ts
+++ b/backend/src/auth/application/guard/jwt/jwt.strategy.ts
@@ -21,7 +21,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     async validate(payload: JwtPayload): Promise<User | never> { 
-        const user = await this.userAuthCommonService.findUserByUserId(payload.userId);
+        const user = await this.userAuthCommonService.findUserById(payload.userId);
         if( !user )
             throw new UnauthorizedException(ErrorMessage.NotExistUser);
         return user;

--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -10,10 +10,8 @@ import { AuthMapper } from "../mapper/auth.mapper";
 import { SessionService } from "./session.service";
 import { AuthenticationCodeService } from "./authentication-code.service";
 import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service";
-import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface";
 import { InjectRepository } from "@nestjs/typeorm";
 import { UserRepository } from "src/user-auth-common/domain/repository/user.repository";
-import { RefreshToken } from "src/user-auth-common/domain/refresh-token";
 
 @Injectable()
 export class AuthService {
@@ -41,6 +39,11 @@ export class AuthService {
         await this.sendPhoneAuthCode(phoneNumber); // 발송 이후 코드 저장
         if (await this.userAuthCommonService.checkExistingUserByPhone(phoneNumber)) return 'exist'; // 가입 사용자인지 체크
         return 'newuser';
+    }
+
+    /* 로그아웃 -> 세션 리스트에서 사용자의 토큰 삭제 */
+    async logout(user: User): Promise<void> {
+        await this.sessionService.deleteUserFromList(user.getId());
     }
 
     /* 새로운 인증 갱신 */

--- a/backend/src/auth/application/service/session.service.ts
+++ b/backend/src/auth/application/service/session.service.ts
@@ -12,11 +12,18 @@ export class SessionService {
         private readonly configService: ConfigService
     ) { this.key = configService.get('db.redis.key.session_list')};
 
+    /* 세션리스트에 사용자 추가 */
     async addUserToList(userId: number, authentication: string) {
         await this.redis.HSET(this.key, userId, authentication);
     };
 
+    /* 현재 세션리스트로부터 사용자 조회 */
     async getUserFromList(userId: number) {
         return await this.redis.HGET(this.key, userId.toString());
+    }
+
+    /* 세션리스트로부터 사용자 삭제 */
+    async deleteUserFromList(userId: number) {
+        await this.redis.HDEL(this.key, userId.toString());
     }
 }

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -44,4 +44,10 @@ export class AuthController {
     async login(@Body('phoneNumber') phoneNumber: string): Promise<'newuser' | 'exist'> {
         return await this.authService.login(phoneNumber);
     }
+
+    @Post('logout')
+    /* 로그아웃 */
+    async logout(@AuthenticatedUser() user: User): Promise<void> {
+        return await this.authService.logout(user)
+    }
 } 

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -5,6 +5,7 @@ export const enum ErrorMessage {
     NotMatchedAuthenticationCode = '인증번호가 일치하지 않습니다.',
     ExceededPhoneDailyLimit = '일일 가능한 인증횟수를 초과하였습니다.',
     ExceededCodeAttempLimit = '인증번호를 연속으로 틀렸습니다.',
+    NotExistUser = '일치하는 사용자 정보를 찾을 수 없습니다.',
     NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
     InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
     NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.'

--- a/backend/src/user-auth-common/application/user-auth-common.service.ts
+++ b/backend/src/user-auth-common/application/user-auth-common.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Phone } from "../domain/entity/user-phone.entity";
 import { PhoneRepository } from "../domain/repository/user-phone.repository";
+import { User } from "../domain/entity/user.entity";
+import { UserRepository } from "../domain/repository/user.repository";
 
 @Injectable()
 export class UserAuthCommonService {
     constructor(
         @InjectRepository(Phone)
-        private readonly phoneRepository: PhoneRepository
+        private readonly phoneRepository: PhoneRepository,
+        @InjectRepository(User)
+        private readonly userRepository: UserRepository
     ) { };
 
     /* 이미 가입되어있는 사용자인지 확인 */
@@ -15,5 +19,9 @@ export class UserAuthCommonService {
         if (await this.phoneRepository.findByPhoneNumber(phoneNumber)) 
             return true;
         return false;
+    }
+
+    async findUserById(userId: number): Promise<User | null> {
+        return await this.userRepository.findById(userId);
     }
 }

--- a/backend/test/unit/__mock__/user-auth-common/service.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/service.mock.ts
@@ -3,6 +3,7 @@ import { UserAuthCommonService } from "src/user-auth-common/application/user-aut
 export const MockUserAuthCommonService = {
     provide: UserAuthCommonService,
     useValue: {
-        checkExistingUserByPhone: jest.fn()
+        checkExistingUserByPhone: jest.fn(),
+        findUserByUserId: jest.fn()
     }
 }

--- a/backend/test/unit/__mock__/user-auth-common/service.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/service.mock.ts
@@ -4,6 +4,6 @@ export const MockUserAuthCommonService = {
     provide: UserAuthCommonService,
     useValue: {
         checkExistingUserByPhone: jest.fn(),
-        findUserByUserId: jest.fn()
+        findUserById: jest.fn()
     }
 }

--- a/backend/test/unit/auth/application/guard/jwt-strategy.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-strategy.spec.ts
@@ -1,0 +1,44 @@
+import { ConfigService } from "@nestjs/config"
+import { Test } from "@nestjs/testing"
+import { JwtStrategy } from "src/auth/application/guard/jwt/jwt.strategy"
+import { JwtPayload } from "src/auth/application/type/jwt-payload.type"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
+import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock"
+
+describe('Jwt 전략(JwtStrategy) Test', () => {
+    let jwtStrategy: JwtStrategy;
+    let userAuthCommonService: UserAuthCommonService;
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                JwtStrategy,
+                MockUserAuthCommonService,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn().mockReturnValue('test')
+                    }
+                }
+            ]
+        }).compile();
+        jwtStrategy = module.get(JwtStrategy);
+        userAuthCommonService = module.get(UserAuthCommonService);
+    })
+
+    it('토큰에 들어있는 사용자 정보를 찾을 수 없는경우 에러', async() => {
+        jest.spyOn(userAuthCommonService, 'findUserByUserId').mockResolvedValueOnce(null);
+
+        const result = async () => await jwtStrategy.validate({ userId: 1 } as JwtPayload);
+        await expect(result).rejects.toThrowError(ErrorMessage.NotExistUser);
+    })
+
+    it('토큰에 들어있는 사용자 정보를 찾을 수 있는 경우 확인', async() => {
+        jest.spyOn(userAuthCommonService, 'findUserByUserId').mockResolvedValueOnce({ id: 1 } as User);
+        
+        const result = await jwtStrategy.validate({ userId: 1 } as JwtPayload);
+        expect(result).toEqual({id: 1})
+    })
+
+})

--- a/backend/test/unit/auth/application/guard/jwt-strategy.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-strategy.spec.ts
@@ -28,14 +28,14 @@ describe('Jwt 전략(JwtStrategy) Test', () => {
     })
 
     it('토큰에 들어있는 사용자 정보를 찾을 수 없는경우 에러', async() => {
-        jest.spyOn(userAuthCommonService, 'findUserByUserId').mockResolvedValueOnce(null);
+        jest.spyOn(userAuthCommonService, 'findUserById').mockResolvedValueOnce(null);
 
         const result = async () => await jwtStrategy.validate({ userId: 1 } as JwtPayload);
         await expect(result).rejects.toThrowError(ErrorMessage.NotExistUser);
     })
 
     it('토큰에 들어있는 사용자 정보를 찾을 수 있는 경우 확인', async() => {
-        jest.spyOn(userAuthCommonService, 'findUserByUserId').mockResolvedValueOnce({ id: 1 } as User);
+        jest.spyOn(userAuthCommonService, 'findUserById').mockResolvedValueOnce({ id: 1 } as User);
         
         const result = await jwtStrategy.validate({ userId: 1 } as JwtPayload);
         expect(result).toEqual({id: 1})

--- a/backend/test/unit/auth/application/service/session-service.spec.ts
+++ b/backend/test/unit/auth/application/service/session-service.spec.ts
@@ -36,10 +36,10 @@ describe('토큰 서비스(TokenService) Test', () => {
         it('주어진 아이디와 토큰이 세션리스트에 저장되어야 한다', async () => {
             await sessionService.addUserToList(1, 'testAccessToken');
 
-            const result = await redis.HGET('user:session:list', '1');
+            const result = await sessionService.getUserFromList(1);
             expect(result).toBe('testAccessToken');
             
-            await redis.HDEL('user:session:list', '1');
+            await sessionService.deleteUserFromList(1);
         })
     });
 
@@ -56,7 +56,21 @@ describe('토큰 서비스(TokenService) Test', () => {
             const result = await sessionService.getUserFromList(40);
             expect(result).toBe('testAccessToken');
 
-            await redis.HDEL('user:session:list', '40');
+            await sessionService.deleteUserFromList(40);
         });
+    });
+
+    describe('deleteUserFromList', () => {
+        it('세션리스트에 존재하는 사용자가 삭제되는지 확인', async () => {
+            await sessionService.addUserToList(100, 'test');
+
+            const beforeFindResult = await sessionService.getUserFromList(100);
+            expect(beforeFindResult).not.toBe(null);
+
+            await sessionService.deleteUserFromList(100);
+
+            const afterFindResult = await sessionService.getUserFromList(100);
+            expect(afterFindResult).toBe(null);
+        })
     })
 })

--- a/backend/test/unit/common/database/datebase-setup.fixture.ts
+++ b/backend/test/unit/common/database/datebase-setup.fixture.ts
@@ -1,5 +1,11 @@
+import { TypeOrmModuleOptions } from "@nestjs/typeorm";
 import { Db, MongoClient } from "mongodb";
 import { RedisClientType, createClient } from "redis";
+import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
+import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 let mongodb: Db, mongoClient: MongoClient; // MongoDB
 
@@ -26,3 +32,15 @@ export async function ConnectRedis() {
 export function getRedis() { return redisClient; };
 
 export async function DisconnectRedis() { await redisClient.disconnect(); };
+
+export const TestTypeOrmOptions: TypeOrmModuleOptions = {
+    type: 'mysql',
+    username: 'root',
+    host: '127.0.0.1',
+    port: 3306,
+    password: '1234',
+    database: 'test_caregiver_project',
+    entities: [User, Phone, Email, UserProfile, Token],
+    synchronize: true,
+    logging: true
+}

--- a/backend/test/unit/user/infra/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/user-repository.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm"
+import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity"
+import { User } from "../../../../src/user-auth-common/domain/entity/user.entity"
+import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { UserRepository, customUserRepositoryMethods } from "src/user-auth-common/domain/repository/user.repository"
+import { UUIDUtil } from "src/util/uuid.util"
+import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture"
+import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
+
+describe('사용자 저장소(UserRepository) Test', () => {
+    let userRepository: UserRepository;
+    let module: TestingModule;
+    beforeAll(async() => {
+        module = await Test.createTestingModule({
+            imports: [
+                TypeOrmModule.forRoot(TestTypeOrmOptions),
+                TypeOrmModule.forFeature([User, Phone, Email, UserProfile, Token])
+            ],
+        }).compile();
+        
+        userRepository = module.get(getRepositoryToken(User));
+        userRepository = userRepository.extend(customUserRepositoryMethods);
+    })
+
+    afterAll(async() => module.close() );
+
+
+    describe('findByUserId', () => {
+        it('일치하는 사용자 id로 조회했을 때 반환되는지 확인', async() => {
+            const testUser = new User(
+                '테스트유저', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, 
+                new Phone('01022221111'),new UserProfile(19980101, SEX.MALE), 
+                new Token(null, '123123', 'refresh')
+            );
+            
+            const savedId = (await userRepository.save(testUser)).getId();
+            const result = await userRepository.findById(savedId);
+            
+            expect(result.getId()).toBe(savedId);
+            expect(result.getAuthentication()).not.toBe(null);
+            console.log(result)
+            await userRepository.delete({ id: savedId })
+        })
+    });
+
+    describe('findByRefreshKey()', () => {
+        it('일치하는 RefreshKey가 있을 때 Authentication Entity까지 로드되는지 확인', async() => {
+            const [testUuid, testRefreshToken] = [UUIDUtil.generateOrderedUuid(), 'refreshToken'];
+            const testUser = new User(
+                '테스트유저', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, 
+                new Phone('01022221111'),new UserProfile(19980101, SEX.MALE), 
+                new Token(null, testUuid, testRefreshToken)
+            );
+
+            const id = (await userRepository.save(testUser)).getId();
+            const findResult = await userRepository.findByRefreshKey(testUuid);
+
+            expect(findResult.getAuthentication()).not.toBe(null);
+            expect(findResult.getAuthentication().getRefreshKey()).toBe(testUuid);
+            expect(findResult.getAuthentication().getRefreshToken()).toBe(testRefreshToken);
+            
+            await userRepository.delete({ id })
+        });
+    });
+})


### PR DESCRIPTION
- 로그인되어있는 사용자들 리스트에서 로그아웃한 사용자의 토큰 삭제
- JwtStrategy에서 decode된 JwtPayload가 아닌 사용자를 조회해서 넘기는것으로 변경
- UserRepository에 id로 조회하는 **findById** 추가
- UserAuthCommonService에 UserRepository에 접근하는 **findUserById**추가
- SessionService에 리스트로부터 사용자 삭제하는 **deleteUserFromList** 메소드 추가
- UserRepository findByRefreshKey메소드에서 binary로 조회하기 위해 **toBinary()**로 수정