### PR TITLE
[백엔드] Get Method의 멱등성 위해 조회 내역 관리 분리

### DIFF
--- a/backend/src/profile/application/service/caregiver-profile.service.ts
+++ b/backend/src/profile/application/service/caregiver-profile.service.ts
@@ -5,9 +5,7 @@ import { CaregiverProfileRepository } from "src/profile/infra/repository/caregiv
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { ProfileListDto } from "src/profile/interface/dto/profile-list.dto";
 import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
-import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
-import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
 
@@ -16,7 +14,6 @@ export class CaregiverProfileService {
     constructor(
         private readonly caregiverProfileMapper: CaregiverProfileMapper,
         private readonly caregiverProfileRepository: CaregiverProfileRepository,
-        private readonly profileViewRankService: ProfileViewRankService
     ) {}
     
     /* 회원가입시 새로운 프로필 추가 */
@@ -26,13 +23,9 @@ export class CaregiverProfileService {
     } 
 
     /* 프로필 상세보기 */
-    async getProfile(profileId: string, viewUser: User): Promise<ProfileDetailDto> {
+    async getProfile(profileId: string): Promise<ProfileDetailDto> {
         const profile = await this.caregiverProfileRepository.findById(profileId);
         profile.checkPrivacy();
-
-        if( viewUser.getRole() === ROLE.PROTECTOR )
-            await this.profileViewRankService.increment(profileId, viewUser);
-
         return this.caregiverProfileMapper.toDetailDto(profile);
     }
 

--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param,  Post,  Query, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param,  Patch,  Post,  Query, UseGuards } from "@nestjs/common";
 import { Public } from "src/auth/application/decorator/public.decorator";
 import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
 import { ProfileListDto } from "../dto/profile-list.dto";
@@ -9,13 +9,16 @@ import { Roles } from "src/common/shared/decorator/roles.decorator";
 import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
 import { ProfileLikeHistoryService } from "src/profile/application/service/profile-like-history.service";
 import { RoleGuard } from "src/core/guard/role.guard";
+import { ProfileViewRankService } from "src/rank/application/service/profile-view-rank.service";
 
 @Controller('profile')
 export class ProfileController {
 
     constructor(
         private readonly caregiverProfileService: CaregiverProfileService,
-        private readonly profileLikeHistoryService: ProfileLikeHistoryService
+        private readonly profileLikeHistoryService: ProfileLikeHistoryService,
+        private readonly profileViewRankService: ProfileViewRankService
+
     ) {};
 
     @Public()
@@ -25,8 +28,18 @@ export class ProfileController {
     }
 
     @Get('detail/:id')
-    async getProfileDetail(@Param('id') profileId: string, @AuthenticatedUser() authenticatedUser: User){
-        return await this.caregiverProfileService.getProfile(profileId, authenticatedUser)
+    async getProfileDetail(@Param('id') profileId: string){
+        return await this.caregiverProfileService.getProfile(profileId)
+    }
+
+    @Patch(':profileId/view')
+    async addViewHistory(
+        @Param('profileId') profileId: string, 
+        @AuthenticatedUser() authenticatedUser: User
+    ) {
+        /* 사용자가 보호자라면 증가 */
+        if( authenticatedUser.getRole() === ROLE.PROTECTOR )
+            return await this.profileViewRankService.increment(profileId, authenticatedUser);
     }
 
     @Post('like')


### PR DESCRIPTION
- 프로필을 조회할 때마다 사용자의 조회 내역과 조회수를 증가시켜 랭크를 매기기때문에 Get Method는 데이터만 반환하도록 분리