### PR TITLE
[프론트엔드] 프로필 리스트 조회 Api의 sort 파라미터 수정

### DIFF
--- a/frontendv2/api/Profile/requestProfileList.jsx
+++ b/frontendv2/api/Profile/requestProfileList.jsx
@@ -63,6 +63,7 @@ export default async function requestProfileList(purpose) {
 }
 
 export function getMainFilterValue(mainFilter) {
+    
     switch (mainFilter) {
         case '기본순':
             return undefined;
@@ -73,9 +74,9 @@ export function getMainFilterValue(mainFilter) {
         case '찜 많은 순':
             return 'HighLike';
         case '일당 낮은 순':
-            return 'LowPay';
+            return { field: 'pay', orderBy: 'ASC' };
         case '시작일 빠른 순':
-            return 'FastStartDate';
+            return { field: 'possibleDate', orderBy: 'ASC' };
     }
 }
 


### PR DESCRIPTION
- 기존에는 기준 자체를 넘겼지만 추후에 유연성을 위해 정렬하기 위한 필드와 정렬 기준을 sort 객체로 감싸서 보내는 것으로 수정