### PR TITLE
[백엔드] 로그아웃 시 만료된 토큰을 가지고 있는 사용자 처리 완료

### DIFF
--- a/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
+++ b/backend/src/auth/application/guard/jwt/jwt-auth.guard.ts
@@ -6,6 +6,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { SessionService } from "../../service/session.service";
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { IS_PUBLIC_KEY } from "../../decorator/public.decorator";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -27,6 +28,15 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
 
         return await this.isExistUserInSessionList(user.getId())
     };
+
+    handleRequest(err: any, user: User, info: any, context: ExecutionContext, status?: any): any {
+        if( user ) return user;
+
+        if( info.name === 'TokenExpiredError' )
+            throw new UnauthorizedException(ErrorMessage.ExpiredToken);
+        
+        return super.handleRequest(err, user, info, context, status);
+    }
 
     private isPublicApi(context: ExecutionContext) {
         return this.reflector.getAllAndOverride(IS_PUBLIC_KEY, [

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -47,8 +47,9 @@ export class AuthController {
         return await this.authService.login(phoneNumber);
     }
 
-    @Post('logout')
     /* 로그아웃 */
+    @UseFilters(TokenExpiredExceptionFilter)
+    @Post('logout')
     async logout(@AuthenticatedUser() user: User): Promise<void> {
         return await this.authService.logout(user)
     }

--- a/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
@@ -108,8 +108,31 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
             };
             
             const result = async () => await jwtGuard.canActivate(mockContext);
-            await expect(result).rejects.toThrowError(UnauthorizedException);
+            await expect(result).rejects.toThrowError(new UnauthorizedException(ErrorMessage.ExpiredToken));
         });
+
+        describe('handledRequest()', () => {
+            it('user가 있는경우 그대로 반환 확인', async () => {
+                const testUser = TestUser.default() as unknown as User;
+                const result = jwtGuard.handleRequest(null, testUser, null, null, null);
+
+                expect(result).toEqual(testUser);
+            });
+
+            it('TokenExpiredError가 난 경우 Custom ErrorMessage로 변경하여 호출', () => {
+                const mockInfo = { name: 'TokenExpiredError' };
+
+                const result = () => jwtGuard.handleRequest(null, null, mockInfo, null, null);
+                expect(result).toThrowError(new UnauthorizedException(ErrorMessage.ExpiredToken));
+            });
+
+            it('TokenExpiredError가 아닌경우 기존 처리방식으로 처리 확인', () => {
+                const mockInfo = { name: 'JsonWebTokenError'}
+
+                const result = () => jwtGuard.handleRequest(null, null, mockInfo, null, null);
+                expect(result).toThrowError(UnauthorizedException);
+            });
+        })
 
         describe('토큰의 유효성 검사를 모두 통과했을 경우', () => {
             it('인증된 사용자가 세션리스트에서 있으면 반환', async() => {


### PR DESCRIPTION
기존에 만료된 토큰의 오류를 catch해 해당 토큰의 사용자를 세션리스트에서 삭제하는 Filter를 로그아웃 라우터에도 적용

로그아웃 시도 -> 시도하는 사용자의 토큰이 만료 오류 -> 해당 오류를 catch하여 로그아웃 처리
