### PR TITLE
[백엔드] CaregiverProfileRepository에 리스트 조회하는 getProfileList() 구현 완료

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -87,7 +87,7 @@ export class CaregiverProfileMapper {
 
     /* 클라이언트 데이터 노출에 맞게 가능 지역 변환 */
     private toDtoAreaList(areaList: string[]): string[] | string {
-        return areaList.length >= 4 ? '상세보기참고' : areaList;
+        return areaList.length >= 4 ? '상세보기참고' : areaList.join(',');
     }
 
     private toLicenseList(licenseList: string[]): License[] {

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -3,8 +3,16 @@ import { Warning } from "./warning.entity";
 import { PossibleDate } from "../../enum/possible-date.enum";
 import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
 import { License } from "./license.entity";
+import { ExposeOptions, Transform, TransformFnParams } from 'class-transformer';
+
+/* _id 필드 plainToInstance 시 새로 할당하지 않기 위해 그대로 노출 */
+const ExposeId = (options?: ExposeOptions) =>
+((target: Object, propertyKey: string) => {
+    Transform((params: TransformFnParams) => params.obj[propertyKey])(target, propertyKey);
+});
 
 export class CaregiverProfile {
+    @ExposeId()
     readonly _id: ObjectId;
     private userId: number; // mysql 사용자 계정 ID
     private weight: number; // 몸무게
@@ -15,12 +23,12 @@ export class CaregiverProfile {
     private notice: string; // 공지
     private helpExperience: CaregiverHelpExperience; //간병 경험
     private additionalChargeCase: string; //추가 요금 상황
-    private possibleAreaList: string []; // 지역
-    private licenseList: License []; // 자격증
-    private strengthList: string []; // 강점
-    private tagList: string []; // 키워드
+    private possibleAreaList: string[]; // 지역
+    private licenseList: License[]; // 자격증
+    private strengthList: string[]; // 강점
+    private tagList: string[]; // 키워드
     private isPrivate: boolean; // 프로필 비공개, 공개
-    private warningList: Warning [];
+    private warningList: Warning[];
 
     constructor(id: ObjectId) { this._id = id; };
 
@@ -34,12 +42,12 @@ export class CaregiverProfile {
     setNotice(notice: string) { this.notice = notice; };
     setHelpExperience(experience: CaregiverHelpExperience) { this.helpExperience = experience; };
     setAdditionalChargeCase(situation: string) { this.additionalChargeCase = situation; };
-    setPossibleAreaList(areaList: string []) { this.possibleAreaList = areaList; };
-    setLicenseList(licenseList: License []) { this.licenseList = licenseList; };
-    setStrengthList(strengthList: string []) { this.strengthList = strengthList; };
-    setTagList(tagList: string []) { this.tagList = tagList; };
+    setPossibleAreaList(areaList: string[]) { this.possibleAreaList = areaList; };
+    setLicenseList(licenseList: License[]) { this.licenseList = licenseList; };
+    setStrengthList(strengthList: string[]) { this.strengthList = strengthList; };
+    setTagList(tagList: string[]) { this.tagList = tagList; };
     setIsPrivate(isPrivate: boolean) { this.isPrivate = isPrivate; };
-    setWarning(warningList: Warning []) { this.warningList = warningList; };
+    setWarning(warningList: Warning[]) { this.warningList = warningList; };
 
     getId(): string { return this._id.toHexString(); };
     getUserId(): number { return this.userId; };
@@ -47,9 +55,9 @@ export class CaregiverProfile {
     getPay(): number { return this.pay; };
     getPossibleDate(): number { return this.possibleDate; };
     getHelpExperience(): CaregiverHelpExperience { return this.helpExperience; };
-    getPossibleAreaList(): string [] { return this.possibleAreaList; };
+    getPossibleAreaList(): string[] { return this.possibleAreaList; };
     getLicenseList(): License[] { return this.licenseList; };
-    getTagList(): string [] { return this.tagList; };
+    getTagList(): string[] { return this.tagList; };
     getStrengthList(): string[] { return this.strengthList; };
     getIsPrivate(): boolean { return this.isPrivate; };
     getNotice(): string { return this.notice; };

--- a/backend/src/profile/infra/repository/caregiver-profile.repository.ts
+++ b/backend/src/profile/infra/repository/caregiver-profile.repository.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { plainToInstance } from "class-transformer";
-import { Db, ObjectId, WithId } from "mongodb";
+import { AggregationCursor, Db, Document, ObjectId, WithId } from "mongodb";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { ICaregiverProfileRepository } from "src/profile/domain/repository/icaregiver-profile.repository";
 
@@ -28,7 +28,7 @@ export class CaregiverProfileRepository implements ICaregiverProfileRepository<W
                                 .collection<CaregiverProfile>(this.collectionName)
                                 .findOne({ _id: new ObjectId(id) });
         
-        return plainToInstance(CaregiverProfile, findProfile); 
+        return this.documentToInstance(findProfile);
     }
 
     async findByUserId(userId: number): Promise<CaregiverProfile> {
@@ -37,12 +37,53 @@ export class CaregiverProfileRepository implements ICaregiverProfileRepository<W
                                 .aggregate()
                                 .match({ userId })
                                 .toArray();
-        return plainToInstance(CaregiverProfile, findProfile);
+        
+        return this.documentToInstance(findProfile);
     }
 
     async delete(id: string): Promise<void> {
         await this.mongodb
             .collection<CaregiverProfile>(this.collectionName)
             .deleteOne({ _id: new ObjectId(id) });
+    }
+
+    /* 데이터에 접근할 수 있는 Cursor 반환 */
+    getProfileList(lastProfileId?: string): AggregationCursor {
+        return this.mongodb
+                .collection(this.collectionName)
+                .aggregate(this.profileListPipelineStage(lastProfileId))
+                .batchSize(20)
+    }
+
+    /* 조회된 Document를 인스턴스로 변경 */
+    private documentToInstance(document: WithId<CaregiverProfile> | Document): CaregiverProfile {
+        return plainToInstance(CaregiverProfile, document);
+    }
+
+    /* 프로필 리스트 조회하는 Stage */
+    private profileListPipelineStage = (lastProfileId: string) => [
+        { $match: 
+            {
+            ...this.ltProfileId(lastProfileId),
+            isPrivate: false
+            }
+        },
+        { $sort: { _id: -1 }},
+        { $project: {
+            userId: 1,
+            career: 1,
+            pay: 1,
+            notice: 1,
+            possibleDate: 1,
+            possibleAreaList: 1,
+            tagList: 1
+        }}
+    ]
+
+    /* 마지막 프로필 아이디보다 오래된 프로필들 받아오기 위해 */
+    private ltProfileId(profileId: string): null | { _id: { $lt: ObjectId }} {
+        if( !profileId ) return null;
+
+        return { _id: { $lt: new ObjectId(profileId) } };
     }
 }

--- a/backend/test/unit/__mock__/profile/repository.mock.ts
+++ b/backend/test/unit/__mock__/profile/repository.mock.ts
@@ -1,0 +1,13 @@
+import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository";
+
+/* Mocking CaregiverProfileRepository */
+export const MockCaregiverProfileRepository = {
+    provide: CaregiverProfileRepository,
+    useValue: {
+        save: jest.fn(),
+        findById: jest.fn(),
+        findByUserId: jest.fn(),
+        delete: jest.fn(),
+        getProfileList: jest.fn()
+    }
+};

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -67,8 +67,7 @@ describe('Caregiver Profile Mapper Component Test', () => {
         });
 
         it.each([
-            [[], []],
-            [['인천', '서울'], ['인천', '서울']],
+            [['인천', '서울'], '인천,서울'],
             [['인천', '서울', '경기', '부산'], '상세보기참고']
         ])('possibleAreaList(가능한 지역)이 클라이언트 화면용 값으로 변경되는지 확인', (testAreaList, expectedAreaList) => {
             const userStub = TestUser.default() as unknown as User;

--- a/backend/test/unit/profile/profile.fixtures.ts
+++ b/backend/test/unit/profile/profile.fixtures.ts
@@ -1,16 +1,24 @@
 import { ObjectId } from "mongodb";
 import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.builder";
+import { License } from "src/profile/domain/entity/caregiver/license.entity";
 
 export class TestCaregiverProfile {
     static default() {
         return new CaregiverProfileBuilder(new ObjectId())
             .userId(1)
+            .weight(50)
             .career(10)
             .pay(10)
+            .possibleDate(1)
+            .possibleAreaList(['인천', '서울'])
+            .nextHosptial('다음 병원 여부')
             .tagList(['태그1', '태그2', '태그3'])
             .isPrivate(false)
             .notice('공지사항입니다.')
-            .possibleAreaList(['인천', '서울'])
-            .possibleDate(1)
+            .additionalChargeCase('추가요금이 붙는 상황')
+            .helpExperience({ suction: '석션 관련 내용'})
+            .licenseList([new License('자격증1', false), new License('자격증2', false)])
+            .strengthList(['강점1'])
+            .warningList(null)
     }
 }


### PR DESCRIPTION
프로필의 리스트를 조회하고 해당 프로필의 주인인 사용자의 기본 정보도 가져와야 하기 때문에 getProfileList() 메서드에서는 cursor를 반환