### PR TITLE
[백엔드] 데이터베이스에서 조회한 Profile 인터페이스 수정 및 Mapper의 toListDto() 수정

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -3,7 +3,7 @@ import { ObjectId } from "mongodb";
 import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.builder";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
-import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
+import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
 import { ProfileSort } from "src/profile/domain/profile-sort";
@@ -16,11 +16,11 @@ import { User } from "src/user-auth-common/domain/entity/user.entity";
 export class CaregiverProfileMapper {
     mapFrom(user: User, caregiverRegisterDto: CaregiverRegisterDto): CaregiverProfile {
         const { secondRegister, thirdRegister, lastRegister } = caregiverRegisterDto;
-        return new CaregiverProfileBuilder( new ObjectId() )
+        return new CaregiverProfileBuilder(new ObjectId())
             .userId(user.getId())
             .name(user.getName())
             .sex(user.getProfile().getSex())
-            .age(this.toDtoAge( user.getProfile().getBirth() ))
+            .age(this.toDtoAge(user.getProfile().getBirth()))
             .weight(secondRegister.weight)
             .career(secondRegister.career)
             .pay(secondRegister.pay)
@@ -40,7 +40,7 @@ export class CaregiverProfileMapper {
 
     /* 리스트의 쿼리 옵션으로 변환 */
     toListQueryOptions(getProfileListDto: GetProfileListDto): ProfileListQueryOptions {
-        return new ProfileListQueryOptions( 
+        return new ProfileListQueryOptions(
             new ProfileListCursor(getProfileListDto.nextCursor),
             new ProfileSort(getProfileListDto.sort),
             getProfileListDto.filter
@@ -48,50 +48,42 @@ export class CaregiverProfileMapper {
     };
 
     /* 사용자 데이터와 프로필 데이터로 클라이언트 노출용 데이터 변환 */
-    toListDto(user: User, caregiverProfile: CaregiverProfile): CaregiverProfileListData {
+    toListDto(caregiverProfileListData: CaregiverProfileListData): ProfileListDataAsClient {
         return {
-            user: {
-                name: user.getName(),
-                sex: user.getProfile().getSex(),
-                age: this.toDtoAge(user.getProfile().getBirth())
-            },
-            profile: {
-                id: caregiverProfile.getId(),
-                userId: caregiverProfile.getUserId(),
-                career: this.toDtoCareer(caregiverProfile.getCareer()),
-                pay: caregiverProfile.getPay(),
-                possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
-                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'list'),
-                tagList: caregiverProfile.getTagList(),
-                notice: caregiverProfile.getNotice()
-            }
+            id: caregiverProfileListData.id,
+            name: caregiverProfileListData.name,
+            sex: caregiverProfileListData.sex,
+            age: this.toDtoAge(caregiverProfileListData.age),
+            userId: caregiverProfileListData.userId,
+            career: this.toDtoCareer(caregiverProfileListData.career),
+            pay: caregiverProfileListData.pay,
+            possibleDate: this.toDtoPossibleDate(caregiverProfileListData.possibleDate),
+            possibleAreaList: this.toDtoAreaList(caregiverProfileListData.possibleAreaList, 'list'),
+            tagList: caregiverProfileListData.tagList,
+            notice: caregiverProfileListData.notice
         }
     };
 
     /* 프로필 상세보기에 필요한 데이터에 맞춰 변환 */
-    toDetailDto(user: User, caregiverProfile: CaregiverProfile): ProfileDetailDto {
+    toDetailDto(caregiverProfile: CaregiverProfile): ProfileDetailDto {
 
         return {
-            user: {
-                name: user.getName(),
-                sex: user.getProfile().getSex(),
-                age: this.toDtoAge(user.getProfile().getBirth())
-            },
-            profile: {
-                id: caregiverProfile.getId(),
-                userId: caregiverProfile.getUserId(),
-                career: this.toDtoCareer(caregiverProfile.getCareer()),
-                pay: caregiverProfile.getPay(),
-                possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
-                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
-                notice: caregiverProfile.getNotice(),
-                licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
-                additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
-                nextHosptial: caregiverProfile.getNextHosptial(),
-                helpExperience: caregiverProfile.getHelpExperience(),
-                strengthList: caregiverProfile.getStrengthList(),
-                warningList: caregiverProfile.getWarningList()
-            }
+            id: caregiverProfile.getId(),
+            name: caregiverProfile.getName(),
+            sex: caregiverProfile.getSex(),
+            age: this.toDtoAge(caregiverProfile.getAge()),
+            userId: caregiverProfile.getUserId(),
+            career: this.toDtoCareer(caregiverProfile.getCareer()),
+            pay: caregiverProfile.getPay(),
+            possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
+            possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
+            notice: caregiverProfile.getNotice(),
+            licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
+            additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
+            nextHosptial: caregiverProfile.getNextHosptial(),
+            helpExperience: caregiverProfile.getHelpExperience(),
+            strengthList: caregiverProfile.getStrengthList(),
+            warningList: caregiverProfile.getWarningList()
         }
     };
 
@@ -101,15 +93,15 @@ export class CaregiverProfileMapper {
     };
 
     /* 클라이언트 데이터 노출에 맞게 인증이 완료된 자격증만 노출 */
-    private toDtoLicenseList(licenseList: License []): string [] {        
+    private toDtoLicenseList(licenseList: License[]): string[] {
         return licenseList.filter(license => license.getIsCertified())
-                        .map(certificatedLicense => certificatedLicense.getName());
+            .map(certificatedLicense => certificatedLicense.getName());
     }
 
     /* 클라이언트 데이터 노출에 맞게 나이 변환 */
     private toDtoAge(birth: number): number {
         const [currentYear, userYear] = [
-            new Date().getFullYear(), 
+            new Date().getFullYear(),
             parseInt(birth.toString().substring(0, 4))
         ];
 
@@ -118,7 +110,7 @@ export class CaregiverProfileMapper {
 
     /* 클라이언트 데이터 노출에 맞게 경력 변환 */
     private toDtoCareer(career: number): string {
-        if( career < 12 ) return `${career}개월`;
+        if (career < 12) return `${career}개월`;
 
         const [year, month] = [Math.floor(career / 12), career % 12];
         return month ? `${year}년 ${month}개월` : `${year}년`;
@@ -126,7 +118,7 @@ export class CaregiverProfileMapper {
 
     /* ENUM으로 변경 요망 */
     private toDtoPossibleDate(value: number): string {
-        switch(value) {
+        switch (value) {
             case 1:
                 return '즉시가능';
             case 2:
@@ -135,7 +127,7 @@ export class CaregiverProfileMapper {
                 return '2주이내';
             case 4:
                 return '3주이내';
-            case 5: 
+            case 5:
                 return '한달이내';
         };
     };
@@ -143,6 +135,6 @@ export class CaregiverProfileMapper {
     /* 클라이언트 데이터 노출에 맞게 가능 지역 변환 */
     private toDtoAreaList(areaList: string[], page: string): string[] | string {
         /* 메인 페이지에서는 화면이 잘리므로 지역이 많으면 줄여서 노출 */
-        return ( areaList.length >= 4 && page === 'list' ) ? '상세보기참고' : areaList.join(',');
+        return (areaList.length >= 4 && page === 'list') ? '상세보기참고' : areaList.join(',');
     }
 }

--- a/backend/src/profile/domain/profile-list-data.ts
+++ b/backend/src/profile/domain/profile-list-data.ts
@@ -1,4 +1,20 @@
+// DB에서 조회되는 데이터 형식
 export interface CaregiverProfileListData {
+    id: string;
+    userId: number;
+    name: string;
+    sex: string;
+    age: number;
+    career: number;
+    pay: number;
+    possibleDate: number;
+    possibleAreaList: string[];
+    tagList: string[];
+    notice: string;
+};
+
+// 프론트엔드에서 필요한 형식으로 변환
+export interface ProfileListDataAsClient {
     id: string;
     userId: number;
     name: string;
@@ -10,4 +26,4 @@ export interface CaregiverProfileListData {
     possibleAreaList: string[] | string;
     tagList: string[];
     notice: string;
-};
+}

--- a/backend/src/profile/domain/profile-list.cursor.ts
+++ b/backend/src/profile/domain/profile-list.cursor.ts
@@ -1,4 +1,4 @@
-import { CaregiverProfileListData } from "./profile-list-data";
+import { ProfileListDataAsClient } from "./profile-list-data";
 import { ProfileListQueryOptions } from "./profile-list-query-options";
 
 export class ProfileListCursor {
@@ -20,11 +20,11 @@ export class ProfileListCursor {
     defaultSortNext(): string | undefined { return this.next; };
 
     /* 클라이언트에게 넘겨줄 cursor 값 */
-    toClientNext(): string | null { return this.next; };
+    toClientNext(): string | undefined { return this.next; };
 
     /* 다음 커서 생성 */
     static createNextCursor(
-        profileList: CaregiverProfileListData [],
+        profileList: ProfileListDataAsClient [],
         queryOptions: ProfileListQueryOptions
     ) {
         if( !profileList.length ) return new ProfileListCursor(null);
@@ -37,7 +37,7 @@ export class ProfileListCursor {
         return new ProfileListCursor(nextCursor)
     }
 
-    private static createCombinedCursor(lastProfile: CaregiverProfileListData, otherSortField: string) {
+    private static createCombinedCursor(lastProfile: ProfileListDataAsClient, otherSortField: string) {
         const otherSortFieldLastValue = otherSortField === 'pay' ? 
             lastProfile.pay : lastProfile.possibleDate;
         return `${otherSortFieldLastValue}_${lastProfile.id}`;

--- a/backend/src/profile/interface/dto/profile-detail.dto.ts
+++ b/backend/src/profile/interface/dto/profile-detail.dto.ts
@@ -3,24 +3,21 @@ import { SEX } from "src/user-auth-common/domain/enum/user.enum"
 import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
 
 export interface ProfileDetailDto {
-    user: {
-        name: string;
-        sex: SEX;
-        age: number;
-    },
-    profile: {
-        id: string;
-        userId: number;
-        career: string;
-        pay: number;
-        possibleDate: string;
-        possibleAreaList: string[] | string;
-        notice: string;
-        licenseList: string[] | [];
-        additionalChargeCase: string | null;
-        nextHosptial: string | null;
-        helpExperience: CaregiverHelpExperience,
-        strengthList: string[] | [],
-        warningList: Warning [] | []
-    }
+    id: string;
+    name: string;
+    sex: SEX;
+    age: number;
+    userId: number;
+    career: string;
+    pay: number;
+    possibleDate: string;
+    possibleAreaList: string[] | string;
+    notice: string;
+    licenseList: string[] | [];
+    additionalChargeCase: string | null;
+    nextHosptial: string | null;
+    helpExperience: CaregiverHelpExperience,
+    strengthList: string[] | [],
+    warningList: Warning[] | []
+
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -13,6 +13,7 @@ import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
 import { ProfileSort } from "src/profile/domain/profile-sort";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
+import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
@@ -76,11 +77,10 @@ describe('Caregiver Profile Mapper Component Test', () => {
             [13, '1년 1개월'],
             [12, '1년']
         ])('career(경력)이 클라이언트 화면용 값으로 변경되는지 확인', (testCareer, expectedCareer) => {
-            const userStub = TestUser.default() as unknown as User;
-            const profileStub = TestCaregiverProfile.default().career(testCareer).build();
+            const profileStub = TestCaregiverProfile.default().career(testCareer).build() as unknown as CaregiverProfileListData;
 
-            const result = profileMapper.toListDto(userStub, profileStub);
-            expect(result.profile.career).toBe(expectedCareer);
+            const result = profileMapper.toListDto(profileStub);
+            expect(result.career).toBe(expectedCareer);
         });
 
         it.each([
@@ -88,73 +88,62 @@ describe('Caregiver Profile Mapper Component Test', () => {
             [2, '1주이내'],
             [5, '한달이내']
         ])('possibleDate(가능한 날짜)가 클라이언트 화면용 값으로 변경되는지 확인', (testValue, expectedDate) => {
-            const userStub = TestUser.default() as unknown as User;
-            const profileStub = TestCaregiverProfile.default().possibleDate(testValue).build();
+            const profileStub = TestCaregiverProfile.default().possibleDate(testValue).build() as unknown as CaregiverProfileListData;
 
-            const result = profileMapper.toListDto(userStub, profileStub);
-            expect(result.profile.possibleDate).toBe(expectedDate);
+            const result = profileMapper.toListDto(profileStub);
+            expect(result.possibleDate).toBe(expectedDate);
         });
 
         it.each([
             [['인천', '서울'], '인천,서울'],
             [['인천', '서울', '경기', '부산'], '상세보기참고']
         ])('possibleAreaList(가능한 지역)이 클라이언트 화면용 값으로 변경되는지 확인', (testAreaList, expectedAreaList) => {
-            const userStub = TestUser.default() as unknown as User;
-            const profileStub = TestCaregiverProfile.default().possibleAreaList(testAreaList).build();
+            const profileStub = TestCaregiverProfile.default().possibleAreaList(testAreaList).build() as unknown as CaregiverProfileListData;
 
-            const result = profileMapper.toListDto(userStub, profileStub);
-            expect(result.profile.possibleAreaList).toEqual(expectedAreaList);
+            const result = profileMapper.toListDto(profileStub);
+            expect(result.possibleAreaList).toEqual(expectedAreaList);
         });
 
         it('toListDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
-            const userStub = TestUser.default() as unknown as User;
-            const profileStub = TestCaregiverProfile.default().build();
+            const profileStub = TestCaregiverProfile.default().build() as unknown as CaregiverProfileListData;
 
-            const result = profileMapper.toListDto(userStub, profileStub);
+            const result = profileMapper.toListDto(profileStub);
 
-            expect(result).toHaveProperty('user');
-            expect(result).toHaveProperty('profile');
+            expect(result).toHaveProperty('name');
+            expect(result).toHaveProperty('age');
+            expect(result).toHaveProperty('sex');
 
-            expect(result.user).toHaveProperty('name');
-            expect(result.user).toHaveProperty('age');
-            expect(result.user).toHaveProperty('sex');
-
-            expect(result.profile).toHaveProperty('id');
-            expect(result.profile).toHaveProperty('userId');
-            expect(result.profile).toHaveProperty('career');
-            expect(result.profile).toHaveProperty('pay');
-            expect(result.profile).toHaveProperty('possibleDate');
-            expect(result.profile).toHaveProperty('possibleAreaList');
-            expect(result.profile).toHaveProperty('tagList');
-            expect(result.profile).toHaveProperty('notice');
+            expect(result).toHaveProperty('id');
+            expect(result).toHaveProperty('userId');
+            expect(result).toHaveProperty('career');
+            expect(result).toHaveProperty('pay');
+            expect(result).toHaveProperty('possibleDate');
+            expect(result).toHaveProperty('possibleAreaList');
+            expect(result).toHaveProperty('tagList');
+            expect(result).toHaveProperty('notice');
         })
     });
 
     describe('toDetailDto()', () => {
-        let userStub: User;
-
-        beforeAll(() => userStub = TestUser.default() as unknown as User );
 
         it('가능한 지역을 상세페이지에선 모두 나열해주는지 확인', () => {
             const possibleAreaList = ['인천', '서울', '부산', '대구', '포항'];
             const expectedArea = '인천,서울,부산,대구,포항';
 
-            const profileStub = TestCaregiverProfile.default()
-                                                    .possibleAreaList(possibleAreaList)
-                                                    .build();
+            const profileStub = TestCaregiverProfile.default().possibleAreaList(possibleAreaList).build();
 
-            const result = profileMapper.toDetailDto(userStub, profileStub);
+            const result = profileMapper.toDetailDto(profileStub);
 
-            expect(result.profile.possibleAreaList).toBe(expectedArea);
+            expect(result.possibleAreaList).toBe(expectedArea);
         });
 
         it('자격증이 없는 사용자는 빈 배열로 반환되어야 한다', () => {
             const emptyLicenseList = [];
             const profileStub = TestCaregiverProfile.default().licenseList(emptyLicenseList).build();
 
-            const result = profileMapper.toDetailDto(userStub, profileStub);
+            const result = profileMapper.toDetailDto(profileStub);
             
-            expect(result.profile.licenseList).toEqual(emptyLicenseList);
+            expect(result.licenseList).toEqual(emptyLicenseList);
         })
 
         it('인증이 완료된 자격증의 이름은 포함되고, 완료되지 않은 자격증은 포함되지 않는지 확인', () => {
@@ -162,37 +151,35 @@ describe('Caregiver Profile Mapper Component Test', () => {
             const licenseList = [new License(unCertificatedLicense, false), new License(certificatedLicense, true)];
             const expectedLicense = [certificatedLicense];
 
-            const profileStub = TestCaregiverProfile.default()
-                                                    .licenseList(licenseList)
-                                                    .build();
+            const profileStub = TestCaregiverProfile.default().licenseList(licenseList).build();
 
-            const result = profileMapper.toDetailDto(userStub, profileStub);
+            const result = profileMapper.toDetailDto(profileStub);
 
-            expect(result.profile.licenseList).toEqual(expectedLicense);
+            expect(result.licenseList).toEqual(expectedLicense);
         })
 
         it('toDetailDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
             const profileStub = TestCaregiverProfile.default().build();
 
-            const result = profileMapper.toDetailDto(userStub, profileStub);
+            const result = profileMapper.toDetailDto(profileStub);
 
-            expect(result.user).toHaveProperty('name');
-            expect(result.user).toHaveProperty('sex');
-            expect(result.user).toHaveProperty('age');
+            expect(result).toHaveProperty('name');
+            expect(result).toHaveProperty('sex');
+            expect(result).toHaveProperty('age');
 
-            expect(result.profile).toHaveProperty('id');
-            expect(result.profile).toHaveProperty('userId');
-            expect(result.profile).toHaveProperty('career');
-            expect(result.profile).toHaveProperty('pay');
-            expect(result.profile).toHaveProperty('possibleDate');
-            expect(result.profile).toHaveProperty('possibleAreaList');
-            expect(result.profile).toHaveProperty('notice');
-            expect(result.profile).toHaveProperty('licenseList');
-            expect(result.profile).toHaveProperty('additionalChargeCase');
-            expect(result.profile).toHaveProperty('nextHosptial');
-            expect(result.profile).toHaveProperty('helpExperience');
-            expect(result.profile).toHaveProperty('strengthList');
-            expect(result.profile).toHaveProperty('warningList');
+            expect(result).toHaveProperty('id');
+            expect(result).toHaveProperty('userId');
+            expect(result).toHaveProperty('career');
+            expect(result).toHaveProperty('pay');
+            expect(result).toHaveProperty('possibleDate');
+            expect(result).toHaveProperty('possibleAreaList');
+            expect(result).toHaveProperty('notice');
+            expect(result).toHaveProperty('licenseList');
+            expect(result).toHaveProperty('additionalChargeCase');
+            expect(result).toHaveProperty('nextHosptial');
+            expect(result).toHaveProperty('helpExperience');
+            expect(result).toHaveProperty('strengthList');
+            expect(result).toHaveProperty('warningList');
         })
     })
 })

--- a/backend/test/unit/profile/domain/profile-list-cursor.spec.ts
+++ b/backend/test/unit/profile/domain/profile-list-cursor.spec.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from "mongodb";
 import { Sort } from "src/profile/domain/enum/sort.enum";
-import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
+import { ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor"
 import { ProfileSort } from "src/profile/domain/profile-sort";
@@ -41,7 +41,7 @@ describe('프로필 리스트 커서 객체 Test', () => {
             });
 
             it('마지막 프로필의 id와 정렬 옵션의 마지막 값이 조합되어 생성되어야 한다', () => {
-                const profileList = [ {profile: { id: 1, pay: 50 }} ] as unknown as CaregiverProfileListData[];
+                const profileList = [ { id: 1, pay: 50 } ] as unknown as ProfileListDataAsClient [];
 
                 const queryOptions = new ProfileListQueryOptions(undefined, new ProfileSort(Sort.LowPay), undefined);
                 const expectedCursor = `${profileList[0].pay}_${profileList[0].id}`

--- a/backend/test/unit/profile/profile.fixtures.ts
+++ b/backend/test/unit/profile/profile.fixtures.ts
@@ -6,6 +6,9 @@ export class TestCaregiverProfile {
     static default() {
         return new CaregiverProfileBuilder(new ObjectId())
             .userId(1)
+            .name('test')
+            .age(1995)
+            .career(20)
             .weight(50)
             .career(10)
             .pay(10)


### PR DESCRIPTION
- 프로필 상세보기 조회, 프로필 리스트 조회 시 반환되는 데이터의 인터페이스에 각각 MySQL에 저장되어 있던 사용자의 정보가 추가됨
- Mapper는 프론트엔드 형식에 맞춰서 데이터를 가공하는 역할