### PR TITLE
[백엔드] 프로필 리스트 조회 Controller, Mapper 수정

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -7,7 +7,6 @@ import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
-import { ProfileSort } from "src/profile/domain/profile-sort";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
@@ -43,7 +42,7 @@ export class CaregiverProfileMapper {
     toListQueryOptions(getProfileListDto: GetProfileListDto): ProfileListQueryOptions {
         return new ProfileListQueryOptions(
             new ProfileListCursor(getProfileListDto.nextCursor),
-            new ProfileSort(getProfileListDto.sort),
+            getProfileListDto.sort,
             getProfileListDto.filter
         );
     };

--- a/backend/src/profile/interface/decorator/sort-option-transformer.decorator.ts
+++ b/backend/src/profile/interface/decorator/sort-option-transformer.decorator.ts
@@ -1,0 +1,15 @@
+import { Transform } from "class-transformer";
+import { ProfileSortField } from "src/profile/domain/enum/sort.enum";
+import { ProfilePaySort, ProfileStartDateSort } from "src/profile/domain/profile-sort";
+
+export const SortOptionTransformer = () => Transform(({ value }) => {
+    if( !value ) return null;
+    const sortOption = JSON.parse(value);
+    switch( sortOption.field ) {
+        case ProfileSortField.PAY:
+            return new ProfilePaySort(sortOption.orderBy);
+        case ProfileSortField.STARTDATE:
+            return new ProfileStartDateSort(sortOption.orderBy);
+    }
+})
+

--- a/backend/src/profile/interface/dto/get-profile-list.dto.ts
+++ b/backend/src/profile/interface/dto/get-profile-list.dto.ts
@@ -1,7 +1,8 @@
 import { Transform, Type, plainToInstance } from "class-transformer";
-import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
-import { Sort } from "src/profile/domain/enum/sort.enum";
+import { IsOptional, IsString, ValidateNested } from "class-validator";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
+import { ProfileSort } from "src/profile/domain/profile-sort";
+import { SortOptionTransformer } from "../decorator/sort-option-transformer.decorator";
 
 export class GetProfileListDto {
     @IsOptional()
@@ -9,8 +10,10 @@ export class GetProfileListDto {
     nextCursor?: string;
 
     @IsOptional()
-    @IsEnum(Sort)
-    sort: Sort;
+    @SortOptionTransformer()
+    @ValidateNested()
+    @Type(() => ProfileSort)
+    sort?: ProfileSort;
 
     @IsOptional()
     @ValidateNested()
@@ -18,5 +21,5 @@ export class GetProfileListDto {
     @Type(() => ProfileFilter)
     filter?: ProfileFilter;
 
-    static of(filter?: ProfileFilter, sort?: Sort) { return { sort, filter }; };
+    static of(filter?: ProfileFilter, sort?: ProfileSort) { return { sort, filter }; };
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -6,15 +6,15 @@ import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto,
 import { TestUser } from "test/unit/user/user.fixtures";
 import { TestCaregiverProfile } from "../../profile.fixtures";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
-import { Sort } from "src/profile/domain/enum/sort.enum";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
-import { ProfileSort } from "src/profile/domain/profile-sort";
+import { ProfilePaySort, ProfileSort } from "src/profile/domain/profile-sort";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
 import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
+import { OrderBy } from "src/common/shared/enum/sort-order.enum";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
@@ -59,7 +59,7 @@ describe('Caregiver Profile Mapper Component Test', () => {
 
     describe('toListQueryOptions()', () => {
         it('Cursor, Sort, Filter에 맞게 인스턴스가 생성되는지 확인', () => {
-            const sort = Sort.LowPay;
+            const sort = new ProfilePaySort(OrderBy.ASC);
             const filter = new ProfileFilter();
             const getProfileListDto = GetProfileListDto.of(filter, sort);
 

--- a/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
+++ b/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
@@ -42,7 +42,7 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
         it('반환된 데이터와 다음 커서를 생성하여 반환하는지 확인', async () => {
 
             const mockListQueryOption = new ProfileListQueryOptions(
-                new ProfileListCursor(), new ProfileSort(), new ProfileFilter()
+                new ProfileListCursor(), null, new ProfileFilter()
             );
             jest.spyOn(caregiverProfileMapper, 'toListQueryOptions').mockReturnValueOnce(mockListQueryOption); // 옵션 객체
             const profileList = [{}, {}] as CaregiverProfileListData [];

--- a/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
+++ b/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
@@ -1,20 +1,21 @@
 import 'reflect-metadata';
 import { validate } from "class-validator";
-import { Sort } from "src/profile/domain/enum/sort.enum"
 import { plainToInstance } from 'class-transformer';
 import { PossibleDate } from 'src/profile/domain/enum/possible-date.enum';
 import { GetProfileListDto } from 'src/profile/interface/dto/get-profile-list.dto';
 import { ProfileFilter } from 'src/profile/domain/profile-filter';
+import { ProfileSortField } from 'src/profile/domain/enum/sort.enum';
+import { OrderBy } from 'src/common/shared/enum/sort-order.enum';
 
 describe('GetProfileListDto Test', () => {
-    describe('sort 필드 Test', () => {
+    describe('ProfileSort Test', () => {
         it('잘못된 Enum 체크', async () => {
-            const wrongSort = 'sortByWrong' as Sort;
-            const sortTestDto = GetProfileListDto.of(undefined, wrongSort);
+            const wrongSort = { field: ProfileSortField.PAY, orderBy: 'reverse' }
+            const sortTestDto = GetProfileListDto.of(undefined, JSON.stringify(wrongSort) as any);
             const instanceDto = plainToInstance(GetProfileListDto, sortTestDto);
             
             const [result] = await validate(instanceDto);
-            expect(result.value).toBe(wrongSort);
+            expect(result.property).toBe('sort');
         });
     })
 
@@ -39,7 +40,7 @@ describe('GetProfileListDto Test', () => {
     })
 
     it('올바르게 입력된 Dto면 패스되는지 확인', async() => {
-        const sort = Sort.LowPay;
+        const sortOption = { field: ProfileSortField.PAY, orderBy: OrderBy.ASC };
         const filter = {
             pay: 10,
             age: 20,
@@ -47,8 +48,7 @@ describe('GetProfileListDto Test', () => {
             area: ['인천'],
             license: ['자격증1']
         };
-        const filterToInstance = plainToInstance(ProfileFilter, filter);
-        const testDto = GetProfileListDto.of(JSON.stringify(filter) as any, sort);
+        const testDto = GetProfileListDto.of(JSON.stringify(filter) as any, JSON.stringify(sortOption) as any);
         const toInstanceDto = plainToInstance(GetProfileListDto, testDto);
 
         const result = await validate(toInstanceDto);


### PR DESCRIPTION
- 요청으로 들어오는 정렬 조건을 보고 해당 객체로 변환해주는 SortOptionTransformer 데코레이터 추가
- 요청에서 변환해서 들어오기 때문에 Mapper에서는 그대로 넘겨줌
- GetProfileListDto에 필드와 정렬 기준 따로 필드로 받는 것으로 변경