### PR TITLE
Fixed(#33): 내 정보 Api 조회 오류 해결 완료

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -37,8 +37,8 @@ import { RefreshAuthenticationGuard } from './application/guard/refresh-authenti
     RefreshAuthenticationGuard
   ],
   exports: [
-    TokenService,
     SessionService,
+    AuthService,
     PhoneVerificationRepository
   ]
 })

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -25,13 +25,13 @@ export class User {
     private registeredAt: Time;
 
     @OneToOne(() => Email, (email) => email.userId, { cascade: ['insert', 'update'] })
-    private email: Promise<Email>;
+    private email: Email;
 
     @OneToOne(() => Phone, (phone) => phone.userId, { cascade: ['insert', 'update'] })
-    private phone: Promise<Phone>;
+    private phone: Phone;
 
     @OneToOne(() => UserProfile, (profile) => profile.userId, { cascade: ['insert'] })
-    private profile: Promise<UserProfile>;
+    private profile: UserProfile;
 
     @OneToOne(() => Token, (token) => token.userId, { cascade: ['insert', 'update'] })
     private authentication: Token;
@@ -41,9 +41,9 @@ export class User {
         this.role = role;
         this.loginType = loginType;
         this.authentication = authentication;
-        this.email = Promise.resolve(email);
-        this.phone = Promise.resolve(phone);
-        this.profile = Promise.resolve(profile);
+        this.email = email;
+        this.phone = phone;
+        this.profile = profile;
     };
 
     getId(): number { return this.id; };
@@ -51,8 +51,8 @@ export class User {
     getRole(): ROLE { return this.role; };
     getAuthentication(): Token { return this.authentication; };
 
-    async getPhone(): Promise<Phone> { return await this.phone; };
-    async getEmail(): Promise<Email> { return await this.email; };
+    getPhone(): Phone { return this.phone; };
+    getEmail(): Email { return this.email; }
 
     /* 회원가입시 새로 발급된 인증 */
     setAuthentication(newUserAuthentication: NewUserAuthentication) {

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -19,6 +19,8 @@ export const customUserRepositoryMethods: Pick<
         :Promise<User> {
             return await this.createQueryBuilder('user')
                 .innerJoinAndSelect('user.authentication', 'auth')
+                .innerJoinAndSelect('user.phone', 'phone')
+                .leftJoinAndSelect('user.email', 'email')
                 .where('user.id = :userId', { userId })
                 .getOne();
         },

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -25,9 +25,9 @@ export class UserMapper extends UserAuthCommonMapper{
     /* 내 정보 -> 내 프로필 조회에 쓰이는 Dto */
     async toMyProfileDto(user: User, profile?: CaregiverProfile) {
         return {
-            phoneNumber: (await user.getPhone()).getPhoneNumber(),
+            phoneNumber: user.getPhone().getPhoneNumber(),
             role: user.getRole(),
-            email: this.checkEmailVerificationStatus(await user.getEmail()),
+            email: this.checkEmailVerificationStatus(user.getEmail()),
             isPrivate: profile ? profile.getIsPrivate() : undefined, // 간병인일 경우에만 프로필 비공개인지
         }
     }

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -5,20 +5,18 @@ import { UserMapper } from "../mapper/user.mapper";
 import { InjectRepository } from "@nestjs/typeorm";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { Repository } from "typeorm";
-import { TokenService } from "src/auth/application/service/token.service";
 import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
 import { CaregiverProfileService } from "./caregiver-profile.service";
 import { ProtectorRegisterDto } from "src/user/interface/dto/protector-register.dto";
 import { PatientProfileService } from "./patient-profile.service";
-import { SessionService } from "src/auth/application/service/session.service";
 import { MyProfileDto } from "src/user/interface/dto/my-profile.dto";
+import { AuthService } from "src/auth/application/service/auth.service";
 
 @Injectable()
 export class UserService {
     constructor(
         private readonly userMapper: UserMapper,
-        private readonly tokenService: TokenService,
-        private readonly sessionService: SessionService,
+        private readonly authService: AuthService,
         private readonly caregiverProfileService: CaregiverProfileService,
         private readonly patientProfileService: PatientProfileService,
         @InjectRepository(User)
@@ -28,16 +26,11 @@ export class UserService {
     async register(registerDto: CaregiverRegisterDto | ProtectorRegisterDto): Promise<ClientDto> {
         const user = this.userMapper.mapFrom(registerDto.firstRegister); // 공통회원가입 양식으로부터 사용자 생성
 
-        const authentication = await this.tokenService.generateNewUsersToken(user); // 새로운 인증 생성
-        user.setAuthentication(authentication); 
+        const savedUser = await this.userRepository.save(user); // DB에 저장하고 ID를 발급받음
 
-        const savedUser = await this.userRepository.save(user); // DB에 저장된 User
-        await Promise.all([
-            this.sessionService.addUserToList(savedUser.getId(), authentication.accessToken), // 세션리스트에 사용자 토큰 추가
-            this.addProfile(savedUser.getId(), registerDto) // 가입목적별 프로필 추가
-        ]); 
+        await this.addProfile(savedUser.getId(), registerDto); // 각자의 역할 프로필 저장
 
-        return this.userMapper.toDto(savedUser)
+        return await this.authService.refreshAuthentication(savedUser); // 새로운 토큰들을 발급받아 저장
     }
 
     async getMyProfile(user: User): Promise<MyProfileDto> {

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -20,6 +20,7 @@ export const MockAuthService = {
     useValue: {
         register: jest.fn(),
         login: jest.fn(),
+        refreshAuthentication: jest.fn(),
         createAuthenticationToUser: jest.fn(),
         validateSmsCode: jest.fn()
     }

--- a/backend/test/unit/__mock__/user/service.mock.ts
+++ b/backend/test/unit/__mock__/user/service.mock.ts
@@ -1,0 +1,32 @@
+import { UserMapper } from "src/user/application/mapper/user.mapper";
+import { CaregiverProfileService } from "src/user/application/service/caregiver-profile.service";
+import { PatientProfileService } from "src/user/application/service/patient-profile.service";
+
+/* Mocking UserMapper */
+export const MockUserMapper = {
+    provide: UserMapper,
+    useValue: {
+        mapFrom: jest.fn(),
+        toDto: jest.fn(),
+        toMyProfileDto: jest.fn()
+    }
+};
+
+/* Mocking CaregiverProfileService */
+export const MockCaregiverProfileService = {
+    provide: CaregiverProfileService,
+    useValue: {
+        addProfile: jest.fn(),
+        getProfileByUserId: jest.fn()
+    }
+};
+
+/* Mocking PatientProfileService */
+export const MockPatientProfileService = {
+    provide: PatientProfileService,
+    useValue: {
+        addProfile: jest.fn(),
+    }
+};
+
+

--- a/backend/test/unit/auth/application/guard/authentication-code-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/authentication-code-guard.spec.ts
@@ -1,24 +1,18 @@
 import { NotFoundException, UnauthorizedException } from "@nestjs/common"
 import { Test } from "@nestjs/testing"
-import { getRepositoryToken } from "@nestjs/typeorm"
-import { RedisClientType } from "redis"
 import { PhoneAuthenticationCodeGuard } from "src/auth/application/guard/authentication-code.guard"
 import { AuthenticationCodeService } from "src/auth/application/service/authentication-code.service"
 import { VerificationUsageService } from "src/auth/application/service/verification-usage.service"
 import { AuthenticationCode } from "src/auth/domain/authentication-code"
 import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity"
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
-import { User } from "src/user-auth-common/domain/entity/user.entity"
-import { UserRepository } from "src/user-auth-common/domain/repository/user.repository"
 import { MockAuthenticationCodeService, MockVerificationUsageService } from "test/unit/__mock__/auth/service.mock"
 import { MockUserRepository } from "test/unit/__mock__/user-auth-common/repository.mock"
 
 describe('인증코드 관련 가드(AuthenticationCodeGuard) Test', () => {
-    let userRepository: UserRepository;
     let verificationUsgaeService: VerificationUsageService;
     let authenticationCodeService: AuthenticationCodeService;
     let guard: PhoneAuthenticationCodeGuard;
-    let redis: RedisClientType;
 
     beforeAll(async () => {
         const module = await Test.createTestingModule({
@@ -36,11 +30,9 @@ describe('인증코드 관련 가드(AuthenticationCodeGuard) Test', () => {
             ]
         }).compile();
 
-        userRepository = module.get(getRepositoryToken(User));
         verificationUsgaeService = module.get(VerificationUsageService);
         authenticationCodeService = module.get(AuthenticationCodeService);
         guard = module.get(PhoneAuthenticationCodeGuard);
-        redis = module.get('REDIS_CLIENT');
     });
 
     const [phoneNumber, code] = ['01012345667', 232222];

--- a/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
@@ -4,12 +4,10 @@ import { Reflector } from "@nestjs/core"
 import { Test } from "@nestjs/testing"
 import { JwtAuthGuard } from "src/auth/application/guard/jwt/jwt-auth.guard"
 import { JwtStrategy } from "src/auth/application/guard/jwt/jwt.strategy"
-import { SessionService } from "src/auth/application/service/session.service"
 import { MockSessionService } from "test/unit/__mock__/auth/service.mock"
 import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock"
 
 describe('Jwt인증가드(JwtAuthGuard) Test', () => {
-    let sessionService: SessionService;
     let reflector: Reflector;
     let jwtGuard: JwtAuthGuard;
 
@@ -35,7 +33,6 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
             ]
         }).compile();
 
-        sessionService = module.get(SessionService);
         reflector = module.get(Reflector);
         jwtGuard = module.get(JwtAuthGuard);
     });

--- a/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/phone-authentication-guard.spec.ts
@@ -4,8 +4,6 @@ import { VerificationUsageService } from "src/auth/application/service/verificat
 import { PhoneVerificationUsage } from "src/auth/domain/entity/phone-verification-usage.entity";
 
 describe('휴대폰인증 발송 가드(PhoneAuthenticationGuard) Test', () => {
-    const blockedAt = new Date();
-
     const mockContext: any = {
         switchToHttp: () => ({
             getRequest: () => ({

--- a/backend/test/unit/auth/application/guard/refresh-authentication-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/refresh-authentication-guard.spec.ts
@@ -5,12 +5,11 @@ import { Test } from "@nestjs/testing"
 import { getRepositoryToken } from "@nestjs/typeorm"
 import { RefreshAuthenticationGuard } from "src/auth/application/guard/refresh-authentication.guard"
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
-import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
-import { LOGIN_TYPE, ROLE } from "src/user-auth-common/domain/enum/user.enum"
 import { UserRepository } from "src/user-auth-common/domain/repository/user.repository"
 import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
 import { MockUserRepository } from "test/unit/__mock__/user-auth-common/repository.mock"
+import { TestUser } from "test/unit/user/user.fixtures"
 
 describe('인증 갱신 가드(RefreshAuthenticationGuard) Test', () => {
     let userRepository: UserRepository,
@@ -89,9 +88,11 @@ describe('인증 갱신 가드(RefreshAuthenticationGuard) Test', () => {
                     })
                 })
             } as ExecutionContext;
-            const userStub = new User('test', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, new Token('access', 'key', 'refresh'));
 
-            jest.spyOn(userRepository, 'findByRefreshKey').mockResolvedValueOnce(userStub);
+
+            const testUser = TestUser.default();
+
+            jest.spyOn(userRepository, 'findByRefreshKey').mockResolvedValueOnce(testUser as unknown as User);
             jest.spyOn(jwtService, 'verifyAsync').mockRejectedValueOnce(new UnauthorizedException('검증실패'));
 
             const result = async () => await refreshAuthenticationGuard.canActivate(mockContext);

--- a/backend/test/unit/auth/application/service/auth-service.spec.ts
+++ b/backend/test/unit/auth/application/service/auth-service.spec.ts
@@ -20,6 +20,7 @@ import { MockAuthenticationCodeService, MockVerificationUsageService, MockTokenS
 import { MockSmsService } from 'test/unit/__mock__/notification/service.mock';
 import { MockUserRepository } from 'test/unit/__mock__/user-auth-common/repository.mock';
 import { MockUserAuthCommonService } from 'test/unit/__mock__/user-auth-common/service.mock';
+import { TestUser } from 'test/unit/user/user.fixtures';
 
 describe('인증 서비스(AuthService) Test', () => {
     let authService: AuthService;
@@ -99,19 +100,19 @@ describe('인증 서비스(AuthService) Test', () => {
         it('새로운 AccessToken을 변경하고 Session목록에 추가하기 위해 서비스 호출', async () => {
             const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];
             const existAuthentication = new Token(existAccessToken, existRefreshKey, existRefreshToken);
-            const user = new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, existAuthentication);
+            const user = TestUser.default().withToken(existAuthentication);
 
             jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce('accessToken');
             const sessionServiceSpy = jest.spyOn(sessionService, 'addUserToList').mockResolvedValueOnce(null);
 
-            await authService.createAuthenticationToUser(user);
+            await authService.createAuthenticationToUser(user as unknown as User);
             expect(sessionServiceSpy).toBeCalledTimes(1);
         });
 
         it('새로운 AccessToken으로 변경할때는 AccessToken만 변경되고, RefreshToken은 기존 값이어야 한다', async() => {
             const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];
             const existAuthentication = new Token(existAccessToken, existRefreshKey, existRefreshToken);
-            const user = new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, existAuthentication);
+            const user = TestUser.default().withToken(existAuthentication);
 
             const newAccessToken = 'newAccessToken';
             
@@ -128,7 +129,7 @@ describe('인증 서비스(AuthService) Test', () => {
         it('RefreshToken으로 갱신할 경우 RefreshToken의 key와 값도 새로 발급받아져야 한다', async() => {
             const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];
             const existAuthentication = new Token(existAccessToken, existRefreshKey, existRefreshToken);
-            const user = new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, existAuthentication);
+            const user = TestUser.default().withToken(existAuthentication);
 
             const [refreshAccessToken, newUuid, newRefreshToken] = ['refreshAccessToken', 'newUuid', 'newRefreshToken'];
             const refreshToken = new RefreshToken(newUuid, newRefreshToken);
@@ -136,7 +137,7 @@ describe('인증 서비스(AuthService) Test', () => {
 
             jest.spyOn(tokenService, 'generateNewUsersToken').mockResolvedValueOnce(refreshAuthentication);
 
-            await authService.refreshAuthentication(user);
+            await authService.refreshAuthentication(user as unknown as User);
             expect(user.getAuthentication().getAccessToken()).toBe(refreshAccessToken);
             expect(user.getAuthentication().getRefreshKey()).toBe(newUuid);
             expect(user.getAuthentication().getRefreshToken()).toBe(newRefreshToken);

--- a/backend/test/unit/auth/application/service/token-service.spec.ts
+++ b/backend/test/unit/auth/application/service/token-service.spec.ts
@@ -3,10 +3,10 @@ import { JwtService } from "@nestjs/jwt"
 import { Test } from "@nestjs/testing"
 import { TokenService } from "src/auth/application/service/token.service"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
-import { LOGIN_TYPE, ROLE } from "src/user-auth-common/domain/enum/user.enum"
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
 import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
 import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
+import { TestUser } from "test/unit/user/user.fixtures"
 
 describe('토큰 서비스(TokenService) Test', () => {
     let tokenService: TokenService; 
@@ -41,7 +41,7 @@ describe('토큰 서비스(TokenService) Test', () => {
         tokenService = module.get(TokenService);
     });
 
-    beforeEach(() => userStub = new User('test', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, null, null, null))
+    beforeEach(() => userStub = TestUser.default() as unknown as User )
 
     describe('generateNewUsersToken()', () => {
         it('반환된 객체는 NewUserAuthentication의 인스턴스여야한다', async() => {

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -1,14 +1,9 @@
 import { Test } from "@nestjs/testing"
 import { getRepositoryToken } from "@nestjs/typeorm"
 import { ObjectId } from "mongodb"
-import { SessionService } from "src/auth/application/service/session.service"
-import { TokenService } from "src/auth/application/service/token.service"
-import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
-import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity"
+import { AuthService } from "src/auth/application/service/auth.service"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
-import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
-import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
-import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum"
 import { UserMapper } from "src/user/application/mapper/user.mapper"
 import { CaregiverProfileService } from "src/user/application/service/caregiver-profile.service"
 import { PatientProfileService } from "src/user/application/service/patient-profile.service"
@@ -16,15 +11,16 @@ import { UserService } from "src/user/application/service/user.service"
 import { CaregiverProfileBuilder } from "src/user/domain/builder/profile.builder"
 import { CaregiverRegisterDto } from "src/user/interface/dto/caregiver-register.dto"
 import { ProtectorRegisterDto } from "src/user/interface/dto/protector-register.dto"
-import { CommonRegisterForm } from "src/user/interface/dto/register-page"
-import { MockSessionService } from "test/unit/__mock__/auth/service.mock"
+import { MockAuthService } from "test/unit/__mock__/auth/service.mock"
+import { MockUserRepository } from "test/unit/__mock__/user-auth-common/repository.mock"
+import { MockCaregiverProfileService, MockPatientProfileService, MockUserMapper } from "test/unit/__mock__/user/service.mock"
 import { Repository } from "typeorm"
+import { TestUser } from "../../user.fixtures"
 
 describe('UserService Test', () => { 
     let userService: UserService,
         userMapper: UserMapper,
-        tokenService: TokenService,
-        sessionService: SessionService,
+        authService: AuthService,
         caregiverProfileService: CaregiverProfileService,
         patientProfileService: PatientProfileService,
         userRepository: Repository<User>;
@@ -33,92 +29,61 @@ describe('UserService Test', () => {
         const module = await Test.createTestingModule({
             providers: [
                 UserService,
-                MockSessionService,
-                {
-                    provide: UserMapper,
-                    useValue: {
-                        mapFrom: jest.fn().mockReturnValue(createTestUser()),
-                        toDto: jest.fn(),
-                        toMyProfileDto: jest.fn()
-                    }
-                },
-                {
-                    provide: TokenService,
-                    useValue: {
-                        generateNewUsersToken: jest.fn().mockReturnValue(createTestAuthentication()),
-                        addAccessTokenToSessionList: jest.fn().mockReturnValue(null)
-                    }
-                },
-                {
-                    provide: CaregiverProfileService,
-                    useValue: {
-                        addProfile: jest.fn().mockReturnValue(null),
-                        getProfileByUserId: jest.fn()
-                    }
-                },
-                {
-                    provide: PatientProfileService,
-                    useValue: {
-                        addProfile: jest.fn().mockReturnValue(null)
-                    }
-                },
-                {
-                    provide: getRepositoryToken(User),
-                    useValue: {
-                        save: jest.fn().mockResolvedValue(createTestUser())
-                    }
-                }
+                MockUserMapper,
+                MockCaregiverProfileService,
+                MockPatientProfileService,
+                MockAuthService,
+                MockUserRepository
             ]
         }).compile();
 
         userService = module.get(UserService);
         userMapper = module.get(UserMapper);
-        tokenService = module.get(TokenService);
+        authService = module.get(AuthService);
         userRepository = module.get(getRepositoryToken(User));
         caregiverProfileService = module.get(CaregiverProfileService);
         patientProfileService = module.get(PatientProfileService);
-        sessionService = module.get(SessionService);
     })
 
     describe('register()', () => {
-        it('회원가입을 진행하면 인증/인가에 필요한 토큰 발급', async () => {
-            const user = userMapper.mapFrom({} as CommonRegisterForm);
-            const authentication = await tokenService.generateNewUsersToken(user);
-            user.setAuthentication(authentication);
+        it('간병인 회원가입 확인', async () => {
+            const caregiverUser = TestUser.default() // Db 저장 전 user
+            jest.spyOn(userMapper, 'mapFrom').mockReturnValueOnce(caregiverUser as unknown as User);
 
-            expect(user.getAuthentication().getAccessToken()).toBe('testAccessToken');
-            expect(user.getAuthentication().getRefreshKey()).toBe('uuid');
-            expect(user.getAuthentication().getRefreshToken()).toBe('testRefreshToken');
+            const savedUser = caregiverUser.withId(1); // Db 저장 이후 User
+            jest.spyOn(userRepository, 'save').mockResolvedValueOnce(savedUser as unknown as User);
+
+            jest.spyOn(caregiverProfileService, 'addProfile').mockResolvedValueOnce(null);
+
+            const clientDto = { name: '테스트', accessToken: 'access', refreshKey: 'refreshKey' };
+            jest.spyOn(authService, 'refreshAuthentication').mockResolvedValueOnce(clientDto);
+
+            const registerDto = { firstRegister: { purpose: ROLE.CAREGIVER } } as CaregiverRegisterDto;
+            const result = await userService.register(registerDto);
+
+            expect(userRepository.save).toBeCalledWith(caregiverUser); // 먼저 계정 DB 호출
+            expect(caregiverProfileService.addProfile).toBeCalledWith(savedUser.getId(), registerDto); // 간병인 프로필 저장 호출
+            expect(result).toEqual(clientDto); // return 결과
         });
 
-        it('회원가입을 진행했을 때 DB저장, 세션추가 함수 호출', async () => {
-            const [saveSpay, sessionSpy] = [
-                jest.spyOn(userRepository, 'save'),
-                jest.spyOn(sessionService, 'addUserToList')
-            ];
-            const testRegisterDto = { firstRegister: { purpose: ROLE.CAREGIVER } };
-            await userService.register(testRegisterDto as CaregiverRegisterDto);
+        it('보호자 회원가입 확인', async () => {
+            const protectorUser = TestUser.default() // Db 저장 전 user
+            jest.spyOn(userMapper, 'mapFrom').mockReturnValueOnce(protectorUser as unknown as User);
 
-            expect(saveSpay).toHaveBeenCalled();
-            expect(sessionSpy).toHaveBeenCalled();
-        });
+            const savedUser = protectorUser.withId(1); // Db 저장 이후 User
+            jest.spyOn(userRepository, 'save').mockResolvedValueOnce(savedUser as unknown as User);
 
-        it('간병인 회원가입 진행할 때 간병인 프로필 추가 함수 호출', async () => {
-            const profileSpy = jest.spyOn(caregiverProfileService, 'addProfile');
+            jest.spyOn(patientProfileService, 'addProfile').mockResolvedValueOnce(null);
 
-            const testCaregiverRegisterDto = { firstRegister: { purpose: ROLE.CAREGIVER } };
-            await userService.register(testCaregiverRegisterDto as CaregiverRegisterDto);
+            const clientDto = { name: '테스트', accessToken: 'access', refreshKey: 'refreshKey' };
+            jest.spyOn(authService, 'refreshAuthentication').mockResolvedValueOnce(clientDto);
 
-            expect(profileSpy).toHaveBeenCalled();
-        });
-        
-        it('보호자 회원가입 진행할 때 환자 프로필 추가 함수 호출', async () => {
-            const profileSpy = jest.spyOn(patientProfileService, 'addProfile');
+            const registerDto = { firstRegister: { purpose: ROLE.PROTECTOR } } as ProtectorRegisterDto;
+            const result = await userService.register(registerDto);
 
-            const testCaregiverRegisterDto = { firstRegister: { purpose: ROLE.PROTECTOR } };
-            await userService.register(testCaregiverRegisterDto as ProtectorRegisterDto);
-
-            expect(profileSpy).toHaveBeenCalled();
+            expect(userRepository.save).toBeCalledWith(protectorUser); // 먼저 계정 DB 호출
+            expect(patientProfileService.addProfile).toBeCalledWith(savedUser.getId(), registerDto); // 보호자 프로필 저장 호출
+            expect(result).toEqual(clientDto); // return 결과
         });
     })
 
@@ -127,63 +92,30 @@ describe('UserService Test', () => {
         afterEach(() => jest.resetAllMocks() );
         
         it('간병인이 내 프로필 조회시 자격증과 비공개 여부를 위해 repository를 호출하고 mapper에 profile도 같이 넘겨주어야 한다.', async () => {
-            const caregiver = new User(
-                '테스트',
-                ROLE.CAREGIVER,
-                LOGIN_TYPE.PHONE,
-                null,
-                null,
-                null,
-                null
-            );
+            const caregiver = TestUser.default().withRole(ROLE.CAREGIVER);
+
             const profile = new CaregiverProfileBuilder(new ObjectId()).isPrivate(true).build();
+
             const repositorySpy = jest.spyOn(caregiverProfileService, 'getProfileByUserId').mockResolvedValueOnce(profile);
             const mapperSpy = jest.spyOn(userMapper, 'toMyProfileDto');
             
-            await userService.getMyProfile(caregiver);
+            await userService.getMyProfile(caregiver as unknown as User);
 
             expect(repositorySpy).toBeCalledTimes(1);
             expect(mapperSpy).toBeCalledWith(caregiver, profile)
         });
 
         it('보호자가 내 프로필 조회시 profile을 조회하지 않고 넘어온 User만 mapper에 넘겨준다', async () => {
-            const protector = new User(
-                '테스트',
-                ROLE.PROTECTOR,
-                LOGIN_TYPE.PHONE,
-                null,
-                null,
-                null,
-                null
-            );
+            const protector = TestUser.default().withRole(ROLE.PROTECTOR);
 
             const repositorySpy = jest.spyOn(caregiverProfileService, 'getProfileByUserId')
             const mapperSpy = jest.spyOn(userMapper, 'toMyProfileDto');
             
-            await userService.getMyProfile(protector);
+            await userService.getMyProfile(protector as unknown as User);
 
             expect(repositorySpy).toBeCalledTimes(0);
             expect(mapperSpy).toBeCalledWith(protector)
         })
     })
 })
-
-function createTestUser(): User {
-    return new User(
-        '테스트',
-        ROLE.CAREGIVER,
-        LOGIN_TYPE.PHONE,
-        null,
-        new Phone('01011111111'),
-        new UserProfile(19990101, SEX.MALE),
-        null
-    );
-};
-
-function createTestAuthentication(): NewUserAuthentication {
-    return {
-        accessToken: 'testAccessToken',
-        refreshToken: new RefreshToken('uuid', 'testRefreshToken')
-    }
-};
 

--- a/backend/test/unit/user/infra/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/user-repository.spec.ts
@@ -4,11 +4,11 @@ import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity"
 import { User } from "../../../../src/user-auth-common/domain/entity/user.entity"
-import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum"
 import { UserRepository, customUserRepositoryMethods } from "src/user-auth-common/domain/repository/user.repository"
 import { UUIDUtil } from "src/util/uuid.util"
 import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture"
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
+import { TestUser } from "../user.fixtures"
 
 describe('사용자 저장소(UserRepository) Test', () => {
     let userRepository: UserRepository;
@@ -30,18 +30,19 @@ describe('사용자 저장소(UserRepository) Test', () => {
 
     describe('findByUserId', () => {
         it('일치하는 사용자 id로 조회했을 때 반환되는지 확인', async() => {
-            const testUser = new User(
-                '테스트유저', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, 
-                new Phone('01022221111'),new UserProfile(19980101, SEX.MALE), 
-                new Token(null, '123123', 'refresh')
-            );
+            const [phoneNumber, refreshKey, refreshToken] = ['01022221111', UUIDUtil.generateOrderedUuid(), 'refresh'];
+
+            const token = new Token(null, refreshKey, refreshToken);
+            const testUser = TestUser.default().withPhoneNumber(phoneNumber).withToken(token);
             
-            const savedId = (await userRepository.save(testUser)).getId();
+            const savedId = (await userRepository.save(testUser as unknown as User)).getId();
             const result = await userRepository.findById(savedId);
             
             expect(result.getId()).toBe(savedId);
-            expect(result.getAuthentication()).not.toBe(null);
-            console.log(result)
+            expect(result.getAuthentication().getRefreshKey()).toBe(refreshKey);
+            expect(result.getAuthentication().getRefreshToken()).toBe(refreshToken);
+            expect(result.getPhone().getPhoneNumber()).toBe(phoneNumber);
+
             await userRepository.delete({ id: savedId })
         })
     });
@@ -49,13 +50,11 @@ describe('사용자 저장소(UserRepository) Test', () => {
     describe('findByRefreshKey()', () => {
         it('일치하는 RefreshKey가 있을 때 Authentication Entity까지 로드되는지 확인', async() => {
             const [testUuid, testRefreshToken] = [UUIDUtil.generateOrderedUuid(), 'refreshToken'];
-            const testUser = new User(
-                '테스트유저', ROLE.CAREGIVER, LOGIN_TYPE.PHONE, null, 
-                new Phone('01022221111'),new UserProfile(19980101, SEX.MALE), 
-                new Token(null, testUuid, testRefreshToken)
-            );
+            
+            const token = new Token(null, testUuid, testRefreshToken);
+            const testUser = TestUser.default().withToken(token);
 
-            const id = (await userRepository.save(testUser)).getId();
+            const id = (await userRepository.save(testUser as unknown as User)).getId();
             const findResult = await userRepository.findByRefreshKey(testUuid);
 
             expect(findResult.getAuthentication()).not.toBe(null);

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -1,0 +1,82 @@
+import { Time } from "src/common/shared/type/time.type";
+import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
+import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
+import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
+import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum";
+import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface";
+
+export class TestUser {
+    id: number;
+    name: string;
+    loginType: LOGIN_TYPE;
+    role: ROLE;
+    phone: Phone;
+    email: Email;
+    profile: UserProfile;
+    authentication: Token;
+    registeredAt: Time;
+
+    constructor(name: string, loginType: LOGIN_TYPE, role: ROLE, phone: Phone, profile: UserProfile, token: Token) {
+        this.name = name;
+        this.loginType = loginType;
+        this.role = role;
+        this.phone = phone;
+        this.profile = profile;
+        this.authentication = token;
+    };
+
+    static default() { return new TestUser(
+        '테스트', LOGIN_TYPE.PHONE, ROLE.CAREGIVER, 
+        new Phone('01011223344'), new UserProfile(19980101, SEX.MALE), 
+        new Token('accessToken', 'refreshKey', 'refreshToken')
+        )
+    };
+
+    withId(id: number): this {
+        this.id = id;
+        return this;
+    };
+
+    withRole(role: ROLE): this {
+        this.role = role;
+        return this;
+    }
+
+    withPhoneNumber(phoneNumber: string): this {
+        this.phone = new Phone(phoneNumber);
+        return this;
+    };
+
+    withEmail(email: string): this {
+        this.email = new Email(email);
+        return this;
+    };
+
+    withToken(token: Token): this {
+        this.authentication = token;
+        return this;
+    };
+
+    getId(): number { return this.id; };
+    getName(): string { return this.name; };
+    getRole(): ROLE { return this.role; };
+    getAuthentication(): Token { return this.authentication; };
+
+    getPhone(): Phone { return this.phone; };
+    getEmail(): Email { return this.email; }
+
+    /* 회원가입시 새로 발급된 인증 */
+    setAuthentication(newUserAuthentication: NewUserAuthentication) {
+        this.authentication = new Token(
+            newUserAuthentication.accessToken,
+            newUserAuthentication.refreshToken.getKey(),
+            newUserAuthentication.refreshToken.getToken()
+        );
+    };
+
+    /* 로그인에만 성공시 사용할 AccessToken만 변경 */
+    changeAuthentication(newAccessToken: string): void {
+        this.authentication.changeAccessToken(newAccessToken);
+    }
+ }


### PR DESCRIPTION
Fixed #33 

Lazy loading을 Default로 변경하여 필요한 저장소에서 **innerJoin**과 email은 등록되지 않은 사용자가 있기에 **leftJoin**을 사용
- **OneToOne** 관계에서 Promise로 설정시 로드 자체가 되지 않으며 Promise를 제외하고 **lazy: true** 옵션을 주면 로드가 되지만 해당 데이터에 접근할 때 쿼리를 날리는게 아닌 처음부터 로드가 되어있음

UserController의 **register** 메소드에서 토큰을 발급받는 로직이 DB에 저장되고 난 이후(id를 포함하는) 사용자가 넘겨지는게 아니라 id를 발급받지 않은 사용자가 넘겨져 생성된 토큰에 **userId**가 포함되지 않았음
- 먼저 저장을 하고 아이디가 발급된 사용자를 AuthService에 **refreshAuthentication()**메소드를 통해 새로운 인증을 발급 받고, 세션리스트에 추가하고, **clientDto**로 변환해주는 로직을 수행