### PR TITLE
[백엔드] CaregiverProfileService에 프로필 리스트 조회하는 getProfileList() 추가

### DIFF
--- a/backend/src/profile/application/service/caregiver-profile.service.ts
+++ b/backend/src/profile/application/service/caregiver-profile.service.ts
@@ -3,13 +3,19 @@ import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-regist
 import { CaregiverProfileMapper } from "../mapper/caregiver-profile.mapper";
 import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
+import { concatMap, firstValueFrom, from, mergeMap, toArray } from "rxjs";
+import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service";
+import { plainToInstance } from "class-transformer";
+import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
 
 @Injectable()
 export class CaregiverProfileService {
     constructor(
         private readonly caregiverProfileMapper: CaregiverProfileMapper,
-        private readonly caregiverProfileRepository: CaregiverProfileRepository
+        private readonly caregiverProfileRepository: CaregiverProfileRepository,
+        private readonly userCommonService: UserAuthCommonService
     ) {}
+    
     /* 회원가입시 새로운 프로필 추가 */
     async addProfile(userId: number, caregiverRegisterDto: CaregiverRegisterDto): Promise<void> {
         const caregiverProfile = this.caregiverProfileMapper.mapFrom(userId, caregiverRegisterDto);
@@ -19,5 +25,25 @@ export class CaregiverProfileService {
     /* 사용자 아이디로 프로필 조회 */
     async getProfileByUserId(userId: number): Promise<CaregiverProfile> {
         return await this.caregiverProfileRepository.findByUserId(userId)
+    }
+
+    /* 프로필 리스트 조회 */
+    async getProfileList(lastProfileId?: string): Promise<ProfileListDto []> {
+        const profileCursor = this.caregiverProfileRepository.getProfileList(lastProfileId);
+
+        return await firstValueFrom(
+            from(profileCursor)
+            .pipe(
+                concatMap(async (profile: CaregiverProfile) => 
+                    await this.fetchUserAndMerge(plainToInstance(CaregiverProfile, profile))),
+                toArray()
+            )
+        )
+    }
+ 
+    /* 사용자 id를 받아오면서 profile 형식에 맞춰서 변경 */
+    private async fetchUserAndMerge(profile: CaregiverProfile): Promise<ProfileListDto> { 
+        const user = await this.userCommonService.findUserById(profile.getUserId());
+        return this.caregiverProfileMapper.toListDto(user, profile);
     }
 }

--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { Public } from "src/auth/application/decorator/public.decorator";
+import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
+import { ProfileListDto } from "../dto/profile-list.dto";
+
+@Controller('profile')
+export class ProfileController {
+
+    constructor(
+        private readonly caregiverProfileService: CaregiverProfileService
+    ) {};
+
+    @Public()
+    @Get('list')
+    async getProfileList(@Query('lastProfileId') lastProfileId?: string): Promise<ProfileListDto []> {
+        return await this.caregiverProfileService.getProfileList(lastProfileId);
+    }
+}

--- a/backend/src/profile/profile.module.ts
+++ b/backend/src/profile/profile.module.ts
@@ -7,10 +7,16 @@ import { PatientProfileService } from "./application/service/patient-profile.ser
 import { PatientProfileRepository } from "./infra/repository/patient-profile.repository";
 import { CaregiverProfileMapper } from "./application/mapper/caregiver-profile.mapper";
 import { MongodbModule } from "src/common/shared/database/mongodb/mongodb.module";
+import { UserAuthCommonModule } from "src/user-auth-common/user-auth-common.module";
+import { ProfileController } from "./interface/controller/profile.controller";
 
 @Module({
     imports: [
+        UserAuthCommonModule,
         MongodbModule
+    ],
+    controllers: [
+        ProfileController
     ],
     providers: [
         CaregiverProfileBuilder,

--- a/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
+++ b/backend/test/unit/__mock__/user-auth-common/repository.mock.ts
@@ -7,6 +7,7 @@ export const MockUserRepository = {
     provide: getRepositoryToken(User),
     useValue: {
         save: jest.fn(),
+        findById: jest.fn(),
         findByRefreshKey: jest.fn(),
         findByPhoneNumber: jest.fn()
     }

--- a/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
+++ b/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
@@ -1,0 +1,64 @@
+import { Test } from "@nestjs/testing";
+import { CaregiverProfileMapper } from "src/profile/application/mapper/caregiver-profile.mapper"
+import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
+import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository"
+import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service"
+import { MockCaregiverProfileRepository } from "test/unit/__mock__/profile/repository.mock";
+import { MockCaregiverProfileMapper } from "test/unit/__mock__/profile/service.mock";
+import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock";
+import { TestCaregiverProfile } from "../../profile.fixtures";
+import { AggregationCursor } from "mongodb";
+import { TestUser } from "test/unit/user/user.fixtures";
+import { Observable } from 'rxjs';
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+
+describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
+    let caregiverProfileRepository: CaregiverProfileRepository,
+        caregiverProfileMapper: CaregiverProfileMapper,
+        userCommonService: UserAuthCommonService,
+        caregiverProfileService: CaregiverProfileService;
+    
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                CaregiverProfileService,
+                MockCaregiverProfileRepository,
+                MockCaregiverProfileMapper,
+                MockUserAuthCommonService
+            ]
+        }).compile();
+
+        caregiverProfileMapper = module.get(CaregiverProfileMapper);
+        caregiverProfileRepository = module.get(CaregiverProfileRepository);
+        userCommonService = module.get(UserAuthCommonService);
+        caregiverProfileService = module.get(CaregiverProfileService);
+    });
+
+    describe('getProfileList()', () => {
+        it('프로필 리스트의 개수만큼 사용자의 프로필 데이터를 조회하는지 확인', async () => {
+            const [userId1, userId2] = [11, 20];
+
+            const profileStub1 = TestCaregiverProfile.default().userId(userId1).build();
+            const profileStub2 = TestCaregiverProfile.default().userId(userId2).build();
+            
+            const profileList = new Observable((subscribe) => {
+                subscribe.next(profileStub1);
+                subscribe.next(profileStub2);
+                subscribe.complete();
+            }) as unknown as AggregationCursor;
+    
+            const userStub1 = TestUser.default().withId(userId1) as unknown as User;
+            const userStub2 = TestUser.default().withId(userId2) as unknown as User;
+    
+            jest.spyOn(caregiverProfileRepository, 'getProfileList').mockReturnValueOnce(profileList);
+            jest.spyOn(userCommonService, 'findUserById')
+                .mockResolvedValueOnce(userStub1)
+                .mockResolvedValueOnce(userStub2);
+
+            await caregiverProfileService.getProfileList();
+
+            expect(userCommonService.findUserById).toHaveBeenCalledTimes(2);
+            expect(caregiverProfileMapper.toListDto).toHaveBeenCalledTimes(2);
+        })
+    })
+})


### PR DESCRIPTION
**CaregiverProfileRepository**로부터 받은 **cursor**로 순회하며 해당 프로필 사용자의 기본 정보를 받아와 클라이언트 노출 형식에 맞춰 가공하여 반환

