### PR TITLE
[백엔드] CaregiverProfileService에 getProfileLIst() 구현

### DIFF
--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -4,6 +4,7 @@ import { CaregiverProfileService } from "src/profile/application/service/caregiv
 import { ProfileListDto } from "../dto/profile-list.dto";
 import { AuthenticatedUser } from "src/auth/application/decorator/user.decorator";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
+import { GetProfileListDto } from "../dto/get-profile-list.dto";
 
 @Controller('profile')
 export class ProfileController {
@@ -14,8 +15,8 @@ export class ProfileController {
 
     @Public()
     @Get('list')
-    async getProfileList(@Query('lastProfileId') lastProfileId?: string): Promise<ProfileListDto []> {
-        return await this.caregiverProfileService.getProfileList(lastProfileId);
+    async getProfileList(@Query() getProfilListDto: GetProfileListDto): Promise<ProfileListDto> {
+        return await this.caregiverProfileService.getProfileList(getProfilListDto);
     }
 
     @Get('detail/:id')

--- a/backend/src/profile/interface/dto/profile-list.dto.ts
+++ b/backend/src/profile/interface/dto/profile-list.dto.ts
@@ -1,17 +1,6 @@
+import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
+
 export interface ProfileListDto {
-    user: {
-        name: string;
-        sex: string;
-        age: number;
-    }
-    profile: {
-        id: string;
-        userId: number;
-        career: string;
-        pay: number;
-        possibleDate: string;
-        possibleAreaList: string[] | string;
-        tagList: string[];
-        notice: string;
-    }
-}
+    caregiverProfileListData: CaregiverProfileListData [];
+    nextCursor: string;
+};

--- a/backend/src/profile/profile.module.ts
+++ b/backend/src/profile/profile.module.ts
@@ -10,6 +10,7 @@ import { MongodbModule } from "src/common/shared/database/mongodb/mongodb.module
 import { UserAuthCommonModule } from "src/user-auth-common/user-auth-common.module";
 import { ProfileController } from "./interface/controller/profile.controller";
 import { RankModule } from "src/rank/rank.module";
+import { ProfileQueryFactory } from "./infra/repository/profile-query.factory";
 
 @Module({
     imports: [
@@ -28,7 +29,8 @@ import { RankModule } from "src/rank/rank.module";
         PatientProfileMapper,
         PatientProfileService,
         PatientProfileRepository,
-        PatientProfileBuilder
+        PatientProfileBuilder,
+        ProfileQueryFactory
     ],
     exports: [
         CaregiverProfileBuilder,

--- a/backend/test/unit/__mock__/profile/service.mock.ts
+++ b/backend/test/unit/__mock__/profile/service.mock.ts
@@ -24,6 +24,7 @@ export const MockCaregiverProfileMapper = {
     provide: CaregiverProfileMapper,
     useValue: {
         mapFrom: jest.fn(),
+        toListQueryOptions: jest.fn(),
         toListDto: jest.fn(),
         toDetailDto: jest.fn()
     }

--- a/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
+++ b/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
@@ -2,25 +2,27 @@ import { Test } from "@nestjs/testing";
 import { CaregiverProfileMapper } from "src/profile/application/mapper/caregiver-profile.mapper"
 import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
 import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository"
-import { UserAuthCommonService } from "src/user-auth-common/application/user-auth-common.service"
 import { MockCaregiverProfileRepository } from "test/unit/__mock__/profile/repository.mock";
 import { MockCaregiverProfileMapper } from "test/unit/__mock__/profile/service.mock";
 import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock";
 import { TestCaregiverProfile } from "../../profile.fixtures";
-import { AggregationCursor } from "mongodb";
 import { TestUser } from "test/unit/user/user.fixtures";
-import { Observable } from 'rxjs';
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { NotFoundException } from "@nestjs/common";
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { MockProfileViewRankService } from "test/unit/__mock__/rank/rank-service.mock";
 import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
+import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
+import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
+import { ProfileSort } from "src/profile/domain/profile-sort";
+import { ProfileFilter } from "src/profile/domain/profile-filter";
+import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
+import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 
 describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
     let caregiverProfileRepository: CaregiverProfileRepository,
         caregiverProfileMapper: CaregiverProfileMapper,
-        userCommonService: UserAuthCommonService,
         caregiverProfileService: CaregiverProfileService,
         profileViewRankService: ProfileViewRankService
     
@@ -37,44 +39,34 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
 
         caregiverProfileMapper = module.get(CaregiverProfileMapper);
         caregiverProfileRepository = module.get(CaregiverProfileRepository);
-        userCommonService = module.get(UserAuthCommonService);
         caregiverProfileService = module.get(CaregiverProfileService);
         profileViewRankService = module.get(ProfileViewRankService);
     });
 
     describe('getProfileList()', () => {
-        it('프로필 리스트의 개수만큼 사용자의 프로필 데이터를 조회하는지 확인', async () => {
-            const [userId1, userId2] = [11, 20];
+        it('반환된 데이터와 다음 커서를 생성하여 반환하는지 확인', async () => {
 
-            const profileStub1 = TestCaregiverProfile.default().userId(userId1).build();
-            const profileStub2 = TestCaregiverProfile.default().userId(userId2).build();
+            const mockListQueryOption = new ProfileListQueryOptions(
+                new ProfileListCursor(), new ProfileSort(), new ProfileFilter()
+            );
+            jest.spyOn(caregiverProfileMapper, 'toListQueryOptions').mockReturnValueOnce(mockListQueryOption); // 옵션 객체
+            const profileList = [{}, {}] as CaregiverProfileListData [];
+            jest.spyOn(caregiverProfileRepository, 'getProfileList').mockResolvedValueOnce(profileList)// 조회된 리스트 반환
+
+            jest.spyOn(caregiverProfileMapper, 'toListDto').mockReturnValueOnce({} as ProfileListDataAsClient);
+
+            const mockNextCursor = 'next cursor';
+            const nextCursor = new ProfileListCursor(mockNextCursor);
+            jest.spyOn(ProfileListCursor, 'createNextCursor').mockReturnValueOnce(nextCursor);
             
-            const profileList = new Observable((subscribe) => {
-                subscribe.next(profileStub1);
-                subscribe.next(profileStub2);
-                subscribe.complete();
-            }) as unknown as AggregationCursor;
-    
-            const userStub1 = TestUser.default().withId(userId1) as unknown as User;
-            const userStub2 = TestUser.default().withId(userId2) as unknown as User;
-    
-            jest.spyOn(caregiverProfileRepository, 'getProfileList').mockReturnValueOnce(profileList);
-            jest.spyOn(userCommonService, 'findUserById')
-                .mockResolvedValueOnce(userStub1)
-                .mockResolvedValueOnce(userStub2);
-
-            await caregiverProfileService.getProfileList();
-
-            expect(userCommonService.findUserById).toHaveBeenCalledTimes(2);
-            expect(caregiverProfileMapper.toListDto).toHaveBeenCalledTimes(2);
+            const result = await caregiverProfileService.getProfileList({} as GetProfileListDto);
+            const expectedResult = { caregiverProfileListData: profileList, nextCursor: mockNextCursor };
+            expect(result).toEqual(expectedResult);
         })
     });
 
     describe('getProfile()', () => {
-        const userStub = TestUser.default() as unknown as User;
         
-        beforeAll(() => jest.spyOn(userCommonService, 'findUserById').mockResolvedValue(userStub));
-
         it('비공개 프로필이면 NotFound 에러를 던져야 한다', async () => {
 
             const privateProfile = TestCaregiverProfile.default().isPrivate(true).build();
@@ -91,6 +83,7 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
             beforeEach(() => jest.clearAllMocks() );
 
             it('조회한 사용자가 간병인이라면 클라이언트에게 반환할 Mapper만 호출', async () => {
+                const userStub = TestUser.default() as unknown as User;
                 const publicProfile = TestCaregiverProfile.default().isPrivate(false).build();
                 jest.spyOn(caregiverProfileRepository, 'findById').mockResolvedValue(publicProfile);
 
@@ -99,7 +92,7 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
                 await caregiverProfileService.getProfile('1', userStub);
                 
                 expect(rankSpy).not.toHaveBeenCalled();
-                expect(mapperSpy).toHaveBeenCalledWith(userStub, publicProfile);
+                expect(mapperSpy).toHaveBeenCalledWith(publicProfile);
             });
 
             it('조회한 사용자가 보호자라면 순위 집계를 위한 service를 호출하고 Mapper를 호출', async () => {
@@ -114,7 +107,7 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
                 await caregiverProfileService.getProfile(profileId, protectorUser);
                 
                 expect(rankSpy).toHaveBeenCalledWith(profileId, protectorUser);
-                expect(mapperSpy).toHaveBeenCalledWith(userStub, publicProfile);
+                expect(mapperSpy).toHaveBeenCalledWith(publicProfile);
             })
         })
     })


### PR DESCRIPTION
- 요청으로 들어오는 옵션에 따라 다음 커서부터 리스트를 계속해서 조회
- 클라이언트에게는 반환시 다음으로 요청할 커서를 함께 반환