### PR TITLE
[프론트엔드] 프로필 리스트 조회 노출 화면 구현 완료

### DIFF
--- a/frontendv2/api/Profile/requestProfileList.jsx
+++ b/frontendv2/api/Profile/requestProfileList.jsx
@@ -28,31 +28,33 @@ export default async function requestProfileList(purpose) {
        
         const res = await api.get(`profile/list`, {
             params: {
-                mainFilter: mainFilter,
-                payFilter: payFilter,
-                startDateFilter: startDateFilter,
-                sexFilter: sexFilter,
-                ageFilter: ageFilter,
-                areaFilter: areaFilter,
-                licenseFilter: licenseFilter,
-                warningFilter: warningFilter,
-                strengthFilter: strengthFilter,
-                exceptLicenseFilter: exceptLicenseFilter,
-                lastProfileId: lastListNo
+                nextCursor: lastListNo,
+                sort: mainFilter,
+                filter: {
+                    pay: payFilter,
+                    startDate: startDateFilter,
+                    sex: sexFilter,
+                    age: ageFilter,
+                    area: areaFilter,
+                    license: licenseFilter,
+                    warningExcept: warningFilter,
+                    strengthExcept: strengthFilter,
+                }
             }
-        });        
+        });  
+
         /* 첫 프로필 리스트의 조회 결과를 받아왔으면 Loading 해제 */
         if( !lastListNo ) store.dispatch(listLoading(false));
-        const profileList = res.data;
+        const { caregiverProfileListData, nextCursor } = res.data;
         /* 더 이상 프로필 데이터가 없을 때 */
-        if( !profileList.length ) {
+        if( !caregiverProfileListData.length ) {
             store.dispatch(setNoData(true));
             return;
         };
 
         /* 아직 프로필 데이터가 조회될 때 다음을 위해 저장 */
-        store.dispatch(saveCareGiverProfile(profileList));
-        store.dispatch(saveLastProfileId(profileList[profileList.length - 1].profile.id));
+        store.dispatch(saveCareGiverProfile(caregiverProfileListData));
+        store.dispatch(saveLastProfileId(nextCursor));
         store.dispatch(setNoData(false));
     }
     catch (err) {
@@ -69,11 +71,11 @@ export function getMainFilterValue(mainFilter) {
         case '후기 많은 순':
             return 'review';
         case '찜 많은 순':
-            return 'heart';
+            return 'HighLike';
         case '일당 낮은 순':
-            return 'pay';
+            return 'LowPay';
         case '시작일 빠른 순':
-            return 'startDate';
+            return 'FastStartDate';
     }
 }
 
@@ -82,11 +84,11 @@ export function getPayFilterValue(payFilter) {
         case '일당':
             return undefined;
         case '10만원 이하':
-            return 'under10';
+            return 10;
         case '15만원 이하':
-            return 'under15';
+            return 15;
         case '20만원 이하':
-            return 'under20';
+            return 20;
     };
 };
 
@@ -95,15 +97,15 @@ export function getStartDateFilterValue(startDateFilter) {
         case '시작가능일':
             return undefined;
         case '즉시 가능':
-            return 'immediately';
+            return 1;
         case '1주 이내':
-            return '1week';
+            return 2;
         case '2주 이내':
-            return '2week';
+            return 3;
         case '3주 이내':
-            return '3week';
+            return 4;
         case '한 달 이후':
-            return 'month'
+            return 5;
     };
 };
 
@@ -125,13 +127,9 @@ export function getAgeFilterValue(ageFilter) {
 };
 
 export function getAreaFilterValue(areaFilter) {
-    if (areaFilter.length)
-        return areaFilter.join(',');
-    return undefined;
+    return areaFilter.length ? areaFilter : undefined;
 };
 
 export function getLicenseFilterValue(licenseFilter) {
-    if (licenseFilter.length)
-        return licenseFilter.join(',');
-    return undefined;
+    return licenseFilter.length ? licenseFilter : undefined;
 }

--- a/frontendv2/components/FindHelper/EachHelper/Header.jsx
+++ b/frontendv2/components/FindHelper/EachHelper/Header.jsx
@@ -13,7 +13,7 @@ import { StackActions, useNavigation } from "@react-navigation/native";
 export default function Header({ profile }) {
     const navigation = useNavigation();
 
-    const { user } = profile;
+    const { id, name, sex, age } = profile;
 
     return (
         <View style={header().header}>
@@ -21,10 +21,10 @@ export default function Header({ profile }) {
                 <View style={{ flexDirection: 'row' }}>
                     <View style={styles.name}>
                         <Text style={styles.nameText}>
-                            {user.name}
+                            {name}
                         </Text>
                         <Text style={styles.subInfoText}>
-                            {user.sex}, {user.age}세
+                            {sex}, {age}세
                         </Text>
                     </View>
                 </View>
@@ -34,8 +34,8 @@ export default function Header({ profile }) {
                 underlayColor='none'
                 onPress={() => navigation.dispatch(
                     StackActions.push('helperProfilePage', {
-                        name: user.name,
-                        profileId: profile.profile.id ,
+                        name: name,
+                        profileId: id ,
                     })
                 )}>
                 <View style={styles.confirmProfileBtn}>

--- a/frontendv2/components/FindHelper/EachHelper/Info.jsx
+++ b/frontendv2/components/FindHelper/EachHelper/Info.jsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 
 export default function Info({ profile }) {
-    const { profile: caregiverProfile } = profile;
+    const { career, pay, possibleAreaList, possibleDate } = profile;
 
     return (
         <View style={styles.profileHelperContainer}>
@@ -19,7 +19,7 @@ export default function Info({ profile }) {
                     </Text>
                     <View style={styles.verticalLine} />
                     <Text style={styles.userValue}>
-                        {caregiverProfile.career}
+                        {career}
                     </Text>
                 </View>
 
@@ -29,7 +29,7 @@ export default function Info({ profile }) {
                     </Text>
                     <View style={styles.verticalLine} />
                     <Text style={styles.userValue}>
-                        {caregiverProfile.pay}만원
+                        {pay}만원
                     </Text>
                 </View>
             </View>
@@ -41,7 +41,7 @@ export default function Info({ profile }) {
                     </Text>
                     <View style={styles.verticalLine} />
                     <Text style={styles.userValue}>
-                        {caregiverProfile.possibleAreaList}
+                        {possibleAreaList}
                     </Text>
                 </View>
 
@@ -51,7 +51,7 @@ export default function Info({ profile }) {
                     </Text>
                     <View style={styles.verticalLine} />
                     <Text style={styles.userValue}>
-                        {caregiverProfile.possibleDate}
+                        {possibleDate}
                     </Text>
                 </View>
             </View>

--- a/frontendv2/components/FindHelper/EachHelper/KeyWord.jsx
+++ b/frontendv2/components/FindHelper/EachHelper/KeyWord.jsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 
 export default function KeyWord({ profile }) {
-    const { tagList } = profile.profile;
+    const { tagList } = profile;
     return (
         <View style={styles.keyWords}>
             {tagList.map((keywords, index) => {

--- a/frontendv2/components/FindHelper/EachHelper/Notice.jsx
+++ b/frontendv2/components/FindHelper/EachHelper/Notice.jsx
@@ -6,12 +6,12 @@ import { View } from "react-native";
 import Icon from "../../Icon";
 
 export default function Notice({ profile }) {
-
+    const { notice } = profile;
     return (
         <View style={styles.profileHelperAppeal}>
             <Icon props={['material', 'campaign', 20, 'silver']} />
             <Text style={styles.profileHelperAppealText}>
-               {profile.profile.notice}
+               {notice}
             </Text>
         </View>
     )


### PR DESCRIPTION
- 대부분의 데이터를 프론트에서 가공하는 것이 아닌 서버에서 프론트엔드 화면에 맞게 가공하여 응답
- lastProfileId로 프로필 마지막 아이디만 보내던 기존과 달리 정렬조건과 함께 서버에서 넘겨준 nextCursor를 같이 넘겨줌