### PR TITLE
[백엔드] 프로필 상세 조회시 해당 프로필 찜 데이터도 조회하는 Service 로직 구현 

### DIFF
--- a/backend/src/profile/application/service/caregiver-profile.service.ts
+++ b/backend/src/profile/application/service/caregiver-profile.service.ts
@@ -8,11 +8,13 @@ import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
+import { ProfileLikeHistoryService } from "./profile-like-history.service";
 
 @Injectable()
 export class CaregiverProfileService {
     constructor(
         private readonly caregiverProfileMapper: CaregiverProfileMapper,
+        private readonly profileLikeHistoryService: ProfileLikeHistoryService,
         private readonly caregiverProfileRepository: CaregiverProfileRepository,
     ) {}
     
@@ -23,10 +25,13 @@ export class CaregiverProfileService {
     } 
 
     /* 프로필 상세보기 */
-    async getProfile(profileId: string): Promise<ProfileDetailDto> {
-        const profile = await this.caregiverProfileRepository.findById(profileId);
+    async getProfile(profileId: string, userId: number): Promise<ProfileDetailDto> {
+        const [profile, profileLikeMetadata] = await Promise.all([
+            this.caregiverProfileRepository.findById(profileId),
+            this.profileLikeHistoryService.getProfileLikeMetadata(profileId, userId)
+        ]);
         profile.checkPrivacy();
-        return this.caregiverProfileMapper.toDetailDto(profile);
+        return this.caregiverProfileMapper.toDetailDto(profile, profileLikeMetadata);
     }
 
     /* 사용자 아이디로 프로필 조회 */

--- a/backend/src/profile/application/service/profile-like-history.service.ts
+++ b/backend/src/profile/application/service/profile-like-history.service.ts
@@ -2,6 +2,7 @@ import { ConflictException, Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { ProfileLike } from "src/profile/domain/entity/profile-like";
+import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 import { ProfileLikeHistoryRepository } from "src/profile/domain/repository/iprofile-like-history.repository";
 
 @Injectable()
@@ -26,5 +27,15 @@ export class ProfileLikeHistoryService {
     /* 중복된 찜이 있을 때 삭제 */
     async deleteHistory(profileId: string, likeUserId: number) {
         await this.historyRepository.deleteByProfileAndUserId(profileId, likeUserId);
+    }
+
+    /* 특정 프로필의 찜 정보 */
+    async getProfileLikeMetadata(profileId: string, viewUserId: number): Promise<ProfileLikeMetadata> {
+        /* 갯수와 내가 눌렀던 내역을 조회 */
+        const [likeCount, myLikeHisotry] = await Promise.all([
+            this.historyRepository.countById(profileId),
+            this.historyRepository.findByProfileAndUserId(profileId, viewUserId)
+        ]);
+        return new ProfileLikeMetadata(likeCount, myLikeHisotry);
     }
 }

--- a/backend/src/profile/domain/profile-like-metadata.ts
+++ b/backend/src/profile/domain/profile-like-metadata.ts
@@ -1,0 +1,14 @@
+import { ProfileLike } from "./entity/profile-like";
+
+export class ProfileLikeMetadata {
+    private count: number;
+    private isLiked: boolean;
+    
+    constructor(count: number, profileLike: ProfileLike | null) {
+        this.count = count;
+        this.isLiked = profileLike ? true : false;
+    };
+
+    getCount(): number { return this.count };
+    getIsLike(): boolean { return this.isLiked };
+}

--- a/backend/test/unit/__mock__/profile/service.mock.ts
+++ b/backend/test/unit/__mock__/profile/service.mock.ts
@@ -1,6 +1,7 @@
 import { CaregiverProfileMapper } from "src/profile/application/mapper/caregiver-profile.mapper";
 import { CaregiverProfileService } from "src/profile/application/service/caregiver-profile.service";
 import { PatientProfileService } from "src/profile/application/service/patient-profile.service";
+import { ProfileLikeHistoryService } from "src/profile/application/service/profile-like-history.service";
 
 /* Mocking CaregiverProfileService */
 export const MockCaregiverProfileService = {
@@ -27,5 +28,13 @@ export const MockCaregiverProfileMapper = {
         toListQueryOptions: jest.fn(),
         toListDto: jest.fn(),
         toDetailDto: jest.fn()
+    }
+}
+
+/* Mocking ProfileLikeHistoryService */
+export const MockProfileLikeHistoryService = {
+    provide: ProfileLikeHistoryService,
+    useValue: {
+        getProfileLikeMetadata: jest.fn()
     }
 }

--- a/backend/test/unit/profile/domain/profile-like-metadata.spec.ts
+++ b/backend/test/unit/profile/domain/profile-like-metadata.spec.ts
@@ -1,0 +1,15 @@
+import { ProfileLike } from "src/profile/domain/entity/profile-like"
+import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
+
+describe('ProfileLikeMetadata 객체 Test()', () => {
+    it('자신이 조회한 내역이 있다면 찜 여부를 true로 반환하는지 확인', () => {
+        const alreadyLikedProfile = new ProfileLike('', 1);
+        const testLikeMetadata = new ProfileLikeMetadata(0, alreadyLikedProfile);
+        expect(testLikeMetadata.getIsLike()).toBe(true);
+    });
+
+    it('자신이 조회한 내역이 없다면 찜 여부를 false로 반환하는지 확인', () => {
+        const testLikeMetadata = new ProfileLikeMetadata(2, null);
+        expect(testLikeMetadata.getIsLike()).toBe(false);
+    });
+})

--- a/backend/test/unit/profile/infra/repository/profile-like-history-repo.spec.ts
+++ b/backend/test/unit/profile/infra/repository/profile-like-history-repo.spec.ts
@@ -59,5 +59,34 @@ describe('ProfileLikeHistoryRepository(찜 내역 저장소) Test', () => {
 
             expect(afterFindResult).toBe(null);
         });
+    });
+
+    describe('countById()', () => {
+        let profileId: string;
+        
+        /* 테스트용 데이터 같은 id로 3개 삽입 */
+        beforeAll(async() => {
+            const insertBuffer = []; 
+            profileId = new ObjectId().toHexString();
+            
+            for( let i = 1; i < 4; i++ ) {
+                const testProfileLike = new ProfileLike(profileId, i)
+                insertBuffer.push(historyRepository.save(testProfileLike));    
+            }
+            await Promise.all(insertBuffer);
+        });
+
+        afterAll(async() => historyRepository.clear());
+
+        it('조회하는 프로필의 찜 개수를 정확히 가져오는지 확인', async () => {
+            const result = await historyRepository.countById(profileId);
+            expect(result).toBe(3);
+        });
+
+        it('조회하는 프로필의 찜 개수가 없을 때 0으로 반환되는지 확인', async () => {
+            const otherId = new ObjectId().toHexString();
+            const result = await historyRepository.countById(otherId);
+            expect(result).toBe(0);
+        })
     })
 })


### PR DESCRIPTION
- ProfileLikeHistory Service를 통해 해당 프로필의 찜 개수, 자신이 눌렀는지 여부를 받아옴
- CaregiverProfile Service에서는 기존에 조회했던 프로필 데이터와 찜 데이터를 함께 조회