### PR TITLE
[백엔드] CaregiverProfile 객체에 사용자 정보를 포함하도록 수정

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -14,10 +14,13 @@ import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Injectable()
 export class CaregiverProfileMapper {
-    mapFrom(userId: number, caregiverRegisterDto: CaregiverRegisterDto): CaregiverProfile {
+    mapFrom(user: User, caregiverRegisterDto: CaregiverRegisterDto): CaregiverProfile {
         const { secondRegister, thirdRegister, lastRegister } = caregiverRegisterDto;
         return new CaregiverProfileBuilder( new ObjectId() )
-            .userId(userId)
+            .userId(user.getId())
+            .name(user.getName())
+            .sex(user.getProfile().getSex())
+            .age(this.toDtoAge( user.getProfile().getBirth() ))
             .weight(secondRegister.weight)
             .career(secondRegister.career)
             .pay(secondRegister.pay)

--- a/backend/src/profile/domain/builder/profile.builder.ts
+++ b/backend/src/profile/domain/builder/profile.builder.ts
@@ -21,6 +21,19 @@ export class CaregiverProfileBuilder {
         return this;
     };
 
+    name(name: string): this {
+        this.caregiverProfile.setName(name);
+        return this;
+    }
+    sex(sex: SEX): this { 
+        this.caregiverProfile.setSex(sex);
+        return this;
+    };
+
+    age(age: number): this { 
+        this.caregiverProfile.setAge(age);
+        return this;
+    }
     weight(weight: number): this {
         this.caregiverProfile.setWeight(weight);
         return this;

--- a/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
+++ b/backend/src/profile/domain/entity/caregiver/caregiver-profile.entity.ts
@@ -6,6 +6,7 @@ import { License } from "./license.entity";
 import { ExposeOptions, Transform, TransformFnParams, Type } from 'class-transformer';
 import { NotFoundException } from '@nestjs/common';
 import { ErrorMessage } from 'src/common/shared/enum/error-message.enum';
+import { SEX } from 'src/user-auth-common/domain/enum/user.enum';
 
 /* _id 필드 plainToInstance 시 새로 할당하지 않기 위해 그대로 노출 */
 const ExposeId = (options?: ExposeOptions) =>
@@ -17,6 +18,9 @@ export class CaregiverProfile {
     @ExposeId()
     readonly _id: ObjectId;
     private userId: number; // mysql 사용자 계정 ID
+    private name: string; // 이름
+    private sex: SEX; // 성별
+    private age: number; // 나이
     private weight: number; // 몸무게
     private career: number; // 경력
     private pay: number; // 일당
@@ -37,6 +41,9 @@ export class CaregiverProfile {
 
     /* Setter Method */
     setUserId(userId: number) { this.userId = userId; };
+    setName(name: string) { this.name = name; };
+    setSex(sex: SEX) { this.sex = sex; };
+    setAge(age: number) { this.age = age; };
     setWeight(weight: number) { this.weight = weight; };
     setCareer(career: number) { this.career = career; };
     setPay(pay: number) { this.pay = pay; };
@@ -54,6 +61,9 @@ export class CaregiverProfile {
 
     getId(): string { return this._id.toHexString(); };
     getUserId(): number { return this.userId; };
+    getName(): string { return this.name; };
+    getSex(): SEX { return this.sex; };
+    getAge(): number { return this.age; };
     getCareer(): number { return this.career; };
     getPay(): number { return this.pay; };
     getNextHosptial(): string { return this.nextHosptial; };

--- a/backend/src/user/application/service/user.service.ts
+++ b/backend/src/user/application/service/user.service.ts
@@ -29,7 +29,7 @@ export class UserService {
 
         const savedUser = await this.userRepository.save(user); // DB에 저장하고 ID를 발급받음
 
-        await this.addProfile(savedUser.getId(), registerDto); // 각자의 역할 프로필 저장
+        await this.addProfile(savedUser, registerDto); // 각자의 역할 프로필 저장
 
         return await this.authService.createAuthentication(savedUser); // 새로운 토큰들을 발급받아 저장
     }
@@ -43,10 +43,10 @@ export class UserService {
     }
 
     /* 가입 목적별 프로필 추가 */
-    private async addProfile(userId: number, registerDto: CaregiverRegisterDto | ProtectorRegisterDto) {
+    private async addProfile(user: User, registerDto: CaregiverRegisterDto | ProtectorRegisterDto) {
         registerDto.firstRegister.purpose == ROLE.CAREGIVER ?
-            await this.caregiverProfileService.addProfile(userId, registerDto as CaregiverRegisterDto) : 
-                await this.patientProfileService.addProfile(userId, registerDto as ProtectorRegisterDto);
+            await this.caregiverProfileService.addProfile(user, registerDto as CaregiverRegisterDto) : 
+                await this.patientProfileService.addProfile(user.getId(), registerDto as ProtectorRegisterDto);
     };
 
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -11,14 +11,22 @@ import { ProfileFilter } from "src/profile/domain/profile-filter";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
 import { ProfileSort } from "src/profile/domain/profile-sort";
+import { SEX } from "src/user-auth-common/domain/enum/user.enum";
+import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
-    const userId = 1;
 
     describe('mapFrom()', () => {
+        const [userId, name, birth, sex, expectedAge] = [1, '테스트', 19980303, SEX.MALE, 25];
+        const user = TestUser
+                    .default()
+                    .withId(userId)
+                    .withName(name)
+                    .withUserProfile(new UserProfile(birth, sex)) as unknown as User;
+
         it('간병인 회원가입 양식으로부터 프로필로 변환', () => {
-            const mappingResult = profileMapper.mapFrom(userId, CaregiverRegisterDto.of(
+            const mappingResult = profileMapper.mapFrom(user, CaregiverRegisterDto.of(
                 {} as CommonRegisterForm,
                 createSecondRegisterForm(),
                 createThirdRegisterForm(),
@@ -28,6 +36,8 @@ describe('Caregiver Profile Mapper Component Test', () => {
             expect(mappingResult).toBeInstanceOf(CaregiverProfile);
             expect(mappingResult.getId()).not.toBeNull();
             expect(mappingResult.getUserId()).toBe(userId);
+            expect(mappingResult.getAge()).toBe(expectedAge);
+            expect(mappingResult.getSex()).toBe(sex);
 
             mappingResult.getLicenseList()
                 .map(license => {

--- a/backend/test/unit/user/application/service/user-service.spec.ts
+++ b/backend/test/unit/user/application/service/user-service.spec.ts
@@ -63,7 +63,7 @@ describe('UserService Test', () => {
             const result = await userService.register(registerDto);
 
             expect(userRepository.save).toBeCalledWith(caregiverUser); // 먼저 계정 DB 호출
-            expect(caregiverProfileService.addProfile).toBeCalledWith(savedUser.getId(), registerDto); // 간병인 프로필 저장 호출
+            expect(caregiverProfileService.addProfile).toBeCalledWith(savedUser, registerDto); // 간병인 프로필 저장 호출
             expect(result).toEqual(clientDto); // return 결과
         });
 

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -39,6 +39,11 @@ export class TestUser {
         return this;
     };
 
+    withName(name: string): this {
+        this.name = name;
+        return this;
+    }
+
     withSex(sex: SEX): this {
         this.sex = sex;
         return this;


### PR DESCRIPTION
MongoDB에 저장되어있는 간병인 정보와 MySQL에 저장되어 있는 사용자 정보를 프로필 조회 시 따로 가져오지 않고

MongoDB에 비정규화 모델로 저장