### PR TITLE
[백엔드] 세션리스트에 저장된 토큰과 요청 토큰이 일치하는지 확인하는 로직 구현

### DIFF
--- a/backend/src/auth/application/service/token.service.ts
+++ b/backend/src/auth/application/service/token.service.ts
@@ -48,6 +48,20 @@ export class TokenService {
         return new RefreshToken(uuid, refreshToken);   
     };
 
+    /* Request의 Header로부터 토큰 추출 */
+    extractTokenFromHeader(request: any): string {
+        const { authorization } = request.headers;
+        return authorization.split(' ')[1];
+    }
+
+    /* 토큰의 payload를 구하는 메서드 */
+    decode(token: string): JwtPayload {
+        return this.jwtService.decode(token, {
+            complete: false,
+            json: true
+        }) as JwtPayload;
+    }
+
     /* JwtToken의 Payload 생성 */
     private generateJwtPayload(user: User): JwtPayload {
         return {

--- a/backend/test/unit/__mock__/auth/service.mock.ts
+++ b/backend/test/unit/__mock__/auth/service.mock.ts
@@ -32,7 +32,9 @@ export const MockTokenService = {
     useValue: {
         generateNewUsersToken: jest.fn(),
         generateAccessToken: jest.fn(),
-        generateRefreshToken: jest.fn()
+        generateRefreshToken: jest.fn(),
+        extractTokenFromHeader: jest.fn(),
+        decode: jest.fn()
     }
 };
 

--- a/backend/test/unit/auth/application/service/token-service.spec.ts
+++ b/backend/test/unit/auth/application/service/token-service.spec.ts
@@ -3,24 +3,25 @@ import { JwtService } from "@nestjs/jwt"
 import { Test } from "@nestjs/testing"
 import { TokenService } from "src/auth/application/service/token.service"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum"
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
 import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
 import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
 import { TestUser } from "test/unit/user/user.fixtures"
 
 describe('토큰 서비스(TokenService) Test', () => {
-    let tokenService: TokenService; 
+    let tokenService: TokenService;
     let jwtService: JwtService;
     let userStub: User;
 
-    beforeAll(async() => {
+    beforeAll(async () => {
         const module = await Test.createTestingModule({
             providers: [
                 {
                     provide: ConfigService,
                     useValue: {
                         get: jest.fn((key: string) => {
-                            switch(key) {
+                            switch (key) {
                                 case 'jwt.accessToken.secret':
                                     return 'test_access';
                                 case 'jwt.accessToken.expiresIn':
@@ -41,21 +42,21 @@ describe('토큰 서비스(TokenService) Test', () => {
         tokenService = module.get(TokenService);
     });
 
-    beforeEach(() => userStub = TestUser.default() as unknown as User )
+    beforeEach(() => userStub = TestUser.default() as unknown as User)
 
     describe('generateNewUsersToken()', () => {
-        it('반환된 객체는 NewUserAuthentication의 인스턴스여야한다', async() => {
+        it('반환된 객체는 NewUserAuthentication의 인스턴스여야한다', async () => {
             jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce('testAccess');
             jest.spyOn(tokenService, 'generateRefreshToken').mockResolvedValueOnce(null);
             const result = await tokenService.generateNewUsersToken(userStub);
 
             expect(result).toBeInstanceOf(NewUserAuthentication);
-        }); 
+        });
 
-        it('생성된 토큰들에는 값들이 비어있으면 안된다', async() => {
+        it('생성된 토큰들에는 값들이 비어있으면 안된다', async () => {
             const testAccessToken = 'testAccess';
             jest.spyOn(tokenService, 'generateAccessToken').mockResolvedValueOnce(testAccessToken);
-            
+
             const [testKey, testRefreshToken] = ['uuid', 'testRefresh'];
             const refreshToken = new RefreshToken('uuid', 'testRefresh');
             jest.spyOn(tokenService, 'generateRefreshToken').mockResolvedValueOnce(refreshToken);
@@ -67,15 +68,15 @@ describe('토큰 서비스(TokenService) Test', () => {
         })
     })
 
-    describe('generateRefreshToken()',() => {
-        it('반환된 객체는 RefreshToken의 인스턴스여야한다', async() => {
+    describe('generateRefreshToken()', () => {
+        it('반환된 객체는 RefreshToken의 인스턴스여야한다', async () => {
             jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce('testRefresh');
             const result = await tokenService.generateRefreshToken(userStub);
 
             expect(result).toBeInstanceOf(RefreshToken);
         });
 
-        it('생성된 refreshToken의 토큰은 get으로 조회해보면 같아야 한다.', async() => {
+        it('생성된 refreshToken의 토큰은 get으로 조회해보면 같아야 한다.', async () => {
             const refreshToken = 'testRefreshToken';
             jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce(refreshToken);
             const result = await tokenService.generateRefreshToken(userStub);
@@ -83,11 +84,11 @@ describe('토큰 서비스(TokenService) Test', () => {
             expect(result.getToken()).toBe(refreshToken);
         });
 
-        it('RefreshToken이 생성될때마다 Key값과 토큰값은 달라야한다.', async() => {
+        it('RefreshToken이 생성될때마다 Key값과 토큰값은 달라야한다.', async () => {
             const beforeRefreshToken = 'beforeToken';
             const afterRefreshToken = 'afterToken';
             jest.spyOn(jwtService, 'signAsync').mockResolvedValueOnce(beforeRefreshToken)
-                                                .mockResolvedValueOnce(afterRefreshToken);
+                .mockResolvedValueOnce(afterRefreshToken);
 
             const beforeResult = await tokenService.generateRefreshToken(userStub);
             const afterResult = await tokenService.generateRefreshToken(userStub);
@@ -95,5 +96,36 @@ describe('토큰 서비스(TokenService) Test', () => {
             expect(beforeResult.getKey()).not.toBe(afterResult.getKey());
             expect(beforeResult.getToken()).not.toBe(afterResult.getToken());
         });
+    });
+
+    describe('extractTokenFromHeader()', () => {
+        it('요청의 헤더로부터 토큰이 추출되는지 확인', () => {
+            const testToken = 'authorizationToken';
+
+            const mockRequest = {
+                headers: {
+                    authorization: `Bearer ${testToken}`
+                }
+            };
+
+            const result = tokenService.extractTokenFromHeader(mockRequest);
+
+            expect(result).toBe(testToken);
+        });
+    });
+
+    describe('decode()', () => {
+        it('정상적으로 디코딩이 되는지 확인', () => {
+            const payload = { userId: 1, role: ROLE.CAREGIVER, createdAt: new Date() };
+            
+            jest.spyOn(tokenService, 'decode').mockReturnValueOnce(payload);
+
+            const result = tokenService.decode('');
+
+            expect(result).toEqual(payload);
+            expect(result).toHaveProperty('userId');
+            expect(result).toHaveProperty('role');
+            expect(result).toHaveProperty('createdAt');
+        })
     })
 })


### PR DESCRIPTION
유효한 토큰을 탈취당했을 경우 기존 로직대로라면 이용할 수 있기에 세션 리스트에 존재하는 토큰인지 확인하는 로직 추가

jwtService를 이용하던 로직을 tokenService 내로 옮겨 tokenService를 주입 받도록 수정