### PR TITLE
[프론트엔드] 로그아웃 버튼 테스트 오류 수정

### DIFF
--- a/frontendv2/components/MyProfile/UserLogin/Logout.jsx
+++ b/frontendv2/components/MyProfile/UserLogin/Logout.jsx
@@ -17,9 +17,9 @@ export default function Logout({ navigation }) {
     /* 로그아웃 시도 시 에러가 나면 무조건 로그아웃 처리 */
     const pressLogoutBtn = async () => {
         try {
-            await api.post('auth/logout');
+            const res = await api.post('auth/logout');
         }
-        catch (err) {
+        finally {
             dispatch(logout()); //현재 유저정보 리셋
             await AsyncStorage.multiRemove(['accessToken', 'refreshToken', 'name']);
             navigation.dispatch(
@@ -32,7 +32,7 @@ export default function Logout({ navigation }) {
         <TouchableHighlight
             style={{ heigh: hp('6%') }}
             underlayColor='none'
-            onPress={async () => await pressLogoutBtn(navigation)}
+            onPress={() => pressLogoutBtn()}
         >
             <View style={styles.eachPart}>
                 <Text style={{ fontSize: 16, fontWeight: '400' }}>

--- a/frontendv2/functions/requestLogout.js
+++ b/frontendv2/functions/requestLogout.js
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import api from "../config/CustomAxios";
 import { logout } from "../redux/action/user/userAction";
 import store from "../redux/store";
+import { StackActions } from "@react-navigation/native";
 
 /* 공통 로그아웃 */
 export default async function requestLogout(navigation) {


### PR DESCRIPTION
- 로그아웃 Api 이후 오류 여부에 상관없이 로그아웃 처리가 되어야 하기 때문에 catch에 있던 로직을 finally로 이동
- import 되지 않았던 StackActions import