### PR TITLE
[프론트엔드] 내 프로필, 로그아웃 Api 구현 완료

### DIFF
--- a/frontendv2/components/Login/AuthId.jsx
+++ b/frontendv2/components/Login/AuthId.jsx
@@ -15,8 +15,8 @@ import api from '../../config/CustomAxios';
 import { saveId, saveIsAuthed } from '../../redux/action/register/firstRegisterAction';
 import { useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { saveUser } from '../../redux/action/user/userAction';
 import { StackActions } from '@react-navigation/native';
+import { saveUser } from '../../redux/action/user/userAction';
 
 
 export default function AuthId({ navigation }) {
@@ -81,8 +81,8 @@ export default function AuthId({ navigation }) {
                 }, 200);
             } else {
                 const { accessToken, refreshKey, name } = res.data;  
+                await AsyncStorage.multiSet([['accessToken', accessToken], ['refreshToken', refreshKey], ['name', name]]);
                 dispatch(saveUser(name));
-                await AsyncStorage.multiSet([['accessToken', accessToken], ['refreshToken', refreshKey]]);
                 navigation.dispatch(
                     StackActions.pop()
                 )

--- a/frontendv2/components/MyInfo/LoginBox/LoginProfile.jsx
+++ b/frontendv2/components/MyInfo/LoginBox/LoginProfile.jsx
@@ -14,9 +14,8 @@ import { useSelector } from 'react-redux';
 import Icon from '../../Icon';
 
 export default function LoginProfile({ navigation }) {
-    const { name, purpose } = useSelector(state => ({
+    const { name } = useSelector(state => ({
         name: state.user.name,
-        purpose: state.user.purpose
     }));
 
     return (

--- a/frontendv2/components/MyProfile/UserLogin/Logout.jsx
+++ b/frontendv2/components/MyProfile/UserLogin/Logout.jsx
@@ -1,33 +1,38 @@
 /* 내 계정 관리 logout 부분 */
 
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { StackActions } from "@react-navigation/native";
 import { Text } from "react-native";
 import { StyleSheet } from "react-native";
 import { View } from "react-native";
 import { TouchableHighlight } from "react-native";
-import { heightPercentageToDP as hp} from "react-native-responsive-screen";
-import { useDispatch } from "react-redux";
-import { resetHeartList } from "../../../redux/action/profile/profileAction";
-import { saveIsAuthed } from "../../../redux/action/register/firstRegisterAction";
+import { useDispatch } from 'react-redux';
+import { heightPercentageToDP as hp } from "react-native-responsive-screen";
+import api from "../../../config/CustomAxios";
 import { logout } from "../../../redux/action/user/userAction";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { StackActions } from "@react-navigation/native";
 
 export default function Logout({ navigation }) {
     const dispatch = useDispatch();
+
+    /* 로그아웃 시도 시 에러가 나면 무조건 로그아웃 처리 */
+    const pressLogoutBtn = async () => {
+        try {
+            await api.post('auth/logout');
+        }
+        catch (err) {
+            dispatch(logout()); //현재 유저정보 리셋
+            await AsyncStorage.multiRemove(['accessToken', 'refreshToken', 'name']);
+            navigation.dispatch(
+                StackActions.pop()
+            );
+        }
+    }
 
     return (
         <TouchableHighlight
             style={{ heigh: hp('6%') }}
             underlayColor='none'
-            onPress={async () => {
-                dispatch(logout()); //현재 유저정보 리셋
-                dispatch(saveIsAuthed(false)); //휴대폰 인증 여부 리셋
-                dispatch(resetHeartList()); // 찜 목록 초기화
-                await AsyncStorage.multiRemove(['accessToken', 'refreshToken']);
-                navigation.dispatch(
-                    StackActions.pop()
-                );
-            }}
+            onPress={async () => await pressLogoutBtn(navigation)}
         >
             <View style={styles.eachPart}>
                 <Text style={{ fontSize: 16, fontWeight: '400' }}>

--- a/frontendv2/functions/Register/requestCreateUser.jsx
+++ b/frontendv2/functions/Register/requestCreateUser.jsx
@@ -20,7 +20,7 @@ export default async function requestCreateUser(RegisterData, navigation) {
         });
         const { accessToken, refreshKey, name } = res.data;
         store.dispatch(saveUser(name));
-        await AsyncStorage.multiSet([['accessToken', accessToken], ['refreshToken', refreshKey]]);
+        await AsyncStorage.multiSet([['accessToken', accessToken], ['refreshToken', refreshKey], ['name', nmae]]);
         navigation.dispatch(
             StackActions.push('registerCompletePage')
         );

--- a/frontendv2/functions/requestLogout.js
+++ b/frontendv2/functions/requestLogout.js
@@ -1,0 +1,19 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import api from "../config/CustomAxios";
+import { logout } from "../redux/action/user/userAction";
+import store from "../redux/store";
+
+/* 공통 로그아웃 */
+export default async function requestLogout(navigation) {
+    try {
+        await api.post('auth/logout');
+    }
+    finally {
+        /* AsyncStorage에 있는 값들 모두 지우고  */
+        await AsyncStorage.multiRemove(['accessToken', 'refreshToken', 'name']);
+        store.dispatch(logout());
+        navigation.dispatch(
+            StackActions.push('loginPage')
+        );
+    }
+}

--- a/frontendv2/screens/MyInfo.jsx
+++ b/frontendv2/screens/MyInfo.jsx
@@ -1,6 +1,6 @@
 /* 마이 페이지 */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     View,
     SafeAreaView,
@@ -8,8 +8,21 @@ import {
 } from 'react-native';
 import LoginBox from '../components/MyInfo/LoginBox';
 import StatusBarComponent from '../components/StatusBarComponent';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { saveUser } from '../redux/action/user/userAction';
+import { useDispatch } from 'react-redux';
 
 export default function MyInfo({ navigation }) {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        async function getMyName() {
+            const name = await AsyncStorage.getItem('name');
+            dispatch(saveUser(name));
+        };
+        getMyName()
+    }, []);
+
     return (
         <SafeAreaView style={styles.container}>
             <StatusBarComponent />

--- a/frontendv2/screens/MyProfile.jsx
+++ b/frontendv2/screens/MyProfile.jsx
@@ -12,6 +12,7 @@ import api from "../config/CustomAxios";
 import store from "../redux/store";
 import { saveProfile } from "../redux/action/user/userAction";
 import UserAccount from "../components/MyProfile/UserAccount";
+import { requestRefreshToken } from "../functions/Token";
 
 export default function MyProfile({ navigation }) {
 
@@ -22,7 +23,8 @@ export default function MyProfile({ navigation }) {
                 store.dispatch(saveProfile(res.data));
             }
             catch(err) {
-                console.log(err.response)
+                await requestRefreshToken(navigation);
+                await getMyProfile();
             }
         }
         getMyProfile();


### PR DESCRIPTION
내 프로필 조회
- 단순히 Api 요청하여 받아오는 데이터에 맞게 화면에 렌더링

로그아웃
- RefreshToken으로 갱신에 실패하여 로그아웃을 해야할 때는 공통 함수 이용 후 로그인 페이지로 이동
- 실제 로그아웃 버튼을 눌러 로그아웃을 할 때는 인증 오류가 나도 로그아웃 처리 이후 전 화면으로 이동