### PR TITLE
[백엔드] MongoQueryFactory Util Class에 WithOperators() 메서드 추가

### DIFF
--- a/backend/src/util/mongodb/mongo-query.factory.ts
+++ b/backend/src/util/mongodb/mongo-query.factory.ts
@@ -73,8 +73,31 @@ export abstract class MongoQueryFactory {
      * @param value 값
      * @example ('ne', 70) => {$ne: 70}
      */
-    operator<T>(operator: string, value: T | T []): MongoOperator<T> {
+    operator<T>(operator: string, value: T | T []): MongoOperator<T> | null {
+        if( value === undefined || Number.isNaN(value) ) return null;
+
         return { [`\$${operator}`]: value };
+    }
+
+    /**
+     * 하나의 필드에 여러개의 연산자를 적용하기 위한 메서드
+     * @param field 여러개의 연산자를 적용하고자 하는 필드
+     * @param operators operator()를 사용하여 나온 연산자
+     */
+    withOperators<T>(field: string, ...operators: MongoOperator<T>[]): MongoQuery<MongoOperator<T>> | null{
+        operators = operators.filter((operator) => operator);
+
+        if( !operators.length ) return null;
+
+        const completedOperator = operators.reduce(
+            (combinedOperator, operator) => ({
+            ...combinedOperator,
+            ...operator
+        }), {});
+        
+        return { 
+            [field]: completedOperator
+        }
     }
 
     /**

--- a/backend/test/unit/util/mongodb/query-factory.spec.ts
+++ b/backend/test/unit/util/mongodb/query-factory.spec.ts
@@ -76,7 +76,41 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
             const expectedQuery = { [`\$${operator}`]: value };
 
             const resultQuery = queryFactory.operator(operator, value);
-            expect(resultQuery).toEqual(resultQuery);
+            expect(resultQuery).toEqual(expectedQuery);
+        });
+
+        it.each([
+            undefined,
+            NaN
+        ])('%s이 값으로 왔을 때 Null 값을 반환하는지 확인', (value) => {
+            const resultQuery = queryFactory.operator('ne', value);
+
+            expect(resultQuery).toBe(null);
+        })
+    });
+
+    describe('withOperators()', () => {
+        it('연산자로 null값이 반환된 값들은 제외하고 생성', () => {
+            const ltThan = { '$lt': 30 };
+            const resultQuery = queryFactory.withOperators('age', null, ltThan);
+            const expectedQuery = { 'age': ltThan };
+            
+            expect(resultQuery).toEqual(expectedQuery);
+        });
+
+        it('모든 연산자들이 null값으로 반환되었다면 null로 반환하는지 확인', () => {
+            const resultQuery = queryFactory.withOperators('age', null, null, null);
+
+            expect(resultQuery).toBe(null);
+        });
+
+        it('정상적인 연산 조건들이 들어왔을 때 정상 작동하는지 확인', () => {
+            const ltThan = { '$lt': 30 };
+            const gtThan = { '$gt': 40 };
+            const expectedQuery = { 'age': { ...ltThan, ...gtThan }};
+            const resultQuery = queryFactory.withOperators('age', ltThan, gtThan);
+            
+            expect(resultQuery).toEqual(expectedQuery);
         })
     })
 })


### PR DESCRIPTION
하나의 필드에 여러 연산자를 결합해주는 메서드

연산자들이 null값이라면 해당 메서드도 null을 반환해 자동으로 조건에서 제외

미리 만들어놓은 **operator()** 에서도 값이 undefined 또는 NaN일 때 null 값을 반환하도록 수정