### PR TITLE
[백엔드] QueryFactory와 PipelineBuilder를 활용하여 ProfileListQueryFactory 구현

### DIFF
--- a/backend/src/profile/domain/profile-list-query-options.ts
+++ b/backend/src/profile/domain/profile-list-query-options.ts
@@ -9,7 +9,7 @@ export class ProfileListQueryOptions {
  
     getNextCursor(): ProfileListCursor { return this.nextCursor; }; 
     getSortOptions(): ProfileSort | undefined { return this.sort; };
-    hasSortOptions(): boolean { return this.sort.hasOptions() }; // 기본 최신순을 제외한 정렬 옵션이 있는지
+    hasSortOptions(): boolean { return this.sort.hasOption() }; // 기본 최신순을 제외한 정렬 옵션이 있는지
     getFilters(): ProfileFilter { return this.filters; };
     
     constructor(next?: ProfileListCursor, sort?: ProfileSort, filters?: ProfileFilter) {

--- a/backend/src/profile/domain/profile-list.cursor.ts
+++ b/backend/src/profile/domain/profile-list.cursor.ts
@@ -5,12 +5,16 @@ export class ProfileListCursor {
     private next?: string;
 
     constructor(next?: string) { this.next = next; };
-
+    
     /* 기본 정렬 제외한 다른 정렬의 시작 커서 값 */
-    combinedOtherSortNext(): number { return parseInt( this.next.split('_')[0] ); };
+    combinedOtherSortNext(): number | undefined { 
+        return this.next ? parseInt( this.next.split('_')[0] ) : undefined;
+    };
 
     /* 기본 정렬의  */
-    combinedDefaultSortNext(): string { return this.next.split('_')[1]; };
+    combinedDefaultSortNext(): string | undefined { 
+        return this.next ? this.next.split('_')[1] : undefined;
+    };
 
     /* 요청에서 넘어온 cursor 값 */
     defaultSortNext(): string | undefined { return this.next; };
@@ -27,16 +31,16 @@ export class ProfileListCursor {
         
         const lastProfile = profileList.at(-1);
         
-        let nextCursor = queryOptions.getSortOptions().hasOptions() ? 
-                this.createCombinedCursor(lastProfile, queryOptions.getSortOptions().otherField()) : lastProfile.profile.id;
+        let nextCursor = queryOptions.getSortOptions().hasOption() ? 
+                this.createCombinedCursor(lastProfile, queryOptions.getSortOptions().otherField()) : lastProfile.id;
         
         return new ProfileListCursor(nextCursor)
     }
 
     private static createCombinedCursor(lastProfile: CaregiverProfileListData, otherSortField: string) {
         const otherSortFieldLastValue = otherSortField === 'pay' ? 
-            lastProfile.profile.pay : lastProfile.profile.possibleDate;
-        return `${otherSortFieldLastValue}_${lastProfile.profile.id}`;
+            lastProfile.pay : lastProfile.possibleDate;
+        return `${otherSortFieldLastValue}_${lastProfile.id}`;
     }
 
     /* 테스트용 */

--- a/backend/src/profile/domain/profile-sort.ts
+++ b/backend/src/profile/domain/profile-sort.ts
@@ -3,8 +3,10 @@ import { Sort } from './enum/sort.enum'
 export class ProfileSort {
     private by?: Sort;
 
-    hasOptions(): boolean { return this.by ? true : false; }; // 다른 정렬기준이 있는지
+    hasOption(): boolean { return this.by ? true : false; }; // 다른 정렬기준이 있는지
 
+    getOption(): Sort { return this.by; };
+    
     otherField(): string { return this.by === Sort.LowPay ? 'pay' : 'possibleDate'; }; // 다른 정렬 기준 필드
      
     otherFieldBy(): "DESC" | "ASC" { return "ASC"; }; // 다른 정렬 기준

--- a/backend/src/profile/infra/repository/profile-query.factory.ts
+++ b/backend/src/profile/infra/repository/profile-query.factory.ts
@@ -1,0 +1,186 @@
+import { Injectable } from "@nestjs/common";
+import { MongoQuery, MongoQueryFactory } from "../../../util/mongodb/mongo-query.factory";
+import { AggregratePipelineBuilder } from "src/util/mongodb/aggregrate-pipeline.builder";
+import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
+import { ProfileSort } from "src/profile/domain/profile-sort";
+import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
+import { ProfileFilter } from "src/profile/domain/profile-filter";
+import { Sort } from "src/profile/domain/enum/sort.enum";
+
+@Injectable()
+export class ProfileQueryFactory extends MongoQueryFactory {
+
+    /* 프로필 리스트를 조회하는 Query */
+    listPipeline(listQueryOptions: ProfileListQueryOptions): any {
+        
+        /* builder 초기화 */
+        const pipelineBuilder = AggregratePipelineBuilder.initialize();
+
+        /* 정렬 조건이 추가로 있는 경우 해당 조건에 맞게 파이프라인 생성 */
+        if( listQueryOptions.hasSortOptions() ) {
+            this.createListPipelineWithSortOptions(
+                pipelineBuilder, listQueryOptions.getNextCursor(),
+                listQueryOptions.getSortOptions(), listQueryOptions.getFilters()
+            );
+        }
+        /* 정렬 조건이 추가로 없는 경우 최신순으로만 정렬하여 파이프라인 생성 */ 
+        else {
+            this.createListPipelineWithNonSortOptions(
+                pipelineBuilder, listQueryOptions.getNextCursor(),
+                listQueryOptions.getSortOptions(), listQueryOptions.getFilters()
+            );
+        }
+
+        /* 정렬 조건에 따른 파이프라인 스테이지를 추가하고 마지막 Project 스테이지 추가 */
+        return this.addListProjectStage(pipelineBuilder).build();
+    };
+
+    /* 정렬 조건이 추가로 있는 경우 */
+    private createListPipelineWithSortOptions(
+        pipelineBuilder: AggregratePipelineBuilder,
+        nextCursor: ProfileListCursor,
+        sort: ProfileSort,
+        filters: ProfileFilter
+    ) {
+        const { pay, sex, startDate, age, area, license, strengthExcept } = filters;
+
+        /* 정렬 조건이 일당 낮은 순 */
+        if ( sort.getOption() === Sort.LowPay ) {
+            pipelineBuilder.match(
+                this.equals('isPrivate', false), // 비공개 프로필
+                // 마지막 프로필 커서의 일당보다 크거나, 
+                // 마지막 프로필 커서의 일당과 같으면서 프로필 아이디가 더 오래된 것 
+                this.or([
+                    this.gtThan('pay', nextCursor.combinedOtherSortNext()),
+                    this.combineOperators(
+                        this.equals('pay', nextCursor.combinedOtherSortNext()),
+                        this.ltThan('_id', nextCursor.combinedDefaultSortNext())
+                    )
+                ]),
+                this.lteThan('pay', pay), // 필터 조건의 일당보다 낮은 프로필
+                this.lteThan('possibleDate', startDate), // 필터 조건의 시작 가능일보다 빠른 프로필
+                this.equals('sex', sex), // 필터 조건의 성별과 일치하는 프로필
+                // 나이의 필터는 20대, 30대식으로 이루어지기에
+                // 필터로 20대가 주어지면 조건은 20 ~ 29로 생성
+                this.equals('age',
+                    this.combineOperators(
+                        this.operator('gte', age),
+                        this.operator('lt', age + 10)
+                    )
+                ),
+                this.notEmptyStrengthList(strengthExcept), // 강점 작성한 프로필
+                this.matchAnyElementInArray('possibleAreaList', area), // 주어진 지역과 하나라도 일치하는 프로필
+                this.matchAnyElementInArray('licenseList', license) // 주어진 자격증과 하나라도 일치하는 프로필
+            )
+        }
+        /* 정렬 조건이 시작일 빠른 순 */
+        else if( sort.getOption() === Sort.FastStartDate ) {
+            /* 조건은 위와 동일 */
+            pipelineBuilder.match(
+                this.equals('isPrivate', false),
+                this.or([
+                    this.gtThan('possibleDate', nextCursor.combinedOtherSortNext()),
+                    this.combineOperators(
+                        this.equals('possibleDate', nextCursor.combinedOtherSortNext()),
+                        this.ltThan('_id', nextCursor.combinedDefaultSortNext())
+                    )
+                ]),
+                this.lteThan('possibleDate', startDate),
+                this.lteThan('pay', pay),
+                this.equals('sex', sex), 
+                this.equals('age',
+                    this.combineOperators(
+                        this.operator('gte', age),
+                        this.operator('lt', age + 10)
+                    )
+                ),
+                this.notEmptyStrengthList(strengthExcept), // 강점 작성한 프로필
+                this.matchAnyElementInArray('possibleAreaList', area), // 주어진 지역과 하나라도 일치하는 프로필
+                this.matchAnyElementInArray('licenseList', license) // 주어진 자격증과 하나라도 일치하는 프로필
+            )
+        }
+        /* 정렬 조건은 추가로 있는데 첫 요청일 경우 */
+        else {
+            /* 조건은 위와 동일 */
+            pipelineBuilder.match(
+                this.equals('isPrivate', false),
+                this.lteThan('pay', pay),
+                this.lteThan('possibleDate', startDate),
+                this.equals('sex', sex), 
+                this.equals('age',
+                    this.combineOperators(
+                        this.operator('gte', age),
+                        this.operator('lt', age + 10)
+                    )
+                ),
+                this.notEmptyStrengthList(strengthExcept), // 강점 작성한 프로필
+                this.matchAnyElementInArray('possibleAreaList', area), // 주어진 지역과 하나라도 일치하는 프로필
+                this.matchAnyElementInArray('licenseList', license) // 주어진 자격증과 하나라도 일치하는 프로필
+            )
+        }
+
+        /* 호출되는 시점에 정렬 기준으로 들어온 필드와 이후 최신순으로 정렬 */
+        pipelineBuilder.sort(
+            this.orderBy(sort.otherField(), sort.otherFieldBy()),
+            this.orderBy(sort.defaultField(), sort.defaultFieldBy())
+        )
+    };
+
+    /* 정렬 조건이 추가로 없는 경우 */
+    private createListPipelineWithNonSortOptions (
+        pipelineBuilder: AggregratePipelineBuilder,
+        nextCursor: ProfileListCursor,
+        sort: ProfileSort,
+        filters: ProfileFilter
+    ) {
+        const { pay, sex, startDate, age, area, license, strengthExcept } = filters;
+
+        pipelineBuilder
+            .match(
+                /* 이전 요청에 아이디가 있다면 해당 아이디 다음부터 */
+                this.ltThan('_id', nextCursor.defaultSortNext()), 
+                this.equals('isPrivate', false),
+                this.lteThan('pay', pay), 
+                this.lteThan('possibleDate', startDate), 
+                this.equals('sex', sex), 
+                this.equals('age',
+                    this.combineOperators(
+                        this.operator('gte', age),
+                        this.operator('lt', age + 10)
+                    )
+                ),
+                this.notEmptyStrengthList(strengthExcept), 
+                this.matchAnyElementInArray('possibleAreaList', area), 
+                this.matchAnyElementInArray('licenseList', license) 
+            )
+            .sort(
+                this.orderBy(sort.defaultField(), sort.defaultFieldBy()) // 최신순 정렬
+            )
+    }
+
+    /* 프로필 리스트 조회 파이프라인에 Project 스테이지 추가 */
+    private addListProjectStage(pipelineBuilder: AggregratePipelineBuilder) {
+        pipelineBuilder.project(
+            this.rename('id', this.operator('toString', '$_id')), // _id -> id로 변경
+            this.exclude('_id'), // _id 필드 제외
+            this.select('userId'),
+            this.select('name'),
+            this.select('age'),
+            this.select('sex'),
+            this.select('career'),
+            this.select('pay'),
+            this.select('notice'),
+            this.select('possibleDate'),
+            this.select('possibleAreaList'),
+            this.select('tagList')
+        );
+        return pipelineBuilder;
+    }
+
+    /* 강점을 작성하지 않은 프로필들은 제외 */
+    private notEmptyStrengthList(strengthExcept: boolean): MongoQuery<[]> | null {
+        if (!strengthExcept) return null;
+
+        return this.notEmptyArray('strengthList');
+    }
+}

--- a/backend/test/unit/profile/infra/repository/profile-query-factory.spec.ts
+++ b/backend/test/unit/profile/infra/repository/profile-query-factory.spec.ts
@@ -1,0 +1,147 @@
+import { plainToInstance } from "class-transformer"
+import { ObjectId } from "mongodb"
+import { PossibleDate } from "src/profile/domain/enum/possible-date.enum"
+import { Sort } from "src/profile/domain/enum/sort.enum"
+import { ProfileFilter } from "src/profile/domain/profile-filter"
+import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options"
+import { ProfileListCursor } from "src/profile/domain/profile-list.cursor"
+import { ProfileSort } from "src/profile/domain/profile-sort"
+import { ProfileQueryFactory } from "src/profile/infra/repository/profile-query.factory"
+import { SEX } from "src/user-auth-common/domain/enum/user.enum"
+
+describe('ProfileQueryFactory Test', () => {
+    const queryFactory = new ProfileQueryFactory();
+
+    describe('정렬 조건이 없는 경우', () => {
+        it('필터 중 동적쿼리를 통해 정확한 Pipeline이 생성되는지 확인', () => {
+            const filter = plainToInstance(
+                ProfileFilter,
+                { age: 50, sex: SEX.MALE, pay: 20 },
+            );
+
+            const listQueryOptions = new ProfileListQueryOptions(
+                new ProfileListCursor(), new ProfileSort(), filter
+            );
+            const expectedPipeline = [
+                {
+                    $match:
+                    {
+                        isPrivate: false,
+                        pay: { '$lte': 20 },
+                        sex: SEX.MALE,
+                        age: { '$gte': 50, '$lt': 60 }
+                    }
+                },
+                {
+                    $sort: { _id: -1 }
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        age: 1,
+                        career: 1,
+                        id: { $toString: "$_id" },
+                        name: 1,
+                        notice: 1,
+                        pay: 1,
+                        possibleAreaList: 1,
+                        possibleDate: 1,
+                        sex: 1,
+                        tagList: 1,
+                        userId: 1,
+                    },
+                }
+            ];
+
+            const resultPipeline = queryFactory.listPipeline(listQueryOptions);
+            expect(resultPipeline).toEqual(expectedPipeline);
+        })
+    });
+
+    describe('정렬 조건이 있는 경우', () => {
+        it('Next Cursor가 없는 경우(첫 요청) Pipeline 확인', () => {
+            const sortOption = new ProfileSort(Sort.LowPay);
+            const filter = plainToInstance(
+                ProfileFilter,
+                { startDate: PossibleDate.WITHIN1MONTH }
+            )
+            const listQueryOptions = new ProfileListQueryOptions(
+                new ProfileListCursor(), sortOption, filter
+            );
+            const expectedPipeline = [
+                {
+                    $match:
+                    {
+                        isPrivate: false,
+                        possibleDate: { $lte: PossibleDate.WITHIN1MONTH }
+                    }
+                },
+                {
+                    $sort: { pay: 1, _id: -1 }
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        age: 1,
+                        career: 1,
+                        id: { $toString: "$_id" },
+                        name: 1,
+                        notice: 1,
+                        pay: 1,
+                        possibleAreaList: 1,
+                        possibleDate: 1,
+                        sex: 1,
+                        tagList: 1,
+                        userId: 1,
+                    },
+                }
+            ];
+            const resultPipeline = queryFactory.listPipeline(listQueryOptions);
+            expect(resultPipeline).toEqual(expectedPipeline)
+        });
+
+        it('다음 커서가 있을 때 생성되는 Pipeline 확인', () => {
+            const nextPay = 5;
+            const nextProfileId = new ObjectId().toHexString();
+            const nextCursor = `${nextPay}_${nextProfileId}`;
+            
+            const sortOption = new ProfileSort(Sort.LowPay);
+            const listQueryOptions = new ProfileListQueryOptions(
+                new ProfileListCursor(nextCursor), new ProfileSort(Sort.LowPay), new ProfileFilter()
+            );
+
+            const expectedPipeline = [
+                {
+                    $match: {
+                        isPrivate: false,
+                        $or: [
+                            { pay: { $gt: nextPay } },
+                            { pay: nextPay, _id: { $lt: new ObjectId(nextProfileId) }}
+                        ]
+                    },
+                },
+                {
+                    $sort: { pay: 1, _id: -1 }
+                },
+                {
+                    $project: {
+                        _id: 0,
+                        age: 1,
+                        career: 1,
+                        id: { $toString: "$_id" },
+                        name: 1,
+                        notice: 1,
+                        pay: 1,
+                        possibleAreaList: 1,
+                        possibleDate: 1,
+                        sex: 1,
+                        tagList: 1,
+                        userId: 1,
+                    },
+                }
+            ];
+            const resultPipeline = queryFactory.listPipeline(listQueryOptions);
+            expect(resultPipeline).toEqual(expectedPipeline);
+        })
+    })
+})

--- a/backend/test/unit/util/mongodb/query-factory.spec.ts
+++ b/backend/test/unit/util/mongodb/query-factory.spec.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from "mongodb";
-import { MongoQueryFactory } from "src/util/mongodb/mongo-query.factory";
+import { MongoQueryFactory, Operator } from "src/util/mongodb/mongo-query.factory";
 
 class TestQueryFactory extends MongoQueryFactory {};
 
@@ -23,7 +23,6 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
             ['age', 20],
             ['isPrivate', false],
             ['notice', '공지확인'],
-            ['possibleDate', null]
         ])('%s 필드가 %s와 일치하는지 쿼리 생성 확인', (field, value) => {
             const expectedQuery = { [field]: value };
             const resultQuery = queryFactory.equals(field, value);
@@ -40,11 +39,23 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
             expect(resultQuery).toEqual(expectedQuery);
         });
 
-        it('값이 undefined면 쿼리 생성을 하지 않고 null 반환 확인', () => {
-            const resultQuery = queryFactory.equals('age', undefined);
+        it.each([
+            null, undefined, NaN
+        ])('값이 %s면 쿼리 생성을 하지 않고 null 반환 확인', (value) => {
+            const resultQuery = queryFactory.equals('age', value);
 
             expect(resultQuery).toBe(null);
         });
+
+        it('연산자들이 와도 정상적으로 결합하여 반환되는지 확인', () => {
+            const ltThan = { $lt: 70 };
+            const gtThan = { $gt: 80 };
+            const field = 'age';
+
+            const expectedQuery = { 'age': { ...ltThan, ...gtThan }};
+            const resultQuery = queryFactory.equals(field, { ...ltThan, ...gtThan });
+            expect(resultQuery).toEqual(expectedQuery);
+        })
     });
 
     describe('ltThan()', () => {
@@ -75,7 +86,7 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
         ])('%s 연산자와 알맞은 값 %s으로 쿼리가 생성되는지 확인', (operator, value) => {
             const expectedQuery = { [`\$${operator}`]: value };
 
-            const resultQuery = queryFactory.operator(operator, value);
+            const resultQuery = queryFactory.operator(operator as Operator, value);
             expect(resultQuery).toEqual(expectedQuery);
         });
 
@@ -89,17 +100,17 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
         })
     });
 
-    describe('withOperators()', () => {
+    describe('combineOperators()', () => {
         it('연산자로 null값이 반환된 값들은 제외하고 생성', () => {
             const ltThan = { '$lt': 30 };
-            const resultQuery = queryFactory.withOperators('age', null, ltThan);
-            const expectedQuery = { 'age': ltThan };
+            const resultQuery = queryFactory.combineOperators(null, ltThan);
+            const expectedQuery = { ...ltThan };
             
             expect(resultQuery).toEqual(expectedQuery);
         });
 
         it('모든 연산자들이 null값으로 반환되었다면 null로 반환하는지 확인', () => {
-            const resultQuery = queryFactory.withOperators('age', null, null, null);
+            const resultQuery = queryFactory.combineOperators(null, null, null);
 
             expect(resultQuery).toBe(null);
         });
@@ -107,8 +118,8 @@ describe('MongoDB의 Query를 생성해주는 추상클래스 Test', () => {
         it('정상적인 연산 조건들이 들어왔을 때 정상 작동하는지 확인', () => {
             const ltThan = { '$lt': 30 };
             const gtThan = { '$gt': 40 };
-            const expectedQuery = { 'age': { ...ltThan, ...gtThan }};
-            const resultQuery = queryFactory.withOperators('age', ltThan, gtThan);
+            const expectedQuery = { ...ltThan, ...gtThan };
+            const resultQuery = queryFactory.combineOperators(ltThan, gtThan);
             
             expect(resultQuery).toEqual(expectedQuery);
         })


### PR DESCRIPTION
- pipelineBuilder로 각 스테이지를 추가
- 각 스테이지는 MongoQueryFactory에 메서드를 상속받아 사용
- 요청마다 들어오는 다음 커서와 필터 조건들을 검사하여 동적 쿼리 생성