### PR TITLE
[백엔드] 간병인 프로필 상세보기 Api Service 구현

### DIFF
--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -9,5 +9,6 @@ export const enum ErrorMessage {
     NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
     InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
     NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.',
-    ExpiredToken = 'jwt expired'
+    ExpiredToken = 'jwt expired',
+    NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.'
 }

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -4,6 +4,8 @@ import { PossibleDate } from "../../enum/possible-date.enum";
 import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
 import { License } from "./license.entity";
 import { ExposeOptions, Transform, TransformFnParams } from 'class-transformer';
+import { NotFoundException } from '@nestjs/common';
+import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
 
 /* _id 필드 plainToInstance 시 새로 할당하지 않기 위해 그대로 노출 */
 const ExposeId = (options?: ExposeOptions) =>
@@ -64,4 +66,10 @@ export class CaregiverProfile {
     getNotice(): string { return this.notice; };
     getAdditionalChargeCase(): string { return this.additionalChargeCase; };
     getWarningList(): Warning[] { return this.warningList; };
+
+    /* 프로필이 비공개인지 확인 */
+    checkPrivacy(): void {
+        if( this.isPrivate )
+            throw new NotFoundException(ErrorMessage.NotFoundProfile);
+    }
 }

--- a/backend/test/unit/__mock__/profile/service.mock.ts
+++ b/backend/test/unit/__mock__/profile/service.mock.ts
@@ -25,5 +25,6 @@ export const MockCaregiverProfileMapper = {
     useValue: {
         mapFrom: jest.fn(),
         toListDto: jest.fn(),
+        toDetailDto: jest.fn()
     }
 }

--- a/backend/test/unit/__mock__/rank/rank-service.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-service.mock.ts
@@ -1,0 +1,9 @@
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
+
+/* MockingProfileViewRankService */
+export const MockProfileViewRankService = {
+    provide: ProfileViewRankService,
+    useValue: {
+        increment: jest.fn()
+    }
+}


### PR DESCRIPTION
프로필 아이디가 파라미터로 넘어오면 해당 프로필을 조회하고 CaregiverProfile객체의 **checkPrivacy()**로 비공개인지 체크

이후에 보호자가 많이 조회한 프로필을 제공하기 위해 조회한 사용자가 보호자라면 **ProfileViewRankService** 호출

이후 화면에 필요한 데이터에 맞게 Mapper를 통해 가공 후 클라이언트로 전달