### PR TITLE
[백엔드] 접근 가능한 역할을 검사해주는 RoleGuard 구현

### DIFF
--- a/backend/src/common/shared/decorator/roles.decorator.ts
+++ b/backend/src/common/shared/decorator/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -11,5 +11,6 @@ export const enum ErrorMessage {
     NotExistRefreshKeyInRequest = '요청에 RefreshKey가 존재하지 않습니다.',
     ExpiredToken = 'jwt expired',
     NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.',
-    DuplicatedLikeProfile = '이미 찜한 프로필입니다.'
+    DuplicatedLikeProfile = '이미 찜한 프로필입니다.',
+    PermissionDeniedForRole = '역할의 권한이 맞지 않아 접근이 거부되었습니다.'
 }

--- a/backend/src/core/guard/role.guard.ts
+++ b/backend/src/core/guard/role.guard.ts
@@ -1,0 +1,20 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+
+/* 지정한 역할이 아닌 경우 Api 접근 금지 */
+@Injectable()
+export class RoleGuard implements CanActivate {
+    constructor(
+        private readonly reflector: Reflector
+    ) {};
+
+    /* 인증을 거치고 난 후 들어오는 요청의 사용자 역할 검사 */
+    canActivate(context: ExecutionContext): boolean | never {
+        const { user } = context.switchToHttp().getRequest();
+        /* 사용자의 역할이 보호자가 아니라면 에러 */
+        if( user.role !== this.reflector.get('roles', context.getHandler()))
+            throw new ForbiddenException(ErrorMessage.PermissionDeniedForRole);
+        return true;
+    }
+}

--- a/backend/test/unit/core/guard/role-guard.spec.ts
+++ b/backend/test/unit/core/guard/role-guard.spec.ts
@@ -1,0 +1,48 @@
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
+import { RoleGuard } from "src/core/guard/role.guard";
+import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
+
+describe('설정한 역할 이외는 접근 제한하는 가드(RoleGuard) Test', () => {
+    
+    it('특정 역할만 접근 가능한 API를 다른 역할의 사용자가 접근할 경우 제한하는지 확인', () => {
+        const mockContext = {
+            switchToHttp: () => ({
+                getRequest: () => ({
+                    user: { role: ROLE.CAREGIVER } // 접근한 사용자는 간병인
+                })
+            }),
+            getHandler: jest.fn()
+        } as unknown as ExecutionContext;
+
+        /* 보호자만 가능한 API라고 메타데이터 설정 */
+        const mockReflector = { get: jest.fn().mockReturnValueOnce(ROLE.PROTECTOR) } as unknown as Reflector;
+
+        const roleGuard = new RoleGuard(mockReflector);
+
+        const result = () => roleGuard.canActivate(mockContext);
+
+        expect(result).toThrowError(new ForbiddenException(ErrorMessage.PermissionDeniedForRole));
+    });
+
+    it('접근 가능한 API를 해당 역할의 사용자가 접근했을 경우 true 반환 확인', () => {
+        const mockContext = {
+            switchToHttp: () => ({
+                getRequest: () => ({
+                    user: { role: ROLE.PROTECTOR } // 접근한 사용자는 보호자
+                })
+            }),
+            getHandler: jest.fn()
+        } as unknown as ExecutionContext;
+        
+        /* 보호자만 가능한 API라고 메타데이터 설정 */
+        const mockReflector = { get: jest.fn().mockReturnValueOnce(ROLE.PROTECTOR) } as unknown as Reflector;
+
+        const roleGuard = new RoleGuard(mockReflector);
+
+        const result = roleGuard.canActivate(mockContext);
+
+        expect(result).toBe(true);
+    })
+})


### PR DESCRIPTION
데코레이터를 통해 접근 가능한 역할을 metaData로 설정하고 guard에서는 요청이 들어온 사용자의 역할과 해당 메타데이터 key에 접근하여 검사