### PR TITLE
[백엔드] RankModule과 프로필 조회한 사용자 기록 Repository 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { NotificationModule } from './notification/notification.module';
 import { BatchModule } from './batch/batch.module';
 import { GlobalScopedJwtGuard } from './auth/application/guard/jwt/jwt-auth.guard';
 import { ProfileModule } from './profile/profile.module';
+import { RankModule } from './rank/rank.module';
 
 @Module({
   imports: [
@@ -32,7 +33,8 @@ import { ProfileModule } from './profile/profile.module';
     NotificationModule,
     UserAuthCommonModule,
     UserModule,
-    ProfileModule
+    ProfileModule,
+    RankModule
   ],
   providers: [
     GlobalScopedValidationPipe,

--- a/backend/src/common/shared/database/mysql/typeorm.option.ts
+++ b/backend/src/common/shared/database/mysql/typeorm.option.ts
@@ -1,5 +1,6 @@
 import { ConfigModule, ConfigService } from "@nestjs/config"
 import { TypeOrmModuleAsyncOptions } from "@nestjs/typeorm"
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity"
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
@@ -16,7 +17,7 @@ export const TypeOrmOptions: TypeOrmModuleAsyncOptions = {
         username: configService.get('db.mysql.username'),
         password: configService.get('db.mysql.password'),
         database: configService.get('db.mysql.database'),
-        entities: [User, Email, Phone, UserProfile, Token],
+        entities: [User, Email, Phone, UserProfile, Token, ProfileViewRecord],
         logging: true,
         synchronize: true
     })

--- a/backend/src/profile/profile.module.ts
+++ b/backend/src/profile/profile.module.ts
@@ -9,11 +9,13 @@ import { CaregiverProfileMapper } from "./application/mapper/caregiver-profile.m
 import { MongodbModule } from "src/common/shared/database/mongodb/mongodb.module";
 import { UserAuthCommonModule } from "src/user-auth-common/user-auth-common.module";
 import { ProfileController } from "./interface/controller/profile.controller";
+import { RankModule } from "src/rank/rank.module";
 
 @Module({
     imports: [
         UserAuthCommonModule,
-        MongodbModule
+        MongodbModule,
+        RankModule
     ],
     controllers: [
         ProfileController

--- a/backend/src/rank/domain/entity/profile-view-record.entity.ts
+++ b/backend/src/rank/domain/entity/profile-view-record.entity.ts
@@ -1,0 +1,28 @@
+import { UUIDTransformer } from "src/user-auth-common/domain/entity/transformer";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity('profile_view_record')
+export class ProfileViewRecord {
+    
+    @PrimaryGeneratedColumn('increment')
+    private id: number;
+
+    @Column({ 
+        name: 'profile_id', 
+        type: 'binary', 
+        length: 16, 
+        transformer: new UUIDTransformer() 
+    })
+    private profileId: string;
+
+    @Column({ name: 'user_id' })
+    private userId: number;
+
+    constructor(profileId: string, viewUserId: number) {
+        this.profileId = profileId;
+        this.userId = viewUserId;
+    };
+    
+    getProfileId(): string { return this.profileId; };
+    getViewUser(): number { return this.userId; };
+}

--- a/backend/src/rank/domain/iaction-record.repository.ts
+++ b/backend/src/rank/domain/iaction-record.repository.ts
@@ -1,0 +1,8 @@
+import { Repository } from "typeorm";
+import { ProfileViewRecord } from "./entity/profile-view-record.entity";
+
+export interface IActionRecordRepository<T> extends Repository<T>{
+    /* 특정 Action을 수행한 사용자가 있는지 기록 검사 */
+    findRecordByActionAndUser(action: string, userId: number): Promise<ProfileViewRecord>;
+};
+

--- a/backend/src/rank/infra/profile-view-record.repository.ts
+++ b/backend/src/rank/infra/profile-view-record.repository.ts
@@ -1,0 +1,28 @@
+import { DataSource, Repository } from "typeorm";
+import { ProfileViewRecord } from "../domain/entity/profile-view-record.entity";
+import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
+import { IActionRecordRepository } from "../domain/iaction-record.repository";
+import { UUIDUtil } from "src/util/uuid.util";
+
+export const profileViewRecordRepoMethods: Pick<
+    IActionRecordRepository<ProfileViewRecord>,
+    'findRecordByActionAndUser'
+> = {
+    async findRecordByActionAndUser(this: Repository<ProfileViewRecord>, profileId: string, userId: number)
+    :Promise<ProfileViewRecord> {
+        return await this.createQueryBuilder('pvr')
+                .where('pvr.profile_id = :profileId', { profileId: UUIDUtil.toBinaray(profileId) })
+                .andWhere('pvr.user_id = :userId', { userId })
+                .getOne();
+    }
+};
+
+export const ProfileViewRecordRepoProvider = {
+    provide: getRepositoryToken(ProfileViewRecord),
+    inject: [getDataSourceToken()],
+    useFactory(dataSource: DataSource) {
+        return dataSource
+            .getRepository(ProfileViewRecord)
+            .extend(profileViewRecordRepoMethods)
+    }
+};

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { ProfileViewRecordRepoProvider } from "./infra/profile-view-record.repository";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ProfileViewRecord]),
+    ],
+    providers: [
+        ProfileViewRecordRepoProvider
+    ],
+})
+
+export class RankModule {}

--- a/backend/test/unit/common/database/datebase-setup.fixture.ts
+++ b/backend/test/unit/common/database/datebase-setup.fixture.ts
@@ -1,6 +1,7 @@
 import { TypeOrmModuleOptions } from "@nestjs/typeorm";
 import { Db, MongoClient } from "mongodb";
 import { RedisClientType, createClient } from "redis";
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
@@ -40,7 +41,7 @@ export const TestTypeOrmOptions: TypeOrmModuleOptions = {
     port: 3306,
     password: '1234',
     database: 'test_caregiver_project',
-    entities: [User, Phone, Email, UserProfile, Token],
+    entities: [User, Phone, Email, UserProfile, Token, ProfileViewRecord],
     synchronize: true,
     logging: true
 }


### PR DESCRIPTION
프로필 상세보기 Api에 보호자가 조회 시 조회순으로 순위를 매겨 사용자에게 제공하기 때문에 관련 로직을 담은 Rank Module 추가

순위를 매겨 제공하는 기능(많이 검색한 키워드)이 추가로 있어 사용자가 어떤 Action을 했는지를 저장한 저장소 interface를 제공