### PR TITLE
[백엔드] 프로필 상세 조회시 찜 데이터와 함께 클라이언트 포맷으로 변경해주도록 Mapper 수정

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -3,6 +3,7 @@ import { ObjectId } from "mongodb";
 import { CaregiverProfileBuilder } from "src/profile/domain/builder/profile.builder";
 import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-profile.entity";
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
+import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
@@ -65,25 +66,36 @@ export class CaregiverProfileMapper {
     };
 
     /* 프로필 상세보기에 필요한 데이터에 맞춰 변환 */
-    toDetailDto(caregiverProfile: CaregiverProfile): ProfileDetailDto {
+    toDetailDto(
+        caregiverProfile: CaregiverProfile, 
+        profileLikeMetadata: ProfileLikeMetadata
+    ): ProfileDetailDto {
 
         return {
-            id: caregiverProfile.getId(),
-            name: caregiverProfile.getName(),
-            sex: caregiverProfile.getSex(),
-            age: caregiverProfile.getAge(),
-            userId: caregiverProfile.getUserId(),
-            career: this.toDtoCareer(caregiverProfile.getCareer()),
-            pay: caregiverProfile.getPay(),
-            possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
-            possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
-            notice: caregiverProfile.getNotice(),
-            licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
-            additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
-            nextHosptial: caregiverProfile.getNextHosptial(),
-            helpExperience: caregiverProfile.getHelpExperience(),
-            strengthList: caregiverProfile.getStrengthList(),
-            warningList: caregiverProfile.getWarningList()
+            user: {
+                id: caregiverProfile.getUserId(),
+                name: caregiverProfile.getName(),
+                sex: caregiverProfile.getSex(),
+                age: caregiverProfile.getAge(),
+            },
+            profile: {
+                id: caregiverProfile.getId(),
+                career: this.toDtoCareer(caregiverProfile.getCareer()),
+                pay: caregiverProfile.getPay(),
+                possibleDate: this.toDtoPossibleDate(caregiverProfile.getPossibleDate()),
+                possibleAreaList: this.toDtoAreaList(caregiverProfile.getPossibleAreaList(), 'detail'),
+                notice: caregiverProfile.getNotice(),
+                licenseList: this.toDtoLicenseList(caregiverProfile.getLicenseList()),
+                additionalChargeCase: caregiverProfile.getAdditionalChargeCase(),
+                nextHosptial: caregiverProfile.getNextHosptial(),
+                helpExperience: caregiverProfile.getHelpExperience(),
+                strengthList: caregiverProfile.getStrengthList(),
+                warningList: caregiverProfile.getWarningList(),
+                likeMetadata: {
+                    count: profileLikeMetadata.getCount(),
+                    isLiked: profileLikeMetadata.getIsLike()
+                }
+            }
         }
     };
 

--- a/backend/src/profile/interface/controller/profile.controller.ts
+++ b/backend/src/profile/interface/controller/profile.controller.ts
@@ -28,8 +28,11 @@ export class ProfileController {
     }
 
     @Get('detail/:id')
-    async getProfileDetail(@Param('id') profileId: string){
-        return await this.caregiverProfileService.getProfile(profileId)
+    async getProfileDetail(
+        @Param('id') profileId: string,
+        @AuthenticatedUser() authenticatedUser: User
+    ){
+        return await this.caregiverProfileService.getProfile(profileId, authenticatedUser.getId())
     }
 
     @Patch(':profileId/view')

--- a/backend/src/profile/interface/dto/profile-detail.dto.ts
+++ b/backend/src/profile/interface/dto/profile-detail.dto.ts
@@ -3,21 +3,28 @@ import { SEX } from "src/user-auth-common/domain/enum/user.enum"
 import { CaregiverHelpExperience } from "src/user/interface/dto/register-page";
 
 export interface ProfileDetailDto {
-    id: string;
-    name: string;
-    sex: SEX;
-    age: number;
-    userId: number;
-    career: string;
-    pay: number;
-    possibleDate: string;
-    possibleAreaList: string[] | string;
-    notice: string;
-    licenseList: string[] | [];
-    additionalChargeCase: string | null;
-    nextHosptial: string | null;
-    helpExperience: CaregiverHelpExperience,
-    strengthList: string[] | [],
-    warningList: Warning[] | []
-
+    user: {
+        id: number;
+        name: string;
+        sex: SEX;
+        age: number;
+    },
+    profile: {
+        id: string;
+        career: string;
+        pay: number;
+        possibleDate: string;
+        possibleAreaList: string[] | string;
+        notice: string;
+        licenseList: string[] | [];
+        additionalChargeCase: string | null;
+        nextHosptial: string | null;
+        helpExperience: CaregiverHelpExperience,
+        strengthList: string[] | [],
+        warningList: Warning[] | [],
+        likeMetadata: {
+            count: number,
+            isLiked: boolean
+        }   
+    }
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -14,6 +14,7 @@ import { ProfileSort } from "src/profile/domain/profile-sort";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
+import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
@@ -125,6 +126,9 @@ describe('Caregiver Profile Mapper Component Test', () => {
     });
 
     describe('toDetailDto()', () => {
+        let likeMetadataStub: ProfileLikeMetadata;
+
+        beforeAll(() => likeMetadataStub = new ProfileLikeMetadata(10, null));
 
         it('가능한 지역을 상세페이지에선 모두 나열해주는지 확인', () => {
             const possibleAreaList = ['인천', '서울', '부산', '대구', '포항'];
@@ -132,18 +136,18 @@ describe('Caregiver Profile Mapper Component Test', () => {
 
             const profileStub = TestCaregiverProfile.default().possibleAreaList(possibleAreaList).build();
 
-            const result = profileMapper.toDetailDto(profileStub);
+            const result = profileMapper.toDetailDto(profileStub, likeMetadataStub);
 
-            expect(result.possibleAreaList).toBe(expectedArea);
+            expect(result.profile.possibleAreaList).toBe(expectedArea);
         });
 
         it('자격증이 없는 사용자는 빈 배열로 반환되어야 한다', () => {
             const emptyLicenseList = [];
             const profileStub = TestCaregiverProfile.default().licenseList(emptyLicenseList).build();
 
-            const result = profileMapper.toDetailDto(profileStub);
+            const result = profileMapper.toDetailDto(profileStub, likeMetadataStub);
             
-            expect(result.licenseList).toEqual(emptyLicenseList);
+            expect(result.profile.licenseList).toEqual(emptyLicenseList);
         })
 
         it('인증이 완료된 자격증의 이름은 포함되고, 완료되지 않은 자격증은 포함되지 않는지 확인', () => {
@@ -153,33 +157,35 @@ describe('Caregiver Profile Mapper Component Test', () => {
 
             const profileStub = TestCaregiverProfile.default().licenseList(licenseList).build();
 
-            const result = profileMapper.toDetailDto(profileStub);
+            const result = profileMapper.toDetailDto(profileStub, likeMetadataStub);
 
-            expect(result.licenseList).toEqual(expectedLicense);
+            expect(result.profile.licenseList).toEqual(expectedLicense);
         })
 
         it('toDetailDto()를 수행했을 때 포함되어야 할 필드가 있는지 확인', () => {
             const profileStub = TestCaregiverProfile.default().build();
 
-            const result = profileMapper.toDetailDto(profileStub);
+            const result = profileMapper.toDetailDto(profileStub, likeMetadataStub);
+            
+            expect(result.user).toHaveProperty('id');
+            expect(result.user).toHaveProperty('name');
+            expect(result.user).toHaveProperty('sex');
+            expect(result.user).toHaveProperty('age');
 
-            expect(result).toHaveProperty('name');
-            expect(result).toHaveProperty('sex');
-            expect(result).toHaveProperty('age');
-
-            expect(result).toHaveProperty('id');
-            expect(result).toHaveProperty('userId');
-            expect(result).toHaveProperty('career');
-            expect(result).toHaveProperty('pay');
-            expect(result).toHaveProperty('possibleDate');
-            expect(result).toHaveProperty('possibleAreaList');
-            expect(result).toHaveProperty('notice');
-            expect(result).toHaveProperty('licenseList');
-            expect(result).toHaveProperty('additionalChargeCase');
-            expect(result).toHaveProperty('nextHosptial');
-            expect(result).toHaveProperty('helpExperience');
-            expect(result).toHaveProperty('strengthList');
-            expect(result).toHaveProperty('warningList');
+            expect(result.profile).toHaveProperty('id');
+            expect(result.profile).toHaveProperty('career');
+            expect(result.profile).toHaveProperty('pay');
+            expect(result.profile).toHaveProperty('possibleDate');
+            expect(result.profile).toHaveProperty('possibleAreaList');
+            expect(result.profile).toHaveProperty('notice');
+            expect(result.profile).toHaveProperty('licenseList');
+            expect(result.profile).toHaveProperty('additionalChargeCase');
+            expect(result.profile).toHaveProperty('nextHosptial');
+            expect(result.profile).toHaveProperty('helpExperience');
+            expect(result.profile).toHaveProperty('strengthList');
+            expect(result.profile).toHaveProperty('warningList');
+            expect(result.profile.likeMetadata).toHaveProperty('count');
+            expect(result.profile.likeMetadata).toHaveProperty('isLiked');
         })
     })
 })


### PR DESCRIPTION
- 응답 구조를 중첩된 객체로 다시 설정