### PR TITLE
[백엔드] 프로필 찜 내역 Service 구현

### DIFF
--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -10,5 +10,6 @@ export const enum ErrorMessage {
     InvalidRefreshKey = '유효하지 않은 RefreshKey입니다.',
     NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.',
     ExpiredToken = 'jwt expired',
-    NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.'
+    NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.',
+    DuplicatedLikeProfile = '이미 찜한 프로필입니다.'
 }

--- a/backend/src/profile/application/service/profile-like-history.service.ts
+++ b/backend/src/profile/application/service/profile-like-history.service.ts
@@ -1,0 +1,24 @@
+import { ConflictException, Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { ProfileLike } from "src/profile/domain/entity/profile-like";
+import { ProfileLikeHistoryRepository } from "src/profile/domain/repository/iprofile-like-history.repository";
+
+@Injectable()
+/* 프로필 찜 서비스 */
+export class ProfileLikeHistoryService {
+    constructor(
+        @InjectRepository(ProfileLike)
+        private readonly historyRepository: ProfileLikeHistoryRepository
+    ) {}
+    /* 찜 내역 추가 */
+    async addHistory(profileLike: ProfileLike) {
+        /* 이미 해당 프로필을 찜한 사용자면 오류 */
+        if( await this.historyRepository.findByProfileAndUserId(
+            profileLike.getProfileId(),
+            profileLike.getLikeUserId()
+        ))  throw new ConflictException(ErrorMessage.DuplicatedLikeProfile);
+        /* 처음 누른 상태면 정상적으로 저장 */
+        await this.historyRepository.save(profileLike); 
+    }
+}

--- a/backend/src/profile/profile.module.ts
+++ b/backend/src/profile/profile.module.ts
@@ -12,6 +12,7 @@ import { ProfileController } from "./interface/controller/profile.controller";
 import { RankModule } from "src/rank/rank.module";
 import { ProfileQueryFactory } from "./infra/repository/profile-query.factory";
 import { ProfileLikeHistoryRepoProvider } from "./domain/repository/iprofile-like-history.repository";
+import { ProfileLikeHistoryService } from "./application/service/profile-like-history.service";
 
 @Module({
     imports: [
@@ -32,7 +33,8 @@ import { ProfileLikeHistoryRepoProvider } from "./domain/repository/iprofile-lik
         PatientProfileRepository,
         PatientProfileBuilder,
         ProfileQueryFactory,
-        ProfileLikeHistoryRepoProvider
+        ProfileLikeHistoryRepoProvider,
+        ProfileLikeHistoryService
     ],
     exports: [
         CaregiverProfileBuilder,

--- a/backend/test/unit/__mock__/profile/repository.mock.ts
+++ b/backend/test/unit/__mock__/profile/repository.mock.ts
@@ -1,3 +1,5 @@
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { ProfileLike } from "src/profile/domain/entity/profile-like";
 import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiver-profile.repository";
 
 /* Mocking CaregiverProfileRepository */
@@ -11,3 +13,12 @@ export const MockCaregiverProfileRepository = {
         getProfileList: jest.fn()
     }
 };
+
+/* Mocking ProfileLikeHistoryRepository */
+export const MockProfileLikeHistoryRepository = {
+    provide: getRepositoryToken(ProfileLike),
+    useValue: {
+        save: jest.fn(),
+        findByProfileAndUserId: jest.fn()
+    }
+}

--- a/backend/test/unit/profile/application/service/profile-like-history-service.spec.ts
+++ b/backend/test/unit/profile/application/service/profile-like-history-service.spec.ts
@@ -1,0 +1,49 @@
+import { ConflictException } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { ProfileLikeHistoryService } from "src/profile/application/service/profile-like-history.service"
+import { ProfileLike } from "src/profile/domain/entity/profile-like";
+import { ProfileLikeHistoryRepository } from "src/profile/domain/repository/iprofile-like-history.repository";
+import { MockProfileLikeHistoryRepository } from "test/unit/__mock__/profile/repository.mock";
+
+describe('프로필 찜 내역 서비스(ProfileLikeHistoryService) Test', () => {
+
+    let likeHisotryService: ProfileLikeHistoryService,
+        likeHistoryRepository: ProfileLikeHistoryRepository;
+    
+    beforeAll(async() => {
+        const module = await Test.createTestingModule({
+            providers: [
+                ProfileLikeHistoryService,
+                MockProfileLikeHistoryRepository
+            ]
+        }).compile();
+        likeHisotryService = module.get(ProfileLikeHistoryService);
+        likeHistoryRepository = module.get(getRepositoryToken(ProfileLike))
+    })
+
+    describe('addHistory()', () => {
+        let testProfileId: string, testUserId: number, likeStub: ProfileLike;
+
+        beforeAll(() => {
+            [testProfileId, testUserId] = ['test', 1]; likeStub = new ProfileLike(testProfileId, testUserId);
+        });
+
+        afterEach(() => jest.clearAllMocks());
+
+        it('내역이 없을 경우 DB에 내역을 저장하기 위해 호출해야 한다', async() => {
+            jest.spyOn(likeHistoryRepository, 'findByProfileAndUserId').mockResolvedValueOnce(null);
+            
+            await likeHisotryService.addHistory(likeStub);
+
+            expect(likeHistoryRepository.save).toBeCalledWith(likeStub);
+        });
+
+        it('해당 사용자가 찜한 내역이 있는 경우 충돌 에러', async() => {
+            jest.spyOn(likeHistoryRepository, 'findByProfileAndUserId').mockResolvedValueOnce(likeStub);
+            const result = () => likeHisotryService.addHistory(likeStub);
+            await expect(result).rejects.toThrowError(new ConflictException(ErrorMessage.DuplicatedLikeProfile));
+        })
+    })
+})


### PR DESCRIPTION
- addHistory(): 사용자가 누른 프로필 찜 내역을 추가하기 위한 메서드

이미 찜을 눌렀던 상태라면 409에러를 던져 클라이언트에서는 삭제 요청을 통해 Rest Api 구축