### PR TITLE
[백엔드] UserService getMyProfile() 메서드 중복 호출 제거

### DIFF
--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -11,6 +11,7 @@ import { ProtectorRegisterDto } from "src/profile/interface/dto/protector-regist
 import { PatientProfileService } from "../../../profile/application/service/patient-profile.service";
 import { MyProfileDto } from "src/user/interface/dto/my-profile.dto";
 import { AuthService } from "src/auth/application/service/auth.service";
+import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 
 @Injectable()
 export class UserService {
@@ -34,12 +35,11 @@ export class UserService {
     }
 
     async getMyProfile(user: User): Promise<MyProfileDto> {
+        let caregiverProfile: CaregiverProfile;
         /* 간병인이면 프로필 조회해서  */
-        if( user.getRole() === ROLE.CAREGIVER ) {
-            const caregiverProfile = await this.caregiverProfileService.getProfileByUserId(user.getId());
-            return await this.userMapper.toMyProfileDto(user, caregiverProfile);
-        }
-        return await this.userMapper.toMyProfileDto(user);
+        if( user.getRole() === ROLE.CAREGIVER ) 
+            caregiverProfile = await this.caregiverProfileService.getProfileByUserId(user.getId());
+        return await this.userMapper.toMyProfileDto(user, caregiverProfile);
     }
 
     /* 가입 목적별 프로필 추가 */

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -115,7 +115,7 @@ describe('UserService Test', () => {
             await userService.getMyProfile(protector as unknown as User);
 
             expect(repositorySpy).toBeCalledTimes(0);
-            expect(mapperSpy).toBeCalledWith(protector)
+            expect(mapperSpy).toBeCalledWith(protector, undefined)
         })
     })
 })


### PR DESCRIPTION
getMyProfile() 메서드에서 **toMyProfileDto()**를 호출하는 부분 수정

toMyProfile()의 파라미터로 사용자와 프로필이 오는데 프로필은 **Optional**로 설정하여 없는 경우 **undefined**로 통합하여 호출하도록 변경