### PR TITLE
[백엔드] 간병인 프로필 상세보기 페이지에 맞추는 Mapper 메서드 추가

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -38,6 +38,7 @@ import { RefreshAuthenticationGuard } from './application/guard/refresh-authenti
   ],
   exports: [
     SessionService,
+    TokenService,
     AuthService,
     PhoneVerificationRepository
   ]

--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -4,6 +4,7 @@ import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.buil
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
+import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
 import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 
@@ -44,12 +45,49 @@ export class CaregiverProfileMapper {
                 career: this.toDtoCareer(caregiverProfile.getCareer()),
                 pay: caregiverProfile.getPay(),
                 possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
-                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList()),
+                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'list'),
                 tagList: caregiverProfile.getTagList(),
                 notice: caregiverProfile.getNotice()
             }
         }
     };
+
+    /* 프로필 상세보기에 필요한 데이터에 맞춰 변환 */
+    toDetailDto(user: User, caregiverProfile: CaregiverProfile): ProfileDetailDto {
+        return {
+            user: {
+                name: user.getName(),
+                sex: user.getProfile().getSex(),
+                age: this.toDtoAge(user.getProfile().getBirth())
+            },
+            profile: {
+                _id: caregiverProfile.getId(),
+                userId: caregiverProfile.getUserId(),
+                career: this.toDtoCareer(caregiverProfile.getCareer()),
+                pay: caregiverProfile.getPay(),
+                possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
+                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
+                notice: caregiverProfile.getNotice(),
+                licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
+                additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
+                nextHosptial: caregiverProfile.getNextHosptial(),
+                helpExperience: caregiverProfile.getHelpExperience(),
+                strengthList: caregiverProfile.getStrengthList(),
+                warningList: caregiverProfile.getWarningList()
+            }
+        }
+    };
+
+    private toLicenseList(licenseList: string[]): License[] {
+        /* 자격증을 증명전까지 false */
+        return licenseList.map(license => new License(license, false))
+    };
+
+    /* 클라이언트 데이터 노출에 맞게 인증이 완료된 자격증만 노출 */
+    private toDtoLicenseList(licenseList: License []): string [] {
+        return licenseList.filter(license => license.getIsCertified())
+                        .map(certificatedLicense => certificatedLicense.getName());
+    }
 
     /* 클라이언트 데이터 노출에 맞게 나이 변환 */
     private toDtoAge(birth: number): number {
@@ -86,12 +124,8 @@ export class CaregiverProfileMapper {
     };
 
     /* 클라이언트 데이터 노출에 맞게 가능 지역 변환 */
-    private toDtoAreaList(areaList: string[]): string[] | string {
-        return areaList.length >= 4 ? '상세보기참고' : areaList.join(',');
+    private toDtoAreaList(areaList: string[], page: string): string[] | string {
+        /* 메인 페이지에서는 화면이 잘리므로 지역이 많으면 줄여서 노출 */
+        return ( areaList.length >= 4 && page === 'list' ) ? '상세보기참고' : areaList.join(',');
     }
-
-    private toLicenseList(licenseList: string[]): License[] {
-        /* 자격증을 증명전까지 false */
-        return licenseList.map(license => new License(license, false))
-    };
 }

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -53,6 +53,7 @@ export class CaregiverProfile {
     getUserId(): number { return this.userId; };
     getCareer(): number { return this.career; };
     getPay(): number { return this.pay; };
+    getNextHosptial(): string { return this.nextHosptial; };
     getPossibleDate(): number { return this.possibleDate; };
     getHelpExperience(): CaregiverHelpExperience { return this.helpExperience; };
     getPossibleAreaList(): string[] { return this.possibleAreaList; };
@@ -61,5 +62,6 @@ export class CaregiverProfile {
     getStrengthList(): string[] { return this.strengthList; };
     getIsPrivate(): boolean { return this.isPrivate; };
     getNotice(): string { return this.notice; };
+    getAdditionalChargeCase(): string { return this.additionalChargeCase; };
     getWarningList(): Warning[] { return this.warningList; };
 }

--- a/backend/src/profile/interface/dto/profile-detail.dto.ts
+++ b/backend/src/profile/interface/dto/profile-detail.dto.ts
@@ -1,0 +1,26 @@
+import { Warning } from "src/profile/domain/entity/caregiver/warning.entity";
+import { SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
+
+export interface ProfileDetailDto {
+    user: {
+        name: string;
+        sex: SEX;
+        age: number;
+    },
+    profile: {
+        _id: string;
+        userId: number;
+        career: string;
+        pay: number;
+        possibleDate: string;
+        possibleAreaList: string[] | string;
+        notice: string;
+        licenseList: string[] | [];
+        additionalChargeCase: string | null;
+        nextHosptial: string | null;
+        helpExperience: CaregiverHelpExperience,
+        strengthList: string[] | [],
+        warningList: Warning [] | []
+    }
+}

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -25,7 +25,7 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getUserId()).toBe(userId);
 
             mappingResult.getLicenseList()
-                .map( license => {
+                .map(license => {
                     expect(license).toBeInstanceOf(License);
                     expect(license.getName()).toBe('자격증');
                     expect(license.getIsCertified()).toBe(false);
@@ -39,9 +39,9 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getWarningList()).toEqual([]);
         })
     });
-    
-    describe('toDto()', () => {
-        
+
+    describe('toListDto()', () => {
+
         it.each([
             [8, '8개월'],
             [13, '1년 1개월'],
@@ -77,12 +77,12 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(result.profile.possibleAreaList).toEqual(expectedAreaList);
         });
 
-        it('toDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
+        it('toListDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
             const userStub = TestUser.default() as unknown as User;
             const profileStub = TestCaregiverProfile.default().build();
 
             const result = profileMapper.toListDto(userStub, profileStub);
-            
+
             expect(result).toHaveProperty('user');
             expect(result).toHaveProperty('profile');
 
@@ -98,6 +98,63 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(result.profile).toHaveProperty('possibleAreaList');
             expect(result.profile).toHaveProperty('tagList');
             expect(result.profile).toHaveProperty('notice');
+        })
+    });
+
+    describe('toDetailDto()', () => {
+        let userStub: User;
+
+        beforeAll(() => userStub = TestUser.default() as unknown as User );
+
+        it('가능한 지역을 상세페이지에선 모두 나열해주는지 확인', () => {
+            const possibleAreaList = ['인천', '서울', '부산', '대구', '포항'];
+            const expectedArea = '인천,서울,부산,대구,포항';
+
+            const profileStub = TestCaregiverProfile.default()
+                                                    .possibleAreaList(possibleAreaList)
+                                                    .build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.profile.possibleAreaList).toBe(expectedArea);
+        });
+
+        it('인증이 완료된 자격증의 이름은 포함되고, 완료되지 않은 자격증은 포함되지 않는지 확인', () => {
+            const [unCertificatedLicense, certificatedLicense] = ['자격증1', '자격증2'];
+            const licenseList = [new License(unCertificatedLicense, false), new License(certificatedLicense, true)];
+            const expectedLicense = [certificatedLicense];
+
+            const profileStub = TestCaregiverProfile.default()
+                                                    .licenseList(licenseList)
+                                                    .build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.profile.licenseList).toEqual(expectedLicense);
+        })
+
+        it('toDetailDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
+            const profileStub = TestCaregiverProfile.default().build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.user).toHaveProperty('name');
+            expect(result.user).toHaveProperty('sex');
+            expect(result.user).toHaveProperty('age');
+
+            expect(result.profile).toHaveProperty('_id');
+            expect(result.profile).toHaveProperty('userId');
+            expect(result.profile).toHaveProperty('career');
+            expect(result.profile).toHaveProperty('pay');
+            expect(result.profile).toHaveProperty('possibleDate');
+            expect(result.profile).toHaveProperty('possibleAreaList');
+            expect(result.profile).toHaveProperty('notice');
+            expect(result.profile).toHaveProperty('licenseList');
+            expect(result.profile).toHaveProperty('additionalChargeCase');
+            expect(result.profile).toHaveProperty('nextHosptial');
+            expect(result.profile).toHaveProperty('helpExperience');
+            expect(result.profile).toHaveProperty('strengthList');
+            expect(result.profile).toHaveProperty('warningList');
         })
     })
 })


### PR DESCRIPTION
**toDetailDto()** 메서드 추가

메인 페이지에 조금더 간소화된 데이터를 뿌리는 toListDto()와 toDtoAreaList()가 겹쳐 **page**를 파라미터로 받아 구별

**toDtoAreaList(areaList, page)**
page가 'list'면 지역의 개수가 많으면 상세보기참고로 나타내고, 아니라면 모든 지역 나열