### PR TITLE
[백엔드] 프로필 상세조회 Api 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { NotificationModule } from './notification/notification.module';
 import { BatchModule } from './batch/batch.module';
 import { GlobalScopedJwtGuard } from './auth/application/guard/jwt/jwt-auth.guard';
 import { ProfileModule } from './profile/profile.module';
+import { RankModule } from './rank/rank.module';
 
 @Module({
   imports: [
@@ -32,7 +33,8 @@ import { ProfileModule } from './profile/profile.module';
     NotificationModule,
     UserAuthCommonModule,
     UserModule,
-    ProfileModule
+    ProfileModule,
+    RankModule
   ],
   providers: [
     GlobalScopedValidationPipe,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -38,6 +38,7 @@ import { RefreshAuthenticationGuard } from './application/guard/refresh-authenti
   ],
   exports: [
     SessionService,
+    TokenService,
     AuthService,
     PhoneVerificationRepository
   ]

--- a/backend/src/common/shared/database/mysql/typeorm.option.ts
+++ b/backend/src/common/shared/database/mysql/typeorm.option.ts
@@ -1,5 +1,6 @@
 import { ConfigModule, ConfigService } from "@nestjs/config"
 import { TypeOrmModuleAsyncOptions } from "@nestjs/typeorm"
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity"
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
@@ -16,7 +17,7 @@ export const TypeOrmOptions: TypeOrmModuleAsyncOptions = {
         username: configService.get('db.mysql.username'),
         password: configService.get('db.mysql.password'),
         database: configService.get('db.mysql.database'),
-        entities: [User, Email, Phone, UserProfile, Token],
+        entities: [User, Email, Phone, UserProfile, Token, ProfileViewRecord],
         logging: true,
         synchronize: true
     })

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -9,5 +9,6 @@ export const enum ErrorMessage {
     NotExistUserInSessionList = '현재 로그인정보에 없는 사용자입니다.',
     InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
     NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.',
-    ExpiredToken = 'jwt expired'
+    ExpiredToken = 'jwt expired',
+    NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.'
 }

--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -4,6 +4,7 @@ import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.buil
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
+import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
 import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 
@@ -44,12 +45,49 @@ export class CaregiverProfileMapper {
                 career: this.toDtoCareer(caregiverProfile.getCareer()),
                 pay: caregiverProfile.getPay(),
                 possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
-                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList()),
+                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'list'),
                 tagList: caregiverProfile.getTagList(),
                 notice: caregiverProfile.getNotice()
             }
         }
     };
+
+    /* 프로필 상세보기에 필요한 데이터에 맞춰 변환 */
+    toDetailDto(user: User, caregiverProfile: CaregiverProfile): ProfileDetailDto {
+        return {
+            user: {
+                name: user.getName(),
+                sex: user.getProfile().getSex(),
+                age: this.toDtoAge(user.getProfile().getBirth())
+            },
+            profile: {
+                _id: caregiverProfile.getId(),
+                userId: caregiverProfile.getUserId(),
+                career: this.toDtoCareer(caregiverProfile.getCareer()),
+                pay: caregiverProfile.getPay(),
+                possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
+                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
+                notice: caregiverProfile.getNotice(),
+                licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
+                additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
+                nextHosptial: caregiverProfile.getNextHosptial(),
+                helpExperience: caregiverProfile.getHelpExperience(),
+                strengthList: caregiverProfile.getStrengthList(),
+                warningList: caregiverProfile.getWarningList()
+            }
+        }
+    };
+
+    private toLicenseList(licenseList: string[]): License[] {
+        /* 자격증을 증명전까지 false */
+        return licenseList.map(license => new License(license, false))
+    };
+
+    /* 클라이언트 데이터 노출에 맞게 인증이 완료된 자격증만 노출 */
+    private toDtoLicenseList(licenseList: License []): string [] {
+        return licenseList.filter(license => license.getIsCertified())
+                        .map(certificatedLicense => certificatedLicense.getName());
+    }
 
     /* 클라이언트 데이터 노출에 맞게 나이 변환 */
     private toDtoAge(birth: number): number {
@@ -86,12 +124,8 @@ export class CaregiverProfileMapper {
     };
 
     /* 클라이언트 데이터 노출에 맞게 가능 지역 변환 */
-    private toDtoAreaList(areaList: string[]): string[] | string {
-        return areaList.length >= 4 ? '상세보기참고' : areaList.join(',');
+    private toDtoAreaList(areaList: string[], page: string): string[] | string {
+        /* 메인 페이지에서는 화면이 잘리므로 지역이 많으면 줄여서 노출 */
+        return ( areaList.length >= 4 && page === 'list' ) ? '상세보기참고' : areaList.join(',');
     }
-
-    private toLicenseList(licenseList: string[]): License[] {
-        /* 자격증을 증명전까지 false */
-        return licenseList.map(license => new License(license, false))
-    };
 }

--- a/backend/src/profile/application/service/caregiver-profile.service.ts
+++ b/backend/src/profile/application/service/caregiver-profile.service.ts
@@ -3,17 +3,22 @@ import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-regist
 import { CaregiverProfileMapper } from "../mapper/caregiver-profile.mapper";
 import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
-import { concatMap, firstValueFrom, from, mergeMap, toArray } from "rxjs";
+import { concatMap, firstValueFrom, from, toArray } from "rxjs";
 import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service";
 import { plainToInstance } from "class-transformer";
 import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
+import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 
 @Injectable()
 export class CaregiverProfileService {
     constructor(
         private readonly caregiverProfileMapper: CaregiverProfileMapper,
         private readonly caregiverProfileRepository: CaregiverProfileRepository,
-        private readonly userCommonService: UserAuthCommonService
+        private readonly userCommonService: UserAuthCommonService,
+        private readonly profileViewRankService: ProfileViewRankService
     ) {}
     
     /* 회원가입시 새로운 프로필 추가 */
@@ -21,6 +26,18 @@ export class CaregiverProfileService {
         const caregiverProfile = this.caregiverProfileMapper.mapFrom(userId, caregiverRegisterDto);
         await this.caregiverProfileRepository.save(caregiverProfile);
     } 
+
+    /* 프로필 상세보기 */
+    async getProfile(profileId: string, viewUser: User): Promise<ProfileDetailDto> {
+        const profile = await this.caregiverProfileRepository.findById(profileId);
+        profile.checkPrivacy();
+        const user = await this.userCommonService.findUserById(profile.getUserId());
+
+        if( viewUser.getRole() === ROLE.PROTECTOR )
+            await this.profileViewRankService.increment(profileId, viewUser);
+
+        return this.caregiverProfileMapper.toDetailDto(user, profile);
+    }
 
     /* 사용자 아이디로 프로필 조회 */
     async getProfileByUserId(userId: number): Promise<CaregiverProfile> {

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -53,6 +53,7 @@ export class CaregiverProfile {
     getUserId(): number { return this.userId; };
     getCareer(): number { return this.career; };
     getPay(): number { return this.pay; };
+    getNextHosptial(): string { return this.nextHosptial; };
     getPossibleDate(): number { return this.possibleDate; };
     getHelpExperience(): CaregiverHelpExperience { return this.helpExperience; };
     getPossibleAreaList(): string[] { return this.possibleAreaList; };
@@ -61,5 +62,6 @@ export class CaregiverProfile {
     getStrengthList(): string[] { return this.strengthList; };
     getIsPrivate(): boolean { return this.isPrivate; };
     getNotice(): string { return this.notice; };
+    getAdditionalChargeCase(): string { return this.additionalChargeCase; };
     getWarningList(): Warning[] { return this.warningList; };
 }

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -4,6 +4,8 @@ import { PossibleDate } from "../../enum/possible-date.enum";
 import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
 import { License } from "./license.entity";
 import { ExposeOptions, Transform, TransformFnParams } from 'class-transformer';
+import { NotFoundException } from '@nestjs/common';
+import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
 
 /* _id 필드 plainToInstance 시 새로 할당하지 않기 위해 그대로 노출 */
 const ExposeId = (options?: ExposeOptions) =>
@@ -64,4 +66,10 @@ export class CaregiverProfile {
     getNotice(): string { return this.notice; };
     getAdditionalChargeCase(): string { return this.additionalChargeCase; };
     getWarningList(): Warning[] { return this.warningList; };
+
+    /* 프로필이 비공개인지 확인 */
+    checkPrivacy(): void {
+        if( this.isPrivate )
+            throw new NotFoundException(ErrorMessage.NotFoundProfile);
+    }
 }

--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param,  Query } from "@nestjs/common";
 import { Public } from "src/auth/application/decorator/public.decorator";
 import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
 import { ProfileListDto } from "../dto/profile-list.dto";
+import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Controller('profile')
 export class ProfileController {
@@ -14,5 +16,10 @@ export class ProfileController {
     @Get('list')
     async getProfileList(@Query('lastProfileId') lastProfileId?: string): Promise<ProfileListDto []> {
         return await this.caregiverProfileService.getProfileList(lastProfileId);
+    }
+
+    @Get('detail/:id')
+    async getProfileDetail(@Param('id') profileId: string, @AuthenticatedUser() authenticatedUser: User){
+        return await this.caregiverProfileService.getProfile(profileId, authenticatedUser)
     }
 }

--- a/backend/src/profile/interface/dto/profile-detail.dto.ts
+++ b/backend/src/profile/interface/dto/profile-detail.dto.ts
@@ -1,0 +1,26 @@
+import { Warning } from "src/profile/domain/entity/caregiver/warning.entity";
+import { SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
+
+export interface ProfileDetailDto {
+    user: {
+        name: string;
+        sex: SEX;
+        age: number;
+    },
+    profile: {
+        _id: string;
+        userId: number;
+        career: string;
+        pay: number;
+        possibleDate: string;
+        possibleAreaList: string[] | string;
+        notice: string;
+        licenseList: string[] | [];
+        additionalChargeCase: string | null;
+        nextHosptial: string | null;
+        helpExperience: CaregiverHelpExperience,
+        strengthList: string[] | [],
+        warningList: Warning [] | []
+    }
+}

--- a/backend/src/profile/profile.module.ts
+++ b/backend/src/profile/profile.module.ts
@@ -9,11 +9,13 @@ import { CaregiverProfileMapper } from "./application/mapper/caregiver-profile.m
 import { MongodbModule } from "src/common/shared/database/mongodb/mongodb.module";
 import { UserAuthCommonModule } from "src/user-auth-common/user-auth-common.module";
 import { ProfileController } from "./interface/controller/profile.controller";
+import { RankModule } from "src/rank/rank.module";
 
 @Module({
     imports: [
         UserAuthCommonModule,
-        MongodbModule
+        MongodbModule,
+        RankModule
     ],
     controllers: [
         ProfileController

--- a/backend/src/rank/application/service/profile-view-rank.manager.ts
+++ b/backend/src/rank/application/service/profile-view-rank.manager.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { IRankManager } from "../../domain/irank.manager";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
+import { IActionRecordRepository } from "src/rank/domain/iaction-record.repository";
+
+@Injectable()
+export class ProfileViewRankManager implements IRankManager {
+    constructor(
+        @InjectRepository(ProfileViewRecord)
+        private readonly profileViewRecordRepository: IActionRecordRepository<ProfileViewRecord>
+    ) {}
+
+    /* 프로필을 조회한 사용자 기록 */
+    async recordUserAction(profileId: string, viewUserId: number, ): Promise<void> {
+        await this.profileViewRecordRepository.save(new ProfileViewRecord(profileId, viewUserId));
+    };
+
+    /* 해당 사용자가 해당 프로필을 조회했는지 검사 */
+    async isActionPerformedByUser(profileId: string, userId: number): Promise<boolean> {
+        return await this.profileViewRecordRepository
+                            .findRecordByActionAndUser(profileId, userId) ? true : false;
+    }
+}

--- a/backend/src/rank/application/service/profile-view-rank.service.ts
+++ b/backend/src/rank/application/service/profile-view-rank.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { IRankService } from "src/rank/domain/irank.service";
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { ProfileViewRankManager } from "./profile-view-rank.manager";
+
+@Injectable()
+export class ProfileViewRankService implements IRankService {
+    
+    constructor(
+        private readonly profileViewRankRepository: ProfileViewRankRepository,
+        private readonly profileViewRankManager: ProfileViewRankManager
+    ) {};
+
+    async increment(profileId: string, viewUser: User): Promise<void> {
+        /* 만약 해당 프로필을 처음 조회한 사용자라면 명단에 추가이후 조회 집계 증가 */
+        if( !await this.profileViewRankManager.isActionPerformedByUser(profileId, viewUser.getId()) ) {
+            await Promise.all([
+                this.profileViewRankManager.recordUserAction(profileId, viewUser.getId()),
+                this.profileViewRankRepository.increment(profileId)
+            ])
+        }
+    };
+}

--- a/backend/src/rank/domain/entity/profile-view-record.entity.ts
+++ b/backend/src/rank/domain/entity/profile-view-record.entity.ts
@@ -1,0 +1,28 @@
+import { UUIDTransformer } from "src/user-auth-common/domain/entity/transformer";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity('profile_view_record')
+export class ProfileViewRecord {
+    
+    @PrimaryGeneratedColumn('increment')
+    private id: number;
+
+    @Column({ 
+        name: 'profile_id', 
+        type: 'binary', 
+        length: 16, 
+        transformer: new UUIDTransformer() 
+    })
+    private profileId: string;
+
+    @Column({ name: 'user_id' })
+    private userId: number;
+
+    constructor(profileId: string, viewUserId: number) {
+        this.profileId = profileId;
+        this.userId = viewUserId;
+    };
+    
+    getProfileId(): string { return this.profileId; };
+    getViewUser(): number { return this.userId; };
+}

--- a/backend/src/rank/domain/iaction-record.repository.ts
+++ b/backend/src/rank/domain/iaction-record.repository.ts
@@ -1,0 +1,8 @@
+import { Repository } from "typeorm";
+import { ProfileViewRecord } from "./entity/profile-view-record.entity";
+
+export interface IActionRecordRepository<T> extends Repository<T>{
+    /* 특정 Action을 수행한 사용자가 있는지 기록 검사 */
+    findRecordByActionAndUser(action: string, userId: number): Promise<ProfileViewRecord>;
+};
+

--- a/backend/src/rank/domain/irank.manager.ts
+++ b/backend/src/rank/domain/irank.manager.ts
@@ -1,0 +1,5 @@
+/* 프로필 조회, 키워드 검색등 랭킹을 매기는 Action들에 대해 사용자 중복 검사 */
+export interface IRankManager {
+    isActionPerformedByUser(action: string, userId: number): Promise<boolean>;
+    recordUserAction(action: string, userId: number): Promise<void>;
+}

--- a/backend/src/rank/domain/irank.repository.ts
+++ b/backend/src/rank/domain/irank.repository.ts
@@ -1,0 +1,4 @@
+export interface IRankRepository {    
+    /* 횟수 증가시키는 메서드 */
+    increment(identify: string): Promise<void>
+;}

--- a/backend/src/rank/domain/irank.service.ts
+++ b/backend/src/rank/domain/irank.service.ts
@@ -1,0 +1,6 @@
+import { User } from "src/user-auth-common/domain/entity/user.entity";
+
+export interface IRankService {
+    /* 횟수 증가시키는 메서드 */
+    increment(identify: string, viewUser: User): Promise<void>;
+}

--- a/backend/src/rank/infra/profile-view-rank.repository.ts
+++ b/backend/src/rank/infra/profile-view-rank.repository.ts
@@ -1,0 +1,21 @@
+import { RedisClientType } from "redis";
+import { IRankRepository } from "../domain/irank.repository";
+import { Inject, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+@Injectable()
+export class ProfileViewRankRepository implements IRankRepository {
+    private rankKey: string;
+
+    constructor(
+        @Inject('REDIS_CLIENT')
+        private readonly redis: RedisClientType,
+        private readonly configService: ConfigService
+    ) {
+        this.rankKey = configService.get('profile_view_rank_key');
+    };
+
+    async increment(profileId: string): Promise<void> {
+        await this.redis.ZINCRBY(this.rankKey, 1, profileId);
+    }
+}

--- a/backend/src/rank/infra/profile-view-record.repository.ts
+++ b/backend/src/rank/infra/profile-view-record.repository.ts
@@ -1,0 +1,28 @@
+import { DataSource, Repository } from "typeorm";
+import { ProfileViewRecord } from "../domain/entity/profile-view-record.entity";
+import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
+import { IActionRecordRepository } from "../domain/iaction-record.repository";
+import { UUIDUtil } from "src/util/uuid.util";
+
+export const profileViewRecordRepoMethods: Pick<
+    IActionRecordRepository<ProfileViewRecord>,
+    'findRecordByActionAndUser'
+> = {
+    async findRecordByActionAndUser(this: Repository<ProfileViewRecord>, profileId: string, userId: number)
+    :Promise<ProfileViewRecord> {
+        return await this.createQueryBuilder('pvr')
+                .where('pvr.profile_id = :profileId', { profileId: UUIDUtil.toBinaray(profileId) })
+                .andWhere('pvr.user_id = :userId', { userId })
+                .getOne();
+    }
+};
+
+export const ProfileViewRecordRepoProvider = {
+    provide: getRepositoryToken(ProfileViewRecord),
+    inject: [getDataSourceToken()],
+    useFactory(dataSource: DataSource) {
+        return dataSource
+            .getRepository(ProfileViewRecord)
+            .extend(profileViewRecordRepoMethods)
+    }
+};

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,4 +1,6 @@
 import { Module } from "@nestjs/common";
+import { ProfileViewRankRepository } from "./infra/profile-view-rank.repository";
+import { RedisModule } from "src/common/shared/database/redis/redis.module";
 import { ProfileViewRecordRepoProvider } from "./infra/profile-view-record.repository";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
@@ -6,8 +8,10 @@ import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
 @Module({
     imports: [
         TypeOrmModule.forFeature([ProfileViewRecord]),
+        RedisModule
     ],
     providers: [
+        ProfileViewRankRepository,
         ProfileViewRecordRepoProvider
     ],
 })

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { ProfileViewRecordRepoProvider } from "./infra/profile-view-record.repository";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([ProfileViewRecord]),
+    ],
+    providers: [
+        ProfileViewRecordRepoProvider
+    ],
+})
+
+export class RankModule {}

--- a/backend/src/rank/rank.module.ts
+++ b/backend/src/rank/rank.module.ts
@@ -1,6 +1,8 @@
 import { Module } from "@nestjs/common";
+import { ProfileViewRankService } from "./application/service/profile-view-rank.service";
 import { ProfileViewRankRepository } from "./infra/profile-view-rank.repository";
 import { RedisModule } from "src/common/shared/database/redis/redis.module";
+import { ProfileViewRankManager } from "./application/service/profile-view-rank.manager";
 import { ProfileViewRecordRepoProvider } from "./infra/profile-view-record.repository";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
@@ -11,9 +13,14 @@ import { ProfileViewRecord } from "./domain/entity/profile-view-record.entity";
         RedisModule
     ],
     providers: [
+        ProfileViewRankService,
         ProfileViewRankRepository,
+        ProfileViewRankManager,
         ProfileViewRecordRepoProvider
     ],
+    exports: [
+        ProfileViewRankService
+    ]
 })
 
 export class RankModule {}

--- a/backend/test/unit/__mock__/profile/service.mock.ts
+++ b/backend/test/unit/__mock__/profile/service.mock.ts
@@ -25,5 +25,6 @@ export const MockCaregiverProfileMapper = {
     useValue: {
         mapFrom: jest.fn(),
         toListDto: jest.fn(),
+        toDetailDto: jest.fn()
     }
 }

--- a/backend/test/unit/__mock__/rank/rank-repository.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-repository.mock.ts
@@ -1,0 +1,8 @@
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository";
+
+export const MockProfileViewRankRepository = {
+    provide: ProfileViewRankRepository,
+    useValue: {
+        increment: jest.fn()
+    }
+}

--- a/backend/test/unit/__mock__/rank/rank-service.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-service.mock.ts
@@ -1,3 +1,4 @@
+import { ProfileViewRankManager } from "src/rank/application/service/profile-view-rank.manager";
 import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 
 /* MockingProfileViewRankService */
@@ -5,5 +6,14 @@ export const MockProfileViewRankService = {
     provide: ProfileViewRankService,
     useValue: {
         increment: jest.fn()
+    }
+};
+
+/* Mocking ProfileViewRankManager */
+export const MockProfileViewRankManager = {
+    provide: ProfileViewRankManager,
+    useValue: {
+        recordUserAction: jest.fn(),
+        isActionPerformedByUser: jest.fn()
     }
 }

--- a/backend/test/unit/__mock__/rank/rank-service.mock.ts
+++ b/backend/test/unit/__mock__/rank/rank-service.mock.ts
@@ -1,0 +1,9 @@
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
+
+/* MockingProfileViewRankService */
+export const MockProfileViewRankService = {
+    provide: ProfileViewRankService,
+    useValue: {
+        increment: jest.fn()
+    }
+}

--- a/backend/test/unit/common/database/datebase-setup.fixture.ts
+++ b/backend/test/unit/common/database/datebase-setup.fixture.ts
@@ -1,6 +1,7 @@
 import { TypeOrmModuleOptions } from "@nestjs/typeorm";
 import { Db, MongoClient } from "mongodb";
 import { RedisClientType, createClient } from "redis";
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
@@ -40,7 +41,7 @@ export const TestTypeOrmOptions: TypeOrmModuleOptions = {
     port: 3306,
     password: '1234',
     database: 'test_caregiver_project',
-    entities: [User, Phone, Email, UserProfile, Token],
+    entities: [User, Phone, Email, UserProfile, Token, ProfileViewRecord],
     synchronize: true,
     logging: true
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -25,7 +25,7 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getUserId()).toBe(userId);
 
             mappingResult.getLicenseList()
-                .map( license => {
+                .map(license => {
                     expect(license).toBeInstanceOf(License);
                     expect(license.getName()).toBe('자격증');
                     expect(license.getIsCertified()).toBe(false);
@@ -39,9 +39,9 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getWarningList()).toEqual([]);
         })
     });
-    
-    describe('toDto()', () => {
-        
+
+    describe('toListDto()', () => {
+
         it.each([
             [8, '8개월'],
             [13, '1년 1개월'],
@@ -77,12 +77,12 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(result.profile.possibleAreaList).toEqual(expectedAreaList);
         });
 
-        it('toDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
+        it('toListDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
             const userStub = TestUser.default() as unknown as User;
             const profileStub = TestCaregiverProfile.default().build();
 
             const result = profileMapper.toListDto(userStub, profileStub);
-            
+
             expect(result).toHaveProperty('user');
             expect(result).toHaveProperty('profile');
 
@@ -98,6 +98,63 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(result.profile).toHaveProperty('possibleAreaList');
             expect(result.profile).toHaveProperty('tagList');
             expect(result.profile).toHaveProperty('notice');
+        })
+    });
+
+    describe('toDetailDto()', () => {
+        let userStub: User;
+
+        beforeAll(() => userStub = TestUser.default() as unknown as User );
+
+        it('가능한 지역을 상세페이지에선 모두 나열해주는지 확인', () => {
+            const possibleAreaList = ['인천', '서울', '부산', '대구', '포항'];
+            const expectedArea = '인천,서울,부산,대구,포항';
+
+            const profileStub = TestCaregiverProfile.default()
+                                                    .possibleAreaList(possibleAreaList)
+                                                    .build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.profile.possibleAreaList).toBe(expectedArea);
+        });
+
+        it('인증이 완료된 자격증의 이름은 포함되고, 완료되지 않은 자격증은 포함되지 않는지 확인', () => {
+            const [unCertificatedLicense, certificatedLicense] = ['자격증1', '자격증2'];
+            const licenseList = [new License(unCertificatedLicense, false), new License(certificatedLicense, true)];
+            const expectedLicense = [certificatedLicense];
+
+            const profileStub = TestCaregiverProfile.default()
+                                                    .licenseList(licenseList)
+                                                    .build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.profile.licenseList).toEqual(expectedLicense);
+        })
+
+        it('toDetailDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
+            const profileStub = TestCaregiverProfile.default().build();
+
+            const result = profileMapper.toDetailDto(userStub, profileStub);
+
+            expect(result.user).toHaveProperty('name');
+            expect(result.user).toHaveProperty('sex');
+            expect(result.user).toHaveProperty('age');
+
+            expect(result.profile).toHaveProperty('_id');
+            expect(result.profile).toHaveProperty('userId');
+            expect(result.profile).toHaveProperty('career');
+            expect(result.profile).toHaveProperty('pay');
+            expect(result.profile).toHaveProperty('possibleDate');
+            expect(result.profile).toHaveProperty('possibleAreaList');
+            expect(result.profile).toHaveProperty('notice');
+            expect(result.profile).toHaveProperty('licenseList');
+            expect(result.profile).toHaveProperty('additionalChargeCase');
+            expect(result.profile).toHaveProperty('nextHosptial');
+            expect(result.profile).toHaveProperty('helpExperience');
+            expect(result.profile).toHaveProperty('strengthList');
+            expect(result.profile).toHaveProperty('warningList');
         })
     })
 })

--- a/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
+++ b/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from "@nestjs/testing"
+import { ProfileViewRankManager } from "src/rank/application/service/profile-view-rank.manager"
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service"
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository"
+import { User } from "src/user-auth-common/domain/entity/user.entity"
+import { UUIDUtil } from "src/util/uuid.util"
+import { MockProfileViewRankRepository } from "test/unit/__mock__/rank/rank-repository.mock"
+import { MockProfileViewRankManager } from "test/unit/__mock__/rank/rank-service.mock"
+import { TestUser } from "test/unit/user/user.fixtures"
+
+describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
+    let profileViewRankRepository: ProfileViewRankRepository;
+    let profileViewRankManager: ProfileViewRankManager;
+    let profileViewRankService: ProfileViewRankService;
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                ProfileViewRankService,
+                MockProfileViewRankRepository,
+                MockProfileViewRankManager
+            ]
+        }).compile();
+        profileViewRankService = module.get(ProfileViewRankService);
+        profileViewRankRepository = module.get(ProfileViewRankRepository);
+        profileViewRankManager = module.get(ProfileViewRankManager);
+    })
+
+    describe('increment()', () => {
+        const [profileId, viewUser] = [UUIDUtil.generateOrderedUuid(), TestUser.default()];
+
+        beforeEach(() => jest.clearAllMocks());
+        
+        it('이미 해당 프로필을 조회한 사용자라면 아무것도 수행하지 않는다.', async() => {
+            jest.spyOn(profileViewRankManager, 'isActionPerformedByUser').mockResolvedValueOnce(true);
+            
+            const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
+            const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
+
+            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+
+            expect(rankSpy).not.toHaveBeenCalled();
+            expect(recordSpy).not.toHaveBeenCalled();
+        });
+
+        it('처음 조회한 사용자라면 조회수를 증가시키고 조회 내역을 기록하기 위한 로직을 호출한다', async() => {
+            jest.spyOn(profileViewRankManager, 'isActionPerformedByUser').mockResolvedValueOnce(false);
+
+            const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
+            const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
+            
+            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+
+            expect(rankSpy).toHaveBeenCalledWith(profileId);
+            expect(recordSpy).toHaveBeenCalledWith(profileId, viewUser.getId());
+        })
+    })
+})

--- a/backend/test/unit/rank/infra/profile-view-rank-repo.spec.ts
+++ b/backend/test/unit/rank/infra/profile-view-rank-repo.spec.ts
@@ -1,0 +1,49 @@
+import { ConfigService } from "@nestjs/config"
+import { Test } from "@nestjs/testing"
+import { RedisClientType } from "redis"
+import { ProfileViewRankRepository } from "src/rank/infra/profile-view-rank.repository"
+import { ConnectRedis, DisconnectRedis, getRedis } from "test/unit/common/database/datebase-setup.fixture"
+
+describe('프로필 조회 랭킹 저장소(ProfileViewRankRepository', () => {
+    let profileViewRankRepository: ProfileViewRankRepository;
+    let redis: RedisClientType;
+    const testRankKey = 'test:profile:view:rank';
+
+    beforeAll( async () => {
+        await ConnectRedis();
+
+        const module = await Test.createTestingModule({
+            providers: [
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn().mockReturnValue(testRankKey)
+                    }
+                },
+                {
+                    provide: 'REDIS_CLIENT',
+                    useValue: getRedis()
+                },
+                ProfileViewRankRepository
+            ]
+        }).compile();
+
+        redis = getRedis();
+        profileViewRankRepository = module.get(ProfileViewRankRepository);
+    });
+
+    afterAll(async () => await DisconnectRedis() );
+    describe('increment()', () => {
+        it('해당 아이디를 가진 프로필의 횟수는 1증가해야 한다.', async () => {
+            const profileId = '1';
+            await profileViewRankRepository.increment(profileId);
+
+            const afterIncrement = await redis.ZSCORE(testRankKey, profileId);
+            const expectedScroe = 1;
+
+            expect(afterIncrement).toBe(expectedScroe);
+
+            await redis.ZREM(testRankKey, profileId);
+        })
+    })
+})

--- a/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
+++ b/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm";
+import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
+import { IActionRecordRepository } from "src/rank/domain/iaction-record.repository"
+import { profileViewRecordRepoMethods } from "src/rank/infra/profile-view-record.repository";
+import { UUIDUtil } from "src/util/uuid.util";
+import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture";
+
+describe('프로필 조회 기록 저장소(ProfileViewRecordRepository', () => {
+    let profileViewRecordRepository: IActionRecordRepository<ProfileViewRecord>;
+    let module: TestingModule;
+
+    beforeAll(async() => {
+        module = await Test.createTestingModule({
+            imports: [
+                TypeOrmModule.forRoot(TestTypeOrmOptions),
+                TypeOrmModule.forFeature([ProfileViewRecord])
+            ]
+        }).compile();
+
+        profileViewRecordRepository = module.get(getRepositoryToken(ProfileViewRecord));
+        profileViewRecordRepository = profileViewRecordRepository.extend(profileViewRecordRepoMethods);
+    });
+
+    afterAll(async() => {
+        await profileViewRecordRepository.clear();
+        await module.close();
+    });
+
+    describe('findRecordByActionAndUser', () => {
+        const [profileId, userId] = [UUIDUtil.generateOrderedUuid(), 1];
+
+        beforeAll(async() => {
+            const profileViewRecord = new ProfileViewRecord(profileId, userId);
+            await profileViewRecordRepository.save(profileViewRecord)
+        });
+
+        it('프로필을 조회한 사용자면 결과에 포함되어야 한다', async () => {
+            const result = await profileViewRecordRepository.findRecordByActionAndUser(profileId, userId);
+
+            expect(result.getProfileId()).toBe(profileId);
+            expect(result.getViewUser()).toBe(userId);            
+        });
+
+        it('조회한 사용자가 아니면 null 값이 나온다', async () => {
+            const result = await profileViewRecordRepository.findRecordByActionAndUser(profileId, 123);
+            
+            expect(result).toBe(null);
+        })
+    })
+})


### PR DESCRIPTION
- 데이터를 클라이언트 화면에 맞춰 가공하는 Mapper - (#54)
- CaregiverProfileService에 상세 조회 Method - (#55 )

**프로필 조회순으로 데이터를 제공하기 위해 순위를 매기는 RankModule**
- 특정 프로필을 조회한 사용자의 기록을 저장하는 Repository - (#56 )
- 실제 프로필 조회수로 순위를 매기는 점수와 순위를 저장하는 Repository - (#57 )
- 중복 사용자인지 검사하고 조회수를 증가시키고, 사용자를 기록하는 Service, Manager - (#58 )