### PR TITLE
Fixed(#35): 만료된 토큰 이후 인증 갱신 오류 수정 완료

### DIFF
--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -34,7 +34,7 @@ export class AuthController {
     @UseGuards(PhoneAuthenticationCodeGuard)
     @Post('code/sms')
     async validateSmsCode(@AuthenticatedUser() user: User): Promise<ClientDto | void> {
-        if( user ) return await this.authService.createAuthenticationToUser(user);
+        if( user ) return await this.authService.changeAuthentication(user);
     }
 
     /* 로그인 */

--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -33,4 +33,9 @@ export class Token {
     getRefreshKey(): string { return this.refreshKey; };
     getRefreshToken(): string { return this.refreshToken; };
     changeAccessToken(newAccessToken: string): void { this.accessToken = newAccessToken; };
+    refreshAuthentication(accessToken: string, refreshKey: string, refreshToken: string) {
+        this.accessToken = accessToken;
+        this.refreshKey = refreshKey;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -55,13 +55,22 @@ export class User {
     getEmail(): Email { return this.email; }
 
     /* 회원가입시 새로 발급된 인증 */
-    setAuthentication(newUserAuthentication: NewUserAuthentication) {
+    setAuthentication(newAuthentication: NewUserAuthentication) {
         this.authentication = new Token(
-            newUserAuthentication.accessToken,
-            newUserAuthentication.refreshToken.getKey(),
-            newUserAuthentication.refreshToken.getToken()
+            newAuthentication.accessToken,
+            newAuthentication.refreshToken.getKey(),
+            newAuthentication.refreshToken.getToken()
         );
     };
+
+    /* 인증을 새로 갱신할 때 전체 값만 변경 */
+    refreshAuthentication(refreshedAuthentication: NewUserAuthentication) {
+        this.authentication.refreshAuthentication(
+            refreshedAuthentication.accessToken, 
+            refreshedAuthentication.refreshToken.getKey(),
+            refreshedAuthentication.refreshToken.getToken()
+        );
+    }
 
     /* 로그인에만 성공시 사용할 AccessToken만 변경 */
     changeAuthentication(newAccessToken: string): void {

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -30,7 +30,7 @@ export class UserService {
 
         await this.addProfile(savedUser.getId(), registerDto); // 각자의 역할 프로필 저장
 
-        return await this.authService.refreshAuthentication(savedUser); // 새로운 토큰들을 발급받아 저장
+        return await this.authService.createAuthentication(savedUser); // 새로운 토큰들을 발급받아 저장
     }
 
     async getMyProfile(user: User): Promise<MyProfileDto> {

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -21,7 +21,8 @@ export const MockAuthService = {
         register: jest.fn(),
         login: jest.fn(),
         refreshAuthentication: jest.fn(),
-        createAuthenticationToUser: jest.fn(),
+        createAuthentication: jest.fn(),
+        changeAuthentication: jest.fn(),
         validateSmsCode: jest.fn()
     }
 };

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -56,7 +56,7 @@ describe('UserService Test', () => {
             jest.spyOn(caregiverProfileService, 'addProfile').mockResolvedValueOnce(null);
 
             const clientDto = { name: '테스트', accessToken: 'access', refreshKey: 'refreshKey' };
-            jest.spyOn(authService, 'refreshAuthentication').mockResolvedValueOnce(clientDto);
+            jest.spyOn(authService, 'createAuthentication').mockResolvedValueOnce(clientDto);
 
             const registerDto = { firstRegister: { purpose: ROLE.CAREGIVER } } as CaregiverRegisterDto;
             const result = await userService.register(registerDto);
@@ -76,7 +76,7 @@ describe('UserService Test', () => {
             jest.spyOn(patientProfileService, 'addProfile').mockResolvedValueOnce(null);
 
             const clientDto = { name: '테스트', accessToken: 'access', refreshKey: 'refreshKey' };
-            jest.spyOn(authService, 'refreshAuthentication').mockResolvedValueOnce(clientDto);
+            jest.spyOn(authService, 'createAuthentication').mockResolvedValueOnce(clientDto);
 
             const registerDto = { firstRegister: { purpose: ROLE.PROTECTOR } } as ProtectorRegisterDto;
             const result = await userService.register(registerDto);

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -67,13 +67,22 @@ export class TestUser {
     getEmail(): Email { return this.email; }
 
     /* 회원가입시 새로 발급된 인증 */
-    setAuthentication(newUserAuthentication: NewUserAuthentication) {
+    setAuthentication(newAuthentication: NewUserAuthentication) {
         this.authentication = new Token(
-            newUserAuthentication.accessToken,
-            newUserAuthentication.refreshToken.getKey(),
-            newUserAuthentication.refreshToken.getToken()
+            newAuthentication.accessToken,
+            newAuthentication.refreshToken.getKey(),
+            newAuthentication.refreshToken.getToken()
         );
     };
+
+    /* 인증을 새로 갱신할 때 전체 값만 변경 */
+    refreshAuthentication(refreshedAuthentication: NewUserAuthentication) {
+        this.authentication.refreshAuthentication(
+            refreshedAuthentication.accessToken, 
+            refreshedAuthentication.refreshToken.getKey(),
+            refreshedAuthentication.refreshToken.getToken()
+        );
+    }
 
     /* 로그인에만 성공시 사용할 AccessToken만 변경 */
     changeAuthentication(newAccessToken: string): void {


### PR DESCRIPTION
Fixed #35 

JwtService에 Option 누락되어 검증(verify)하지 못하는 오류
- ConfigService를 통해 기존 payload 생성할 때 사용했던 RefreshToken용 **secretKey** 부여하여 수행

RefreshToken으로 갱신 이후 저장 시 Id가 삭제되어 Insert 시 충돌 오류
- 변경된 값들만 바꾸어야 하는데 새로운 인스턴스를 만들어 변경하여 오류가 발생하였음
- 회원가입과 만료된 토큰 이후 갱신할 때 method를 분리하여 갱신 시에는 단순히 AccessToken, RefreshKey, RefreshToken을 변경해서 객체 내부의 값을 변경
    - 로그인(changeAuthentication()): RefreshToken의 정보는 변경하지 않고 AccessToken만 새로 발급
    - 회원가입(createAuthentication()): new Token()을 통해 아직 아이디가 부여되지 않은 새로운 토큰 생성
    - 만료 후 갱신(refreshAuthentication()): 이미 부여된 Id가 있기에 내부의 값만 변경하여 update