### PR TITLE
Fixed(#40): AccessToken이 만료될 때마다 로그인해야 하는 문제 해결

### DIFF
--- a/backend/src/auth/application/filter/token-expired-exception.filter.ts
+++ b/backend/src/auth/application/filter/token-expired-exception.filter.ts
@@ -11,12 +11,17 @@ export class TokenExpiredExceptionFilter implements ExceptionFilter {
   ) { }
 
   async catch(exception: UnauthorizedException, host: ArgumentsHost) {
-    const request = host.switchToHttp().getRequest();
+    const [request, response] = [
+      host.switchToHttp().getRequest(),
+      host.switchToHttp().getResponse()
+    ];
 
     /* 만료된 토큰으로 인한 오류면 세션리스트에서 사용자 삭제 */
     if (exception.message === ErrorMessage.ExpiredToken)
       await this.deleteTokenFromSessionList(request);
-    return;
+
+    response.status(exception.getStatus())
+            .send({ statusCode: exception.getStatus(), message: exception.message });
   }
 
   /* 세션리스트에서 해당 토큰 삭제 */

--- a/backend/src/auth/application/service/auth.service.ts
+++ b/backend/src/auth/application/service/auth.service.ts
@@ -55,13 +55,6 @@ export class AuthService {
         return await this.addToSessionListAndMapToDto(user, newAuthentication.accessToken);
     }
 
-    /* 로그인에 성공한 사용자는 새로운 AccessToken으로 변경  */
-    async changeAuthentication(user: User): Promise<ClientDto> {
-        const newAccessToken = await this.tokenService.generateAccessToken(user); // 새로운 AccessToken 발급
-        user.changeAuthentication(newAccessToken); // RefreshToken은 기존 토큰 사용
-        return await this.addToSessionListAndMapToDto(user, newAccessToken);
-    }
-
     /* 만료된 토큰일 경우 RefreshToken으로 새로 갱신 */
     async refreshAuthentication(user: User): Promise<ClientDto> {
         const refreshedAuthentication = await this.generateAuthentication(user);

--- a/backend/src/auth/interface/controller/auth.controller.ts
+++ b/backend/src/auth/interface/controller/auth.controller.ts
@@ -36,7 +36,7 @@ export class AuthController {
     @UseGuards(PhoneAuthenticationCodeGuard)
     @Post('code/sms')
     async validateSmsCode(@AuthenticatedUser() user: User): Promise<ClientDto | void> {
-        if( user ) return await this.authService.changeAuthentication(user);
+        if( user ) return await this.authService.refreshAuthentication(user);
     }
 
     /* 로그인 */

--- a/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/auth-token.entity.ts
@@ -32,7 +32,6 @@ export class Token {
     getAccessToken(): string { return this.accessToken; };
     getRefreshKey(): string { return this.refreshKey; };
     getRefreshToken(): string { return this.refreshToken; };
-    changeAccessToken(newAccessToken: string): void { this.accessToken = newAccessToken; };
     refreshAuthentication(accessToken: string, refreshKey: string, refreshToken: string) {
         this.accessToken = accessToken;
         this.refreshKey = refreshKey;

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -71,9 +71,4 @@ export class User {
             refreshedAuthentication.refreshToken.getToken()
         );
     }
-
-    /* 로그인에만 성공시 사용할 AccessToken만 변경 */
-    changeAuthentication(newAccessToken: string): void {
-        this.authentication.changeAccessToken(newAccessToken);
-    }
 }

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -22,7 +22,6 @@ export const MockAuthService = {
         login: jest.fn(),
         refreshAuthentication: jest.fn(),
         createAuthentication: jest.fn(),
-        changeAuthentication: jest.fn(),
         validateSmsCode: jest.fn()
     }
 };

--- a/backend/test/unit/auth/application/service/auth-service.spec.ts
+++ b/backend/test/unit/auth/application/service/auth-service.spec.ts
@@ -132,41 +132,6 @@ describe('인증 서비스(AuthService) Test', () => {
         })
     })
 
-    describe('changeAuthentication()', () => {
-        it('새로운 AccessToken으로 변경하고 Session목록에 변경된 토큰 추가 및 사용자용 Dto 반환', async () => {
-            const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];
-            const existAuthentication = new Token(existAccessToken, existRefreshKey, existRefreshToken);
-            const user = TestUser.default().withToken(existAuthentication);
-
-            const changedToken = 'changedAccessToken';
-            jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce(changedToken);
-            
-            const expectedDto = { name: user.getName(), accessToken: changedToken, refreshKey: existRefreshKey };
-            jest.spyOn(authMapper, 'toDto').mockReturnValueOnce(expectedDto); // 예상 결과값
-
-            const sessionSpy = jest.spyOn(sessionService, 'addUserToList')
-
-            const result = await authService.changeAuthentication(user as unknown as User);
-            expect(sessionSpy).toHaveBeenCalledWith(user.getId(), changedToken);
-            expect(result).toEqual(expectedDto);
-        });
-
-        it('새로운 AccessToken으로 변경할때는 AccessToken만 변경되고, RefreshToken은 기존 값이어야 한다', async() => {
-            const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];
-            const existAuthentication = new Token(existAccessToken, existRefreshKey, existRefreshToken);
-            const user = TestUser.default().withToken(existAuthentication);
-
-            const newAccessToken = 'newAccessToken';
-            
-            jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce(newAccessToken);
-            user.changeAuthentication(newAccessToken);
-
-            expect(user.getAuthentication().getAccessToken()).toBe(newAccessToken);
-            expect(user.getAuthentication().getRefreshKey()).toBe(existRefreshKey);
-            expect(user.getAuthentication().getRefreshToken()).toBe(existRefreshToken);
-        });
-    })
-
     describe('refreshAuthentication()', () => {
         it('새로 갱신된 토큰을 Session목록에 추가 및 사용자용 Dto 반환', async () => {
             const [existAccessToken, existRefreshKey, existRefreshToken] = ['accessToken', 'uuid', 'existRefreshToken'];

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -83,9 +83,4 @@ export class TestUser {
             refreshedAuthentication.refreshToken.getToken()
         );
     }
-
-    /* 로그인에만 성공시 사용할 AccessToken만 변경 */
-    changeAuthentication(newAccessToken: string): void {
-        this.authentication.changeAccessToken(newAccessToken);
-    }
  }


### PR DESCRIPTION
Fixed #40 

해결책으로 로그인에 성공할 때마다 AccessToken, RefreshKey, RefreshToken을 모두 새로 발급
changeAuthentication() 메서드를 삭제하고 기존 refreshAuthentication() 메서드를 사용

* 추가
TokenExpiredExceptionFilter에서 응답을 돌려보내주지 않아 응답에 데이터 설정 후 전송