### PR TITLE
[백엔드] 쿼리에 필요한 옵션 객체로 변환해주는 Mapper Method 추가

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -3,9 +3,13 @@ import { ObjectId } from "mongodb";
 import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.builder";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
+import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
+import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
+import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
+import { ProfileSort } from "src/profile/domain/profile-sort";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
+import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
-import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Injectable()
@@ -31,8 +35,17 @@ export class CaregiverProfileMapper {
             .build()
     };
 
+    /* 리스트의 쿼리 옵션으로 변환 */
+    toListQueryOptions(getProfileListDto: GetProfileListDto): ProfileListQueryOptions {
+        return new ProfileListQueryOptions( 
+            new ProfileListCursor(getProfileListDto.nextCursor),
+            new ProfileSort(getProfileListDto.sort),
+            getProfileListDto.filter
+        );
+    };
+
     /* 사용자 데이터와 프로필 데이터로 클라이언트 노출용 데이터 변환 */
-    toListDto(user: User, caregiverProfile: CaregiverProfile): ProfileListDto {
+    toListDto(user: User, caregiverProfile: CaregiverProfile): CaregiverProfileListData {
         return {
             user: {
                 name: user.getName(),

--- a/backend/src/profile/domain/profile-filter.ts
+++ b/backend/src/profile/domain/profile-filter.ts
@@ -1,12 +1,12 @@
 import { Transform } from "class-transformer";
-import { IsArray, IsBoolean, IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsArray, IsBoolean, IsEnum, IsNumber, IsNumberString, IsOptional, IsString } from "class-validator";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { PossibleDate } from "./enum/possible-date.enum";
 
 export class ProfileFilter {    
     @IsOptional()
-    @Transform(({ value }) => parseInt(value) )
     @IsNumber()
+    @Transform(({ value }) => parseInt(value) )
     readonly pay?: number;
 
     @IsOptional()
@@ -18,8 +18,8 @@ export class ProfileFilter {
     readonly sex?: SEX;
 
     @IsOptional()
-    @Transform(({ value }) => parseInt(value) )
     @IsNumber()
+    @Transform(({ value }) => parseInt(value) )
     readonly age?: number;
 
     @IsOptional()

--- a/backend/src/profile/domain/profile-list-data.ts
+++ b/backend/src/profile/domain/profile-list-data.ts
@@ -1,0 +1,17 @@
+export interface CaregiverProfileListData {
+    user: {
+        name: string;
+        sex: string;
+        age: number;
+    }
+    profile: {
+        id: string;
+        userId: number;
+        career: string;
+        pay: number;
+        possibleDate: string;
+        possibleAreaList: string[] | string;
+        tagList: string[];
+        notice: string;
+    }
+};

--- a/backend/src/profile/domain/profile-list.cursor.ts
+++ b/backend/src/profile/domain/profile-list.cursor.ts
@@ -1,10 +1,10 @@
+import { CaregiverProfileListData } from "./profile-list-data";
+import { ProfileListQueryOptions } from "./profile-list-query-options";
+
 export class ProfileListCursor {
     private next?: string;
 
     constructor(next?: string) { this.next = next; };
-
-    /* 기본 최신순 제외하고 다른 정렬이 선택됐는지 */
-    hasCombinedSortConditions(): boolean { return this.next && this.next.includes('_') };
 
     /* 기본 정렬 제외한 다른 정렬의 시작 커서 값 */
     combinedOtherSortNext(): number { return parseInt( this.next.split('_')[0] ); };
@@ -12,8 +12,33 @@ export class ProfileListCursor {
     /* 기본 정렬의  */
     combinedDefaultSortNext(): string { return this.next.split('_')[1]; };
 
-    /* 다음 프로필 아이디 */
+    /* 요청에서 넘어온 cursor 값 */
     defaultSortNext(): string | undefined { return this.next; };
 
+    /* 클라이언트에게 넘겨줄 cursor 값 */
+    toClientNext(): string | null { return this.next; };
+
+    /* 다음 커서 생성 */
+    static createNextCursor(
+        profileList: CaregiverProfileListData [],
+        queryOptions: ProfileListQueryOptions
+    ) {
+        if( !profileList.length ) return new ProfileListCursor(null);
+        
+        const lastProfile = profileList.at(-1);
+        
+        let nextCursor = queryOptions.getSortOptions().hasOptions() ? 
+                this.createCombinedCursor(lastProfile, queryOptions.getSortOptions().otherField()) : lastProfile.profile.id;
+        
+        return new ProfileListCursor(nextCursor)
+    }
+
+    private static createCombinedCursor(lastProfile: CaregiverProfileListData, otherSortField: string) {
+        const otherSortFieldLastValue = otherSortField === 'pay' ? 
+            lastProfile.profile.pay : lastProfile.profile.possibleDate;
+        return `${otherSortFieldLastValue}_${lastProfile.profile.id}`;
+    }
+
+    /* 테스트용 */
     static of(next?: string): ProfileListCursor { return new ProfileListCursor(next); };
 }

--- a/backend/src/profile/interface/dto/get-profile-list.dto.ts
+++ b/backend/src/profile/interface/dto/get-profile-list.dto.ts
@@ -1,0 +1,22 @@
+import { Transform, Type, plainToInstance } from "class-transformer";
+import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
+import { Sort } from "src/profile/domain/enum/sort.enum";
+import { ProfileFilter } from "src/profile/domain/profile-filter";
+
+export class GetProfileListDto {
+    @IsOptional()
+    @IsString()
+    nextCursor?: string;
+
+    @IsOptional()
+    @IsEnum(Sort)
+    sort: Sort;
+
+    @IsOptional()
+    @ValidateNested()
+    @Transform(({ value }) => value ? plainToInstance(ProfileFilter, JSON.parse(value)) : undefined)
+    @Type(() => ProfileFilter)
+    filter?: ProfileFilter;
+
+    static of(filter?: ProfileFilter, sort?: Sort) { return { sort, filter }; };
+}

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -6,6 +6,11 @@ import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto,
 import { TestUser } from "test/unit/user/user.fixtures";
 import { TestCaregiverProfile } from "../../profile.fixtures";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { Sort } from "src/profile/domain/enum/sort.enum";
+import { ProfileFilter } from "src/profile/domain/profile-filter";
+import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
+import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
+import { ProfileSort } from "src/profile/domain/profile-sort";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
@@ -39,6 +44,20 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult.getWarningList()).toEqual([]);
         })
     });
+
+    describe('toListQueryOptions()', () => {
+        it('Cursor, Sort, Filter에 맞게 인스턴스가 생성되는지 확인', () => {
+            const sort = Sort.LowPay;
+            const filter = new ProfileFilter();
+            const getProfileListDto = GetProfileListDto.of(filter, sort);
+
+            const mappingResult = profileMapper.toListQueryOptions(getProfileListDto);
+
+            expect(mappingResult.getNextCursor()).toBeInstanceOf(ProfileListCursor);
+            expect(mappingResult.getSortOptions()).toBeInstanceOf(ProfileSort);
+            expect(mappingResult.getFilters()).toBeInstanceOf(ProfileFilter);
+        })
+    })
 
     describe('toListDto()', () => {
 

--- a/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
+++ b/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
@@ -1,0 +1,57 @@
+import 'reflect-metadata';
+import { validate } from "class-validator";
+import { Sort } from "src/profile/domain/enum/sort.enum"
+import { plainToInstance } from 'class-transformer';
+import { PossibleDate } from 'src/profile/domain/enum/possible-date.enum';
+import { GetProfileListDto } from 'src/profile/interface/dto/get-profile-list.dto';
+import { ProfileFilter } from 'src/profile/domain/profile-filter';
+
+describe('GetProfileListDto Test', () => {
+    describe('sort 필드 Test', () => {
+        it('잘못된 Enum 체크', async () => {
+            const wrongSort = 'sortByWrong' as Sort;
+            const sortTestDto = GetProfileListDto.of(undefined, wrongSort);
+            const instanceDto = plainToInstance(GetProfileListDto, sortTestDto);
+            
+            const [result] = await validate(instanceDto);
+            expect(result.value).toBe(wrongSort);
+        });
+    })
+
+    describe('ProfileFilter Test', () => {
+        it.each([
+            ['Age Filter는 숫자, 문자열 숫자가 아니면 오류', 'Higher Than 20', 'age'],
+            ['Pay Filter는 숫자, 문자열 숫자가 아니면 오류', 'Lower Than 10', 'pay'],
+            ['StartDate Filter에 잘못된 Enum 체크', '1week', 'startDate'],
+            ['Sex Filter에 잘못된 Enum 체크', 'Women', 'sex'],
+            ['Area Filter에 문자열 배열이 아니면 오류', [1, 2,3], 'area'],
+            ['License Filter에 문자열 배열이 아니면 오류', "자격증 이름", 'license'],
+            ['StrengthExcept Filter는 boolean 아니면 오류', 'false', 'strengthExcept'],
+            ['WarningExcept Filter는 boolean 아니면 오류', 1, 'warningExcept']
+        ])('%s', async (testName, wrongValue, testFiled) => {
+            const wrongFilter = { [`${testFiled}`]: wrongValue } as unknown as ProfileFilter;
+            const filterToInstance = plainToInstance(ProfileFilter, wrongFilter);
+
+            const [result] = await validate(filterToInstance);
+            
+            expect(result.property).toBe(testFiled)
+        })
+    })
+
+    it('올바르게 입력된 Dto면 패스되는지 확인', async() => {
+        const sort = Sort.LowPay;
+        const filter = {
+            pay: 10,
+            age: 20,
+            startDate: PossibleDate.IMMEDATELY,
+            area: ['인천'],
+            license: ['자격증1']
+        };
+        const filterToInstance = plainToInstance(ProfileFilter, filter);
+        const testDto = GetProfileListDto.of(JSON.stringify(filter) as any, sort);
+        const toInstanceDto = plainToInstance(GetProfileListDto, testDto);
+
+        const result = await validate(toInstanceDto);
+        expect(result.length).toBe(0);
+    })
+})


### PR DESCRIPTION
- CaregiverProfileMapper에 toListQueryOptions() 추가

- 클라이언트로부터 프로필 리스트의 정렬 조건과 필터 조건을 담은 getProfileListDto로부터 ProfileListQueryOptions 객체로 변환

- Filter 객체는 유효성검사를 위해 Dto에서 이미 인스턴스로 생성되어 그대로 반환