### PR TITLE
Fixed(#65): 조회된 ProfileId 찾지 못하는 문제 해결

### DIFF
--- a/backend/src/rank/domain/entity/profile-view-record.entity.ts
+++ b/backend/src/rank/domain/entity/profile-view-record.entity.ts
@@ -10,7 +10,7 @@ export class ProfileViewRecord {
     @Column({ 
         name: 'profile_id', 
         type: 'binary', 
-        length: 16, 
+        length: 12, 
         transformer: new UUIDTransformer() 
     })
     private profileId: string;

--- a/backend/src/rank/infra/profile-view-rank.repository.ts
+++ b/backend/src/rank/infra/profile-view-rank.repository.ts
@@ -12,7 +12,7 @@ export class ProfileViewRankRepository implements IRankRepository {
         private readonly redis: RedisClientType,
         private readonly configService: ConfigService
     ) {
-        this.rankKey = configService.get('profile_view_rank_key');
+        this.rankKey = configService.get('db.redis.key.profile_view_rank_key');
     };
 
     async increment(profileId: string): Promise<void> {

--- a/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
+++ b/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm";
+import { ObjectId } from "mongodb";
 import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
 import { IActionRecordRepository } from "src/rank/domain/iaction-record.repository"
 import { profileViewRecordRepoMethods } from "src/rank/infra/profile-view-record.repository";
-import { UUIDUtil } from "src/util/uuid.util";
 import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture";
 
 describe('프로필 조회 기록 저장소(ProfileViewRecordRepository', () => {
@@ -28,7 +28,7 @@ describe('프로필 조회 기록 저장소(ProfileViewRecordRepository', () => 
     });
 
     describe('findRecordByActionAndUser', () => {
-        const [profileId, userId] = [UUIDUtil.generateOrderedUuid(), 1];
+        const [profileId, userId] = [new ObjectId().toHexString(), 1];
 
         beforeAll(async() => {
             const profileViewRecord = new ProfileViewRecord(profileId, userId);


### PR DESCRIPTION
Fixed #65 
ProfileId는 MongoDB의 **ObjectId**를 쓰고 있는데 type을 binary(16)으로 사용하여 빈 값 패딩

**binary(12)** 로 변경하여 해결