### PR TITLE
[백엔드] 내 프로필 조회 Api 완료

### DIFF
--- a/backend/src/user-auth-common/domain/entity/user-email.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-email.entity.ts
@@ -16,4 +16,8 @@ export class Email {
 
     @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
     private updatedAt: Time;
+
+    constructor(email: string) { this.email = email; };
+
+    getEmail(): string { return this.email; };
 }

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -52,6 +52,7 @@ export class User {
     getAuthentication(): Token { return this.authentication; };
 
     async getPhone(): Promise<Phone> { return await this.phone; };
+    async getEmail(): Promise<Email> { return await this.email; };
 
     /* 회원가입시 새로 발급된 인증 */
     setAuthentication(newUserAuthentication: NewUserAuthentication) {

--- a/backend/src/user/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/user/application/mapper/caregiver-profile.mapper.ts
@@ -23,11 +23,13 @@ export class CaregiverProfileMapper {
             .tagList(thirdRegister.tagList)
             .notice(lastRegister.notice)
             .additionalChargeCase(lastRegister.additionalChargeCase)
+            .isPrivate(false) // 처음 프로필 생성될 시 자동 공개 프로필
             .warningList()
             .build()
     }
 
     private toLicenseList(licenseList: string[]): License[] {
-        return licenseList.map(license => new License(license))
+        /* 자격증을 증명전까지 false */
+        return licenseList.map(license => new License(license, false))
     };
 }

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -5,6 +5,7 @@ import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE } from "src/user-auth-common/domain/enum/user.enum";
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
 import { CommonRegisterForm } from "src/user/interface/dto/register-page";
 
 @Injectable()
@@ -21,13 +22,29 @@ export class UserMapper extends UserAuthCommonMapper{
         )
     };
 
+    /* 내 정보 -> 내 프로필 조회에 쓰이는 Dto */
+    async toMyProfileDto(user: User, profile?: CaregiverProfile) {
+        return {
+            phoneNumber: (await user.getPhone()).getPhoneNumber(),
+            role: user.getRole(),
+            email: this.checkEmailVerificationStatus(await user.getEmail()),
+            isPrivate: profile ? profile.getIsPrivate() : undefined, // 간병인일 경우에만 프로필 비공개인지
+        }
+    }
+
      /* 이메일로 회원가입(현재는 휴대폰으로만 제공) */
      private createEmailByLoginType(loginType: LOGIN_TYPE): null | Email {
-        return loginType == LOGIN_TYPE.PHONE ? null : new Email();
+        return loginType == LOGIN_TYPE.PHONE ? null : null;
     };
 
     /* 휴대폰으로 회원가입  */
     private createPhoneByLoginType(loginType: LOGIN_TYPE, phoneNumber: string): null | Phone {
         return loginType == LOGIN_TYPE.PHONE ? new Phone(phoneNumber) : null;
+    }
+
+    /* 인증된 이메일이 있는지 */
+    private checkEmailVerificationStatus(email: Email): null | string {
+        if( email ) return email.getEmail();
+        return null;
     }
 }

--- a/backend/src/user/application/service/caregiver-profile.service.ts
+++ b/backend/src/user/application/service/caregiver-profile.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto";
 import { CaregiverProfileMapper } from "../mapper/caregiver-profile.mapper";
 import { CaregiverProfileRepository } from "src/user/infra/repository/caregiver-profile.repository";
+import { CaregiverProfile } from "src/user/domain/entity/caregiver/caregiver-profile.entity";
 
 @Injectable()
 export class CaregiverProfileService {
@@ -13,5 +14,10 @@ export class CaregiverProfileService {
     async addProfile(userId: number, caregiverRegisterDto: CaregiverRegisterDto): Promise<void> {
         const caregiverProfile = this.caregiverProfileMapper.mapFrom(userId, caregiverRegisterDto);
         await this.caregiverProfileRepository.save(caregiverProfile);
-    }  
+    } 
+
+    /* 사용자 아이디로 프로필 조회 */
+    async getProfileByUserId(userId: number): Promise<CaregiverProfile> {
+        return await this.caregiverProfileRepository.findByUserId(userId)
+    }
 }

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -11,6 +11,7 @@ import { CaregiverProfileService } from "./caregiver-profile.service";
 import { ProtectorRegisterDto } from "src/user/interface/dto/protector-register.dto";
 import { PatientProfileService } from "./patient-profile.service";
 import { SessionService } from "src/auth/application/service/session.service";
+import { MyProfileDto } from "src/user/interface/dto/my-profile.dto";
 
 @Injectable()
 export class UserService {
@@ -39,10 +40,20 @@ export class UserService {
         return this.userMapper.toDto(savedUser)
     }
 
+    async getMyProfile(user: User): Promise<MyProfileDto> {
+        /* 간병인이면 프로필 조회해서  */
+        if( user.getRole() === ROLE.CAREGIVER ) {
+            const caregiverProfile = await this.caregiverProfileService.getProfileByUserId(user.getId());
+            return await this.userMapper.toMyProfileDto(user, caregiverProfile);
+        }
+        return await this.userMapper.toMyProfileDto(user);
+    }
+
     /* 가입 목적별 프로필 추가 */
     private async addProfile(userId: number, registerDto: CaregiverRegisterDto | ProtectorRegisterDto) {
         registerDto.firstRegister.purpose == ROLE.CAREGIVER ?
             await this.caregiverProfileService.addProfile(userId, registerDto as CaregiverRegisterDto) : 
                 await this.patientProfileService.addProfile(userId, registerDto as ProtectorRegisterDto);
     };
+
 }

--- a/backend/src/user/domain/builder/profile.builder.ts
+++ b/backend/src/user/domain/builder/profile.builder.ts
@@ -81,6 +81,11 @@ export class CaregiverProfileBuilder {
         return this;
     };
 
+    isPrivate(isPrivate: boolean): this {
+        this.caregiverProfile.setIsPrivate(isPrivate);
+        return this;
+    }
+
     warningList(warningList: Warning [] = []): this {
         this.caregiverProfile.setWarning(warningList);
         return this;

--- a/backend/src/user/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/user/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -19,6 +19,7 @@ export class CaregiverProfile {
     private licenseList: License []; // 자격증
     private strengthList: string []; // 강점
     private tagList: string []; // 키워드
+    private isPrivate: boolean; // 프로필 비공개, 공개
     private warningList: Warning [];
 
     constructor(id: ObjectId) { this._id = id; };
@@ -37,6 +38,7 @@ export class CaregiverProfile {
     setLicenseList(licenseList: License []) { this.licenseList = licenseList; };
     setStrengthList(strengthList: string []) { this.strengthList = strengthList; };
     setTagList(tagList: string []) { this.tagList = tagList; };
+    setIsPrivate(isPrivate: boolean) { this.isPrivate = isPrivate; };
     setWarning(warningList: Warning []) { this.warningList = warningList; };
 
     getId(): string { return this._id.toHexString(); };
@@ -44,5 +46,6 @@ export class CaregiverProfile {
     getHelpExperience(): CaregiverHelpExperience { return this.helpExperience; };
     getLicenseList(): License[] { return this.licenseList; };
     getStrengthList(): string[] { return this.strengthList; };
+    getIsPrivate(): boolean { return this.isPrivate; };
     getWarningList(): Warning[] { return this.warningList; };
 }

--- a/backend/src/user/domain/entity/caregiver/license.entity.ts
+++ b/backend/src/user/domain/entity/caregiver/license.entity.ts
@@ -1,7 +1,12 @@
 export class License {
     private name: string;
+    private isCertified: boolean; // 증명됐는지 여부
 
-    constructor(name: string) {
+    constructor(name: string, isCertified: boolean) {
         this.name = name;
+        this.isCertified = isCertified;
     };
+
+    getName(): string { return this.name; };
+    getIsCertified(): boolean { return this.isCertified; };
 }

--- a/backend/src/user/infra/repository/caregiver-profile.repository.ts
+++ b/backend/src/user/infra/repository/caregiver-profile.repository.ts
@@ -23,12 +23,21 @@ export class CaregiverProfileRepository implements ICaregiverProfileRepository<W
             .insertOne(caregiverProfile);
     };
 
-    async findById(id: string): Promise<WithId<CaregiverProfile>> {
+    async findById(id: string): Promise<CaregiverProfile> {
         const findProfile = await this.mongodb
                                 .collection<CaregiverProfile>(this.collectionName)
                                 .findOne({ _id: new ObjectId(id) });
         
         return plainToInstance(CaregiverProfile, findProfile); 
+    }
+
+    async findByUserId(userId: number): Promise<CaregiverProfile> {
+        const [findProfile] = await this.mongodb
+                                .collection<CaregiverProfile>(this.collectionName)
+                                .aggregate()
+                                .match({ userId })
+                                .toArray();
+        return plainToInstance(CaregiverProfile, findProfile);
     }
 
     async delete(id: string): Promise<void> {

--- a/backend/src/user/interface/controller/user.controller.ts
+++ b/backend/src/user/interface/controller/user.controller.ts
@@ -1,9 +1,12 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post } from "@nestjs/common";
 import { ProtectorRegisterDto } from "../dto/protector-register.dto";
 import { ClientDto } from "src/user-auth-common/interface/client.dto";
 import { CaregiverRegisterDto } from "../dto/caregiver-register.dto";
 import { UserService } from "src/user/application/service/user.service";
 import { Public } from "src/auth/application/decorator/public.decorator";
+import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { MyProfileDto } from "../dto/my-profile.dto";
 
 @Controller('user')
 export class UserController {
@@ -21,5 +24,11 @@ export class UserController {
     @Post('register/caregiver')
     async registerAsCaregiver(@Body() caregiverReigsterDto: CaregiverRegisterDto): Promise<ClientDto> {
         return await this.userService.register(caregiverReigsterDto)
+    }
+
+    /* 나의 프로필 조회 */
+    @Get('profile/my')
+    async getMyProfile(@AuthenticatedUser() user: User): Promise<MyProfileDto> {
+        return await this.userService.getMyProfile(user);
     }
 }

--- a/backend/src/user/interface/dto/my-profile.dto.ts
+++ b/backend/src/user/interface/dto/my-profile.dto.ts
@@ -1,0 +1,8 @@
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
+
+export class MyProfileDto {
+    phoneNumber: string;
+    email: string | null;
+    role: ROLE;
+    isPrivate?: boolean;
+}

--- a/backend/test/unit/user/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/caregiver-profile-mapper.spec.ts
@@ -22,12 +22,17 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getUserId()).toBe(userId);
 
             mappingResult.getLicenseList()
-                .map( license => expect(license).toBeInstanceOf(License));
+                .map( license => {
+                    expect(license).toBeInstanceOf(License);
+                    expect(license.getName()).toBe('자격증');
+                    expect(license.getIsCertified()).toBe(false);
+                });
 
             expect(mappingResult.getStrengthList()).toEqual([]);
             expect(mappingResult.getHelpExperience()).toHaveProperty('suction');
             expect(mappingResult.getHelpExperience()).toHaveProperty('movement');
             expect(mappingResult.getHelpExperience()).not.toHaveProperty('meal');
+            expect(mappingResult.getIsPrivate()).toBe(false);
             expect(mappingResult.getWarningList()).toEqual([]);
         })
     });

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -1,7 +1,11 @@
+import { ObjectId } from "mongodb";
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
+import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { UserMapper } from "src/user/application/mapper/user.mapper"
+import { CaregiverProfileBuilder } from "src/user/domain/builder/profile.builder";
 import { CommonRegisterForm } from "src/user/interface/dto/register-page";
 
 describe('UserMapper Component Test', () => {
@@ -29,6 +33,68 @@ describe('UserMapper Component Test', () => {
             expect(mapResult).toHaveProperty('authentication');
         });
     });
+
+    describe('toMyProfileDto()', () => {
+        describe('내 정보 조회시 간병인 보호자 공통', () => {
+            it('이메일을 등록하지 않은 사용자면 null 설정된다', async() => {
+                const phoneNumber = '01011111111';
+                const testUser = new User(
+                    '테스트',
+                    ROLE.PROTECTOR,
+                    LOGIN_TYPE.PHONE,
+                    null,
+                    new Phone(phoneNumber),
+                    null,
+                    null
+                );
+                const result = await userMapper.toMyProfileDto(testUser);
+
+                expect(result.phoneNumber).toBe(phoneNumber);
+                expect(result.email).toBe(null);
+            });
+
+            it('이메일을 등록한 사용자면 해당 이메일이 설정', async() => {
+                const email = 'test@naver.com';
+                const testUser = new User(
+                    '테스트',
+                    ROLE.PROTECTOR,
+                    LOGIN_TYPE.PHONE,
+                    new Email(email),
+                    new Phone('01011111111'),
+                    null,
+                    null
+                );
+                const result = await userMapper.toMyProfileDto(testUser);
+
+                expect(result.email).toBe(email);
+            })
+        });
+
+        describe('내 정보 조회시 간병인', () => {
+            it('간병인의 결과에는 프로필 비공개여부 필드가 있어야 한다', async() => {
+                const phoneNumber = '01012341234';
+                const testUser = new User(
+                    '간병인',
+                    ROLE.CAREGIVER,
+                    LOGIN_TYPE.PHONE,
+                    null,
+                    new Phone(phoneNumber),
+                    null,
+                    null
+                );
+                const testProfile = new CaregiverProfileBuilder(new ObjectId())
+                                        .isPrivate(false)
+                                        .build();
+
+                const result = await userMapper.toMyProfileDto(testUser, testProfile);
+
+                expect(result.phoneNumber).toBe(phoneNumber);
+                expect(result.email).toBe(null);
+                expect(result.role).toBe(ROLE.CAREGIVER);
+                expect(result.isPrivate).toBe(false);
+            })
+        })
+    })
 
     describe('toDto()', () => {
         it('User 객체에서 사용자에게 넘겨줄 Dto Mapping', async () => {

--- a/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
@@ -73,6 +73,22 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
         await caregiverProfileRepository.delete(testProfile.getId());
     });
 
+    it('findByUserId() => 일치하는 문서 반환 확인', async() => {
+        testProfile = createCommonCaregiverProfile()
+                        .helpExperience({ suction: '석션입니다' })
+                        .licenseList([])
+                        .strengthList([])
+                        .warningList([])
+                        .build();
+
+        await caregiverProfileRepository.save(testProfile);
+        const findResult = await caregiverProfileRepository.findByUserId(1);
+
+        expect(findResult.getUserId()).toBe(1);
+
+        await caregiverProfileRepository.delete(testProfile.getId());
+    })
+
     it('delete() => 삭제이후 해당 문서는 존재하면 안된다.', async () => {
 
         testProfile = createCommonCaregiverProfile()
@@ -103,5 +119,6 @@ function createCommonCaregiverProfile() {
         .nextHosptial('다음 병원 여부')
         .tagList(['태그1', '태그2', '태그3'])
         .notice('공지사항을 알려드립니다')
+        .isPrivate(false)
         .additionalChargeCase('추가요금이 붙는 상황')
 };

--- a/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/caregiver-profile-repository.spec.ts
@@ -60,7 +60,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
     it('save() => 간병 경험이 비어있으면 DB에 {}로 저장', async () => {
         testProfile = createCommonCaregiverProfile()
                         .helpExperience({})
-                        .licenseList([new License('자격증')])
+                        .licenseList([new License('자격증', false)])
                         .strengthList(['강점'])
                         .warningList(null)
                         .build()


### PR DESCRIPTION
- 간병인, 보호자에 따라 화면이 다르므로 UserService에 **getMyProfile()**에서 구분
- 간병인에는 자격증, 프로필 비공개 여부가 필요하므로 **License** 객체와 **CaregiverProfile** Entity에 각각 추가
- 간병인이 조회시 간병인 프로필을 가져와야 하므로 간병인 저장소에 **findByUserId()** 추가
- 클라이언트에서 필요로 하는 데이터로 가공하는 **toMyProfileDto() UserMapper**에 추가