### PR TITLE
[프론트엔드] 프로필 상세페이지 컴포넌트 수정

### DIFF
--- a/frontendv2/api/Profile/requestProfileList.jsx
+++ b/frontendv2/api/Profile/requestProfileList.jsx
@@ -43,7 +43,6 @@ export default async function requestProfileList(purpose) {
         });        
         /* 첫 프로필 리스트의 조회 결과를 받아왔으면 Loading 해제 */
         if( !lastListNo ) store.dispatch(listLoading(false));
-
         const profileList = res.data;
         /* 더 이상 프로필 데이터가 없을 때 */
         if( !profileList.length ) {
@@ -53,7 +52,7 @@ export default async function requestProfileList(purpose) {
 
         /* 아직 프로필 데이터가 조회될 때 다음을 위해 저장 */
         store.dispatch(saveCareGiverProfile(profileList));
-        store.dispatch(saveLastProfileId(profileList[profileList.length - 1].profile._id));
+        store.dispatch(saveLastProfileId(profileList[profileList.length - 1].profile.id));
         store.dispatch(setNoData(false));
     }
     catch (err) {

--- a/frontendv2/api/Profile/requestUserProfile.jsx
+++ b/frontendv2/api/Profile/requestUserProfile.jsx
@@ -1,34 +1,28 @@
-import { useSelector } from "react-redux";
 import api from "../../config/CustomAxios";
+import { requestRefreshToken } from "../../functions/Token";
 import { saveUserProfile } from "../../redux/action/profile/profileAction";
 import { saveMostViewed } from "../../redux/action/search/searchAction";
 import store from "../../redux/store";
 
-export default async function requestUserProfile(purpose, profileId) {
-    const userId = store.getState().user.id;
+export default async function requestUserProfile(navigation, profileId) {
     let { mostViewed } = store.getState().search;
     mostViewed = mostViewed ? true : undefined;
     try {
-        //const start = new Date().getTime();
-        const res = await api.get(`user/profile/${purpose}`, {
-            params: {
-                userId: userId,
-                profileId: profileId,
-                mostViewed: mostViewed
-            }
-        })
-        //const end = new Date().getTime();
-        //console.log(end - start)
+        const res = await api.get(`profile/detail/${profileId}`);
         store.dispatch(saveUserProfile(res.data));
         store.dispatch(saveMostViewed(false));
-        return 'true';
+        return true;
     }
     catch (err) {
-        console.log(err.response)
+        console.log(err.response.data)
         const status = err.response.status;
         const message = err.response.data.message;
         if (status == 404) {
             return message;
         }
+        await requestRefreshToken(navigation);
+        const res = await api.get(`profile/detail/${profileId}`);
+        store.dispatch(saveUserProfile(res.data));
+        return true;
     }
 }

--- a/frontendv2/components/FindHelper/EachHelper/Header.jsx
+++ b/frontendv2/components/FindHelper/EachHelper/Header.jsx
@@ -34,7 +34,8 @@ export default function Header({ profile }) {
                 underlayColor='none'
                 onPress={() => navigation.dispatch(
                     StackActions.push('helperProfilePage', {
-                        profileId: profile.id ,
+                        name: user.name,
+                        profileId: profile.profile.id ,
                     })
                 )}>
                 <View style={styles.confirmProfileBtn}>

--- a/frontendv2/components/HelperProfile/ProfileBasicInfo.jsx
+++ b/frontendv2/components/HelperProfile/ProfileBasicInfo.jsx
@@ -11,8 +11,8 @@ export default function ProfileBasicInfo() {
         userProfile: state.profile.userProfile
     }));
     
-    const career = getCareer(userProfile.career);
-    const startDate = changeStartDate(userProfile.startDate);
+    const career = userProfile.profile.career;
+    const startDate = userProfile.profile.possibleDate;
 
     return (
         <View style={{
@@ -63,7 +63,7 @@ export default function ProfileBasicInfo() {
                         </Text>
                         <View style={styles.verticalLine} />
                         <Text style={styles.userValue}>
-                            {userProfile.pay}만원
+                            {userProfile.profile.pay}만원
                         </Text>
                     </View>
                 </View>
@@ -81,7 +81,7 @@ export default function ProfileBasicInfo() {
                         </Text>
                         <View style={styles.verticalLine} />
                         <Text style={[styles.userValue, { flexWrap: 'wrap', paddingRight: 10 }]}>
-                            {userProfile.possibleArea}
+                            {userProfile.possibleAreaList}
                         </Text>
                     </View>
 

--- a/frontendv2/components/HelperProfile/ProfileCareStyle.jsx
+++ b/frontendv2/components/HelperProfile/ProfileCareStyle.jsx
@@ -16,11 +16,13 @@ export default function ProfileCareStyle() {
     const [toilet, setToilet] = useState(true);
     const [suction, setSuction] = useState(true);
     const [washing, setWashing] = useState(true);
-    const [bedsore, setBedsore] = useState(true);
+    const [movement, setMovement] = useState(true);
 
     const { userProfile } = useSelector(state => ({
         userProfile: state.profile.userProfile
     }));
+
+    const { helpExperience } = userProfile.profile;
 
     return (
         <>
@@ -56,7 +58,7 @@ export default function ProfileCareStyle() {
                                 fontSize: 14,
                                 color: '#808080',
                             }}>
-                                {userProfile.toilet}
+                                {helpExperience.toilet}
                             </Text>
                         </View> : null
                     }
@@ -85,7 +87,7 @@ export default function ProfileCareStyle() {
                                 fontSize: 14,
                                 color: '#808080',
                             }}>
-                                {userProfile.suction}
+                                {helpExperience.suction}
                             </Text>
                         </View> : null
                     }
@@ -115,14 +117,14 @@ export default function ProfileCareStyle() {
                             color: '#808080',
                             paddingLeft: 4
                         }}>
-                            {userProfile.washing}
+                            {helpExperience.washing}
                         </Text>
                     </View> : null
                     }
 
                     <TouchableHighlight
                         underlayColor='none'
-                        onPress={() => setBedsore(!bedsore)}
+                        onPress={() => setMovement(!movement)}
                         style={styles.questionTouch}
                     >
                         <View style={styles.question}>
@@ -134,19 +136,19 @@ export default function ProfileCareStyle() {
                                 Q. 욕창 관리는 어떻게 하시나요?
                             </Text>
                             <View style={{ position: 'absolute', right: 10 }}>
-                                <Icon props={['material', bedsore ? 'expand-less' : 'expand-more', 25, 'black']} />
+                                <Icon props={['material', movement ? 'expand-less' : 'expand-more', 25, 'black']} />
                             </View>
                         </View>
                     </TouchableHighlight>
 
-                    {bedsore ?
+                    {movement ?
                     <View style={styles.answer}>
                         <Text style={{
                             fontSize: 14,
                             color: '#808080',
                             paddingLeft: 4
                         }}>
-                            {userProfile.bedsore}
+                            {helpExperience.movement}
                         </Text>
                     </View> : null 
                     }

--- a/frontendv2/components/HelperProfile/ProfileCertificate.jsx
+++ b/frontendv2/components/HelperProfile/ProfileCertificate.jsx
@@ -5,17 +5,11 @@ import { StyleSheet } from "react-native";
 import { View } from "react-native";
 import { heightPercentageToDP as hp, widthPercentageToDP as wp } from "react-native-responsive-screen";
 import { useSelector } from "react-redux"
-import { stringToArray } from "../../functions/Profile/profileFunctions";
 
 export default function ProfileCertificate() {
-    const { license } = useSelector(state => ({
-        license: state.profile.userProfile.license
+    const { licenseList } = useSelector(state => ({
+        licenseList: state.profile.userProfile.profile.licenseList
     }));
-    
-    let certificateList;
-    if(!! license.length) {
-        certificateList = stringToArray(license);
-    }
 
     return (
         <View style={styles.certificate}>
@@ -24,12 +18,12 @@ export default function ProfileCertificate() {
                     자격증
                 </Text>
             </View>
-            {certificateList ? 
+            {licenseList.length ? 
                 <View style = {styles.certificateList}>
-                    {(certificateList).map((certificate) => {
+                    {(licenseList).map((license) => {
                         return(
-                            <Text key={certificate} style = {styles.eachPart}>
-                                {certificate}
+                            <Text key={license} style = {styles.eachPart}>
+                                {license}
                             </Text>
                         )
                     })}

--- a/frontendv2/components/HelperProfile/ProfileExtraFee.jsx
+++ b/frontendv2/components/HelperProfile/ProfileExtraFee.jsx
@@ -7,8 +7,8 @@ import { heightPercentageToDP as hp, widthPercentageToDP as wp } from "react-nat
 import { useSelector } from "react-redux"
 
 export default function ProfileExtraFee() {
-    const { extraFee } = useSelector(state => ({
-        extraFee: state.profile.userProfile.extraFee
+    const { additionalChargeCase } = useSelector(state => ({
+        additionalChargeCase: state.profile.userProfile.profile.additionalChargeCase
     }));
 
     return (
@@ -19,7 +19,7 @@ export default function ProfileExtraFee() {
                 </Text>
             </View>
                 <Text style = {styles.nextHospitalText}>
-                    {extraFee}
+                    {additionalChargeCase}
                 </Text>
         </View>
     )

--- a/frontendv2/components/HelperProfile/ProfileHeader.jsx
+++ b/frontendv2/components/HelperProfile/ProfileHeader.jsx
@@ -5,17 +5,14 @@ import { StyleSheet } from "react-native";
 import { View } from "react-native";
 import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-native-responsive-screen";
 import { useSelector } from "react-redux";
-import { getAge } from "../../functions/Profile/profileFunctions";
 import Icon from "../../components/Icon";
 import Heart from "./ProfileHeader/Heart";
-
 
 export default function ProfileHeader() {
     const {  userProfile } = useSelector(state => ({
         userProfile: state.profile.userProfile
     }));
 
-    const age = getAge(userProfile.user.birth);
     return (
         <View style={styles.profileHeader}>
             <View style={styles.innerProfileHeader}>
@@ -24,7 +21,7 @@ export default function ProfileHeader() {
                         {userProfile.user.sex},
                     </Text>
                     <Text style={{ fontWeight: '500', fontSize: 15, marginLeft: 3 }}>
-                        {age}세
+                        {userProfile.user.age}세
                     </Text>
                 </View>
 
@@ -33,7 +30,7 @@ export default function ProfileHeader() {
                         fontSize: 20,
                         fontWeight: '600'
                     }}>
-                        믿음의 {userProfile.user.purpose} {userProfile.user.name}님
+                        믿음의 간병인 {userProfile.user.name}님
                     </Text>
                     <Heart />
                 </View>
@@ -69,7 +66,7 @@ export default function ProfileHeader() {
                 <View style={styles.profileHelperAppeal}>
                     <Icon props={['material', 'campaign', 21, 'silver']} />
                     <Text style={styles.profileHelperAppealText}>
-                        {userProfile.notice}
+                        {userProfile.profile.notice}
                     </Text>
                 </View>
             </View>

--- a/frontendv2/components/HelperProfile/ProfileHeader/Heart.jsx
+++ b/frontendv2/components/HelperProfile/ProfileHeader/Heart.jsx
@@ -16,51 +16,51 @@ export default function Heart() {
     const navigation = useNavigation();
     const [visible, setVisible] = useState(false);
     const [errMessage, setErrMessage] = useState('');
-    let { loginId, userHeartCount, userIsHearted, userProfileId } = useSelector(state => ({
-        loginId: state.user.id,
-        userHeartCount: state.profile.userProfile.heart.heartCount,
-        userIsHearted: state.profile.userProfile.heart.isHearted,
-        userProfileId: state.profile.userProfile.id
-    }),
-        shallowEqual
-    );
+    // let { loginId, userHeartCount, userIsHearted, userProfileId } = useSelector(state => ({
+    //     loginId: state.user.id,
+    //     userHeartCount: state.profile.userProfile.heart.heartCount,
+    //     userIsHearted: state.profile.userProfile.heart.isHearted,
+    //     userProfileId: state.profile.userProfile.id
+    // }),
+    //     shallowEqual
+    // );
 
 
-    const registerHeart = async () => {
-        let result;
-        if (!!loginId) {
-            result = await RegisterHeart(userProfileId, navigation);
-        }
-        else {
-            //로그인이 되어있지 않으면 refreshToken 확인 후 다시 재 호출
-            if (await requestRefreshToken(navigation)) {
-                result = await RegisterHeart(userProfileId, navigation);
-            }
-        }
-        if (result?.message) {
-            setErrMessage(result.message)
-            setVisible(true);
-        }
-    }
+    // const registerHeart = async () => {
+    //     let result;
+    //     if (!!loginId) {
+    //         result = await RegisterHeart(userProfileId, navigation);
+    //     }
+    //     else {
+    //         //로그인이 되어있지 않으면 refreshToken 확인 후 다시 재 호출
+    //         if (await requestRefreshToken(navigation)) {
+    //             result = await RegisterHeart(userProfileId, navigation);
+    //         }
+    //     }
+    //     if (result?.message) {
+    //         setErrMessage(result.message)
+    //         setVisible(true);
+    //     }
+    // }
 
     return (
         <>
             <TouchableHighlight
                 style={styles.heartTouch}
                 underlayColor='none'
-                onPress={() => registerHeart()}
+                onPress={() => console.log('heart click')}
             >
                 <View>
-                    {/*<Icon props={['material', 'favorite-border', 22, 'black']} /> */}
-                    <Icon props={[
+                    <Icon props={['material', 'favorite-border', 22, 'black']} />
+                    {/* <Icon props={[
                         'material',
                         !!userIsHearted ? 'favorite' : 'favorite-border',
                         22,
                         !!userIsHearted ? 'red' : 'black'
                     ]}
-                    />
+                    /> */}
                     <Text style={styles.heartCount}>
-                        {userHeartCount}
+                        0
                     </Text>
                 </View>
             </TouchableHighlight>

--- a/frontendv2/components/HelperProfile/ProfileNextHospital.jsx
+++ b/frontendv2/components/HelperProfile/ProfileNextHospital.jsx
@@ -7,8 +7,8 @@ import { heightPercentageToDP as hp, widthPercentageToDP as wp } from "react-nat
 import { useSelector } from "react-redux"
 
 export default function ProfileNextHospital() {
-    const { nextHospital } = useSelector(state => ({
-        nextHospital: state.profile.userProfile.nextHospital
+    const { nextHosptial } = useSelector(state => ({
+        nextHosptial: state.profile.userProfile.profile.nextHosptial
     }));
 
     return (
@@ -19,7 +19,7 @@ export default function ProfileNextHospital() {
                 </Text>
             </View>
                 <Text style = {styles.nextHospitalText}>
-                    {nextHospital}
+                    {nextHosptial}
                 </Text>
         </View>
     )

--- a/frontendv2/components/HelperProfile/ProfileStrength.jsx
+++ b/frontendv2/components/HelperProfile/ProfileStrength.jsx
@@ -6,15 +6,9 @@ import { widthPercentageToDP as wp, heightPercentageToDP as hp } from "react-nat
 import { useSelector } from "react-redux";
 
 export default function ProfileStrength() {
-    const { strength } = useSelector(state => ({
-        strength: state.profile.userProfile.strength
+    const { strengthList } = useSelector(state => ({
+        strengthList: state.profile.userProfile.profile.strengthList
     }));
-
-    let strengthList = [];
-    if (!!strength['first'])
-        strengthList.push(strength['first']);
-    if (!!strength['second'])
-        strengthList.push(strength['second']);
 
     return (
         <View style={styles.strength}>

--- a/frontendv2/components/HelperProfile/ProfileWarning.jsx
+++ b/frontendv2/components/HelperProfile/ProfileWarning.jsx
@@ -7,12 +7,9 @@ import { heightPercentageToDP as hp, widthPercentageToDP as wp } from "react-nat
 import { useSelector } from "react-redux";
 
 export default function ProfileWarning() {
-    const { warning } = useSelector((state) => ({
-        warning: state.profile.userProfile.user.warning
+    const { warningList } = useSelector((state) => ({
+        warningList: state.profile.userProfile.profile.warningList
     }))
-
-    //todo 신고가 있을 시 신고 내역을 반환해주는 함수 구현
-    //if( !! warning)
 
     return (
         <View style={styles.warning}>

--- a/frontendv2/screens/HelperProfile.jsx
+++ b/frontendv2/screens/HelperProfile.jsx
@@ -27,7 +27,6 @@ export default function HelperProfile({ navigation, route }) {
     const [loading, setLoading] = useState(true); //데이터 받아오기 전까지
     const [visible, setVisible] = useState(false); //프로필 찾을 수 없을 때 dialog
     const [errMessage, setErrMessage] = useState(''); //프로필 찾을 수 없을 때 message
-    const purpose = route.params.purpose;
     const profileId = route.params.profileId;
     const name = route.params.name;
     
@@ -37,11 +36,9 @@ export default function HelperProfile({ navigation, route }) {
 
     useEffect(() => {
         async function getUserProfile() {
-            const result = await requestUserProfile(
-                purpose === '간병인' ? 'careGiver' : 'assistant',
-                profileId);
+            const result = await requestUserProfile(navigation, profileId);
             //프로필을 찾을 수 없으면 dialog 띄우기
-            if(result !== 'true') {
+            if(!result) {
                 setVisible(true);
                 setErrMessage(result);
             }
@@ -67,7 +64,7 @@ export default function HelperProfile({ navigation, route }) {
 
     const onScrollHandler = (e) => {
         if( e.nativeEvent.contentOffset.y > 50 ) {
-            const newTitle = purpose + ' ' + name + '님';
+            const newTitle = '간병인' + ' ' + name + '님';
             navigation.setOptions({ title: newTitle})
         }else 
             navigation.setOptions({ title: '' })


### PR DESCRIPTION
백엔드 데이터 반환 형식에 맞춰 변수명들 수정
```javascript
            user: {
                name: string;
                sex: SEX('남', '여');
                age: number;
            },
            profile: {
                id: string;
                userId: number;
                career: string;
                pay: number;
                possibleDate: string;
                possibleAreaList: string [];
                notice: string;
                licenseList: string[],
                additionalChargeCase: string;
                nextHosptial: string;
                helpExperience: {
                    toilet: string;
                    washing: string;
                    movement: string;
                    suction: string;
                }
                strengthList: string[]
                warningList: string[]
            }
```

상세 페이지의 찜 개수 데이터는 아직 찜 Api 리팩토링하지 않아 임시 데이터 넣어둠