### PR TITLE
[백엔드] 프로필 조회 랭킹 service 구현

### DIFF
--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param,  Query } from "@nestjs/common";
 import { Public } from "src/auth/application/decorator/public.decorator";
 import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
 import { ProfileListDto } from "../dto/profile-list.dto";
+import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Controller('profile')
 export class ProfileController {
@@ -14,5 +16,10 @@ export class ProfileController {
     @Get('list')
     async getProfileList(@Query('lastProfileId') lastProfileId?: string): Promise<ProfileListDto []> {
         return await this.caregiverProfileService.getProfileList(lastProfileId);
+    }
+
+    @Get('detail/:id')
+    async getProfileDetail(@Param('id') profileId: string, @AuthenticatedUser() authenticatedUser: User){
+        return await this.caregiverProfileService.getProfile(profileId, authenticatedUser)
     }
 }

--- a/backend/src/rank/application/service/profile-view-rank.manager.ts
+++ b/backend/src/rank/application/service/profile-view-rank.manager.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { IRankManager } from "../../domain/irank.manager";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
+import { IActionRecordRepository } from "src/rank/domain/iaction-record.repository";
+
+@Injectable()
+export class ProfileViewRankManager implements IRankManager {
+    constructor(
+        @InjectRepository(ProfileViewRecord)
+        private readonly profileViewRecordRepository: IActionRecordRepository<ProfileViewRecord>
+    ) {}
+
+    /* 프로필을 조회한 사용자 기록 */
+    async recordUserAction(profileId: string, viewUserId: number, ): Promise<void> {
+        await this.profileViewRecordRepository.save(new ProfileViewRecord(profileId, viewUserId));
+    };
+
+    /* 해당 사용자가 해당 프로필을 조회했는지 검사 */
+    async isActionPerformedByUser(profileId: string, userId: number): Promise<boolean> {
+        return await this.profileViewRecordRepository
+                            .findRecordByActionAndUser(profileId, userId) ? true : false;
+    }
+}

--- a/backend/src/rank/application/service/profile-view-rank.service.ts
+++ b/backend/src/rank/application/service/profile-view-rank.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { IRankService } from "src/rank/domain/irank.service";
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { ProfileViewRankManager } from "./profile-view-rank.manager";
+
+@Injectable()
+export class ProfileViewRankService implements IRankService {
+    
+    constructor(
+        private readonly profileViewRankRepository: ProfileViewRankRepository,
+        private readonly profileViewRankManager: ProfileViewRankManager
+    ) {};
+
+    async increment(profileId: string, viewUser: User): Promise<void> {
+        /* 만약 해당 프로필을 처음 조회한 사용자라면 명단에 추가이후 조회 집계 증가 */
+        if( !await this.profileViewRankManager.isActionPerformedByUser(profileId, viewUser.getId()) ) {
+            await Promise.all([
+                this.profileViewRankManager.recordUserAction(profileId, viewUser.getId()),
+                this.profileViewRankRepository.increment(profileId)
+            ])
+        }
+    };
+}

--- a/backend/src/rank/domain/irank.manager.ts
+++ b/backend/src/rank/domain/irank.manager.ts
@@ -1,0 +1,5 @@
+/* 프로필 조회, 키워드 검색등 랭킹을 매기는 Action들에 대해 사용자 중복 검사 */
+export interface IRankManager {
+    isActionPerformedByUser(action: string, userId: number): Promise<boolean>;
+    recordUserAction(action: string, userId: number): Promise<void>;
+}

--- a/backend/src/rank/domain/irank.service.ts
+++ b/backend/src/rank/domain/irank.service.ts
@@ -1,0 +1,6 @@
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+
+export interface IRankService {
+    /* 횟수 증가시키는 메서드 */
+    increment(identify: string, viewUser: User): Promise<void>;
+}

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,6 +1,8 @@
 import { Module } from "@nestjs/common";
+import { ProfileViewRankService } from "./application/service/profile-view-rank.service";
 import { ProfileViewRankRepository } from "./infra/profile-view-rank.repository";
 import { RedisModule } from "src/common/shared/database/redis/redis.module";
+import { ProfileViewRankManager } from "./application/service/profile-view-rank.manager";
 import { ProfileViewRecordRepoProvider } from "./infra/profile-view-record.repository";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
@@ -11,9 +13,14 @@ import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
         RedisModule
     ],
     providers: [
+        ProfileViewRankService,
         ProfileViewRankRepository,
+        ProfileViewRankManager,
         ProfileViewRecordRepoProvider
     ],
+    exports: [
+        ProfileViewRankService
+    ]
 })
 
 export class RankModule {}

--- a/backend/test/unit/__mock__/rank/rank-repository.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-repository.mock.ts
@@ -1,0 +1,8 @@
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository";
+
+export const MockProfileViewRankRepository = {
+    provide: ProfileViewRankRepository,
+    useValue: {
+        increment: jest.fn()
+    }
+}

--- a/backend/test/unit/__mock__/rank/rank-service.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-service.mock.ts
@@ -1,3 +1,4 @@
+import { ProfileViewRankManager } from "src/rank/application/service/profile-view-rank.manager";
 import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 
 /* MockingProfileViewRankService */
@@ -5,5 +6,14 @@ export const MockProfileViewRankService = {
     provide: ProfileViewRankService,
     useValue: {
         increment: jest.fn()
+    }
+};
+
+/* Mocking ProfileViewRankManager */
+export const MockProfileViewRankManager = {
+    provide: ProfileViewRankManager,
+    useValue: {
+        recordUserAction: jest.fn(),
+        isActionPerformedByUser: jest.fn()
     }
 }

--- a/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
+++ b/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from "@nestjs/testing"
+import { ProfileViewRankManager } from "src/rank/application/service/profile-view-rank.manager"
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service"
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { UUIDUtil } from "src/util/uuid.util"
+import { MockProfileViewRankRepository } from "test/unit/__mock__/rank/rank-repository.mock"
+import { MockProfileViewRankManager } from "test/unit/__mock__/rank/rank-service.mock"
+import { TestUser } from "test/unit/user/user.fixtures"
+
+describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
+    let profileViewRankRepository: ProfileViewRankRepository;
+    let profileViewRankManager: ProfileViewRankManager;
+    let profileViewRankService: ProfileViewRankService;
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                ProfileViewRankService,
+                MockProfileViewRankRepository,
+                MockProfileViewRankManager
+            ]
+        }).compile();
+        profileViewRankService = module.get(ProfileViewRankService);
+        profileViewRankRepository = module.get(ProfileViewRankRepository);
+        profileViewRankManager = module.get(ProfileViewRankManager);
+    })
+
+    describe('increment()', () => {
+        const [profileId, viewUser] = [UUIDUtil.generateOrderedUuid(), TestUser.default()];
+
+        beforeEach(() => jest.clearAllMocks());
+        
+        it('이미 해당 프로필을 조회한 사용자라면 아무것도 수행하지 않는다.', async() => {
+            jest.spyOn(profileViewRankManager, 'isActionPerformedByUser').mockResolvedValueOnce(true);
+            
+            const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
+            const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
+
+            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+
+            expect(rankSpy).not.toHaveBeenCalled();
+            expect(recordSpy).not.toHaveBeenCalled();
+        });
+
+        it('처음 조회한 사용자라면 조회수를 증가시키고 조회 내역을 기록하기 위한 로직을 호출한다', async() => {
+            jest.spyOn(profileViewRankManager, 'isActionPerformedByUser').mockResolvedValueOnce(false);
+
+            const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
+            const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
+            
+            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+
+            expect(rankSpy).toHaveBeenCalledWith(profileId);
+            expect(recordSpy).toHaveBeenCalledWith(profileId, viewUser.getId());
+        })
+    })
+})


### PR DESCRIPTION
ProfileViewRankService의 increment() 메서드를 호출하면 **RankManager**를 통해 중복 조회를 수행한 사용자인지 검사 이후 조회수와 사용자 조회 기록 추가