### PR TITLE
[백엔드] JwtToken 만료된 토큰 관리 로직 구현 완료

### DIFF
--- a/backend/src/auth/application/filter/token-expired-exception.filter.ts
+++ b/backend/src/auth/application/filter/token-expired-exception.filter.ts
@@ -1,0 +1,42 @@
+import { ArgumentsHost, Catch, ExceptionFilter, UnauthorizedException } from "@nestjs/common";
+import { SessionService } from "../service/session.service";
+import { JwtService } from "@nestjs/jwt";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+@Catch(UnauthorizedException)
+export class TokenExpiredExceptionFilter implements ExceptionFilter {
+  constructor(
+    private readonly sessionService: SessionService,
+    private readonly jwtService: JwtService
+  ) { }
+
+  async catch(exception: UnauthorizedException, host: ArgumentsHost) {
+    const request = host.switchToHttp().getRequest();
+
+    /* 만료된 토큰으로 인한 오류면 세션리스트에서 사용자 삭제 */
+    if (exception.message === ErrorMessage.ExpiredToken)
+      await this.deleteTokenFromSessionList(request);
+    return;
+  }
+
+  /* 세션리스트에서 해당 토큰 삭제 */
+  private async deleteTokenFromSessionList(request: any) {
+    const accessToken = this.extractTokenFromHeader(request);
+    const { userId } = this.decodeToken(accessToken);
+    await this.sessionService.deleteUserFromList(userId);
+  };
+
+  /* 헤더에서 토큰 추출 */
+  private extractTokenFromHeader(request: any): string {
+    const { authorization } = request.headers;
+    return authorization.split(" ")[1];
+  };
+
+  /* 토큰을 검증하지 않고 단순 decode */
+  private decodeToken(accessToken: string): any {
+    return this.jwtService.decode(accessToken, {
+      complete: false,
+      json: true
+    })
+  };
+}

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -47,7 +47,6 @@ export class AuthController {
         return await this.authService.login(phoneNumber);
     }
 
-    @UseFilters(TokenExpiredExceptionFilter)
     @Post('logout')
     /* 로그아웃 */
     async logout(@AuthenticatedUser() user: User): Promise<void> {

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Post, UseFilters, UseGuards } from "@nestjs/common";
 import { AuthService } from "src/auth/application/service/auth.service";
 import { PhoneAuthenticationSendGuard } from "src/auth/application/guard/authentication-send.guard";
 import { PhoneAuthenticationCodeGuard } from "src/auth/application/guard/authentication-code.guard";
@@ -7,6 +7,7 @@ import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
 import { Public } from "src/auth/application/decorator/public.decorator";
 import { RefreshAuthenticationGuard } from "src/auth/application/guard/refresh-authentication.guard";
+import { TokenExpiredExceptionFilter } from "src/auth/application/filter/token-expired-exception.filter";
 
 @Controller('auth')
 export class AuthController {
@@ -16,6 +17,7 @@ export class AuthController {
 
     @Public()
     @UseGuards(RefreshAuthenticationGuard)
+    @UseFilters(TokenExpiredExceptionFilter)
     @Post('refresh')
     async refreshAuthentication(@AuthenticatedUser() user: User): Promise<ClientDto> {
         return await this.authService.refreshAuthentication(user);
@@ -45,6 +47,7 @@ export class AuthController {
         return await this.authService.login(phoneNumber);
     }
 
+    @UseFilters(TokenExpiredExceptionFilter)
     @Post('logout')
     /* 로그아웃 */
     async logout(@AuthenticatedUser() user: User): Promise<void> {

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -8,5 +8,6 @@ export const enum ErrorMessage {
     NotExistUser = '일치하는 사용자 정보를 찾을 수 없습니다.',
     NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
     InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
-    NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.'
+    NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.',
+    ExpiredToken = 'jwt expired'
 }

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -42,7 +42,8 @@ export const MockSessionService = {
     provide: SessionService,
     useValue: {
         addUserToList: jest.fn(),
-        getUserFromList: jest.fn()
+        getUserFromList: jest.fn(),
+        deleteUserFromList: jest.fn()
     }
 };
 
@@ -60,7 +61,8 @@ export const MockJwtService = {
     provide: JwtService,
     useValue: {
         signAsync: jest.fn(),
-        verifyAsync: jest.fn()
+        verifyAsync: jest.fn(),
+        decode: jest.fn()
     }
 }
 

--- a/backend/test/unit/auth/application/filter/token-expired-exception-filter.spec.ts
+++ b/backend/test/unit/auth/application/filter/token-expired-exception-filter.spec.ts
@@ -1,0 +1,63 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { Test } from "@nestjs/testing";
+import { TokenExpiredExceptionFilter } from "src/auth/application/filter/token-expired-exception.filter";
+import { SessionService } from "src/auth/application/service/session.service"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { MockJwtService, MockSessionService } from "test/unit/__mock__/auth/service.mock";
+
+describe('TokenExpiredExceptionFilter Test', () => {
+    let sessionService: SessionService;
+    let jwtService: JwtService;
+    let tokenExpiredFilter:TokenExpiredExceptionFilter;
+    
+    beforeAll(async () => {
+        const module = await Test.createTestingModule({
+            providers: [
+                MockSessionService,
+                MockJwtService
+            ]
+        }).compile();
+
+        sessionService = module.get(SessionService);
+        jwtService = module.get(JwtService);
+        tokenExpiredFilter = new TokenExpiredExceptionFilter(sessionService, jwtService);
+    });
+
+    it('만료된 토큰으로 인한 문제가 아닌 UnauthorizedException이 발생하면 로직 없이 반환', async () => {
+        
+        const mockRequest: any = {
+            switchToHttp: () => ({
+                getRequest: jest.fn()
+            })
+        };
+
+        const wrongError = new UnauthorizedException('otherMessage');
+
+        const result = await tokenExpiredFilter.catch(wrongError, mockRequest);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('만료된 토큰으로 인한 UnauthorizedException이 발생하면 세션리스트에서 삭제 함수 호출', async () => {
+        const mockRequest: any = {
+            switchToHttp: () => ({
+                getRequest: () => ({
+                    headers: {
+                        authorization: "bearer accessToken"
+                    }
+                })
+            })
+        };
+        
+        const tokenExpiredError = new UnauthorizedException(ErrorMessage.ExpiredToken);
+        
+        const userId = 2;
+        jest.spyOn(sessionService, 'deleteUserFromList').mockResolvedValueOnce(null);
+        jest.spyOn(jwtService, 'decode').mockReturnValueOnce({ userId });
+
+        await tokenExpiredFilter.catch(tokenExpiredError, mockRequest);
+
+        expect(sessionService.deleteUserFromList).toHaveBeenCalledWith(userId);
+    })    
+})

--- a/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
@@ -4,12 +4,18 @@ import { Reflector } from "@nestjs/core"
 import { Test } from "@nestjs/testing"
 import { JwtAuthGuard } from "src/auth/application/guard/jwt/jwt-auth.guard"
 import { JwtStrategy } from "src/auth/application/guard/jwt/jwt.strategy"
+import { SessionService } from "src/auth/application/service/session.service"
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
 import { MockSessionService } from "test/unit/__mock__/auth/service.mock"
 import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock"
+import { TestUser } from "test/unit/user/user.fixtures"
 
 describe('Jwt인증가드(JwtAuthGuard) Test', () => {
     let reflector: Reflector;
     let jwtGuard: JwtAuthGuard;
+    let jwtStrategy: JwtStrategy;
+    let sessionService: SessionService;
 
     beforeAll(async () => {
         const module = await Test.createTestingModule({
@@ -35,6 +41,8 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
 
         reflector = module.get(Reflector);
         jwtGuard = module.get(JwtAuthGuard);
+        jwtStrategy = module.get(JwtStrategy);
+        sessionService = module.get(SessionService);
     });
 
     it('Public Api이면 True 반환', async () => {
@@ -75,7 +83,7 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
                     getResponse: jest.fn(),
                     getRequest: () => ({
                         headers: {
-                            Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                            authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
                         },
                     })
                 })
@@ -93,15 +101,68 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
                     getResponse: jest.fn(),
                     getRequest: () => ({
                         headers: {
-                            Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxIiwicm9sZSI6ImNhcmVnaXZlciIsImlhdCI6MTUxNjIzOTAyMn0.j-8NzDc8SkY7mRzgLpllfVdOAPsc2n1dDCkRbZ1EQgI"
+                            authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjE1MTYyMzkwMjJ9.eWqMgbF5Oa1oIw_UzYeuNIrLgmkOe4hN6hyfVN57f0s"
                         },
                     })
                 })
             };
             
             const result = async () => await jwtGuard.canActivate(mockContext);
-            await expect(result).rejects.toThrowError(UnauthorizedException)
+            await expect(result).rejects.toThrowError(UnauthorizedException);
+        });
 
+        describe('토큰의 유효성 검사를 모두 통과했을 경우', () => {
+            it('인증된 사용자가 세션리스트에서 있으면 반환', async() => {
+                const user = TestUser.default() as unknown as User;
+    
+                const mockContext: any = {
+                    getHandler: jest.fn(),
+                    getClass: jest.fn(),
+                    switchToHttp: () => ({
+                        getResponse: jest.fn(),
+                        getRequest: () => ({
+                            user,
+                            headers: {
+                                authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxMDAxNjYzOTAyMn0.z0AfSIZ385LfcGiLQg2qeHUFcf0RfckEA7eE9EaOL24"
+                            },
+                        })
+                    })
+                };
+    
+                jwtStrategy.validate = jest.fn().mockResolvedValueOnce(user);
+    
+                const sessionCallSpy = jest.spyOn(sessionService, 'getUserFromList').mockResolvedValueOnce('pass');
+                const result = await jwtGuard.canActivate(mockContext);
+    
+                expect(sessionCallSpy).toHaveBeenCalledWith(user.getId());
+                expect(result).toBe(true);
+            });
+
+            it('인증된 사용자가 세션리스트에서 없으면 401에러', async() => {
+                const user = TestUser.default() as unknown as User;
+    
+                const mockContext: any = {
+                    getHandler: jest.fn(),
+                    getClass: jest.fn(),
+                    switchToHttp: () => ({
+                        getResponse: jest.fn(),
+                        getRequest: () => ({
+                            user,
+                            headers: {
+                                authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxMDAxNjYzOTAyMn0.z0AfSIZ385LfcGiLQg2qeHUFcf0RfckEA7eE9EaOL24"
+                            },
+                        })
+                    })
+                };
+    
+                jwtStrategy.validate = jest.fn().mockResolvedValueOnce(user);
+    
+                const sessionCallSpy = jest.spyOn(sessionService, 'getUserFromList').mockResolvedValueOnce(null);
+                const result = async () => await jwtGuard.canActivate(mockContext);
+    
+                expect(sessionCallSpy).toHaveBeenCalledWith(user.getId());
+                await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.NotExistUserInSessionList));
+            });
         })
     })
 })


### PR DESCRIPTION
- AccessToken 만료 후 RefreshToken역시 만료되어 로그아웃 처리가 될 때 해당 토큰의 주인을 세션리스트에서 삭제
- AccessToken이 만료될 때마다 삭제를 하지 않는 이유는 RefreshToken으로 항상 갱신을 시도하기 때문에 RefreshToken으로 갱신에 최종 실패했을 때만 만료 토큰 삭제