### PR TITLE
Refactor(#95): OCP원칙 위반하는 프로필 정렬 조건 객체 리팩토링 완료

### DIFF
--- a/backend/src/common/shared/enum/sort-order.enum.ts
+++ b/backend/src/common/shared/enum/sort-order.enum.ts
@@ -1,0 +1,4 @@
+export enum OrderBy {
+    ASC = 'ASC',
+    DESC = 'DESC'
+}

--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -7,7 +7,6 @@ import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
-import { ProfileSort } from "src/profile/domain/profile-sort";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileDetailDto } from "src/profile/interface/dto/profile-detail.dto";
@@ -43,7 +42,7 @@ export class CaregiverProfileMapper {
     toListQueryOptions(getProfileListDto: GetProfileListDto): ProfileListQueryOptions {
         return new ProfileListQueryOptions(
             new ProfileListCursor(getProfileListDto.nextCursor),
-            new ProfileSort(getProfileListDto.sort),
+            getProfileListDto.sort,
             getProfileListDto.filter
         );
     };

--- a/backend/src/profile/domain/enum/sort.enum.ts
+++ b/backend/src/profile/domain/enum/sort.enum.ts
@@ -1,5 +1,6 @@
 /* 일당 낮은 순, 시작일 빠른 순 */
-export enum Sort {
-    LowPay = 'LowPay',
-    FastStartDate = 'FastStartDate'
-}
+export enum ProfileSortField { 
+    PAY = 'pay',
+    STARTDATE = 'possibleDate',
+    ID = '_id'
+};

--- a/backend/src/profile/domain/profile-list-query-options.ts
+++ b/backend/src/profile/domain/profile-list-query-options.ts
@@ -9,7 +9,7 @@ export class ProfileListQueryOptions {
  
     getNextCursor(): ProfileListCursor { return this.nextCursor; }; 
     getSortOptions(): ProfileSort | undefined { return this.sort; };
-    hasSortOptions(): boolean { return this.sort.hasOption() }; // 기본 최신순을 제외한 정렬 옵션이 있는지
+    hasSortOptions(): boolean { return this.sort ? true : false }; // 기본 최신순을 제외한 정렬 옵션이 있는지
     getFilters(): ProfileFilter { return this.filters; };
     
     constructor(next?: ProfileListCursor, sort?: ProfileSort, filters?: ProfileFilter) {

--- a/backend/src/profile/domain/profile-list.cursor.ts
+++ b/backend/src/profile/domain/profile-list.cursor.ts
@@ -31,8 +31,8 @@ export class ProfileListCursor {
         
         const lastProfile = profileList.at(-1);
         
-        let nextCursor = queryOptions.getSortOptions().hasOption() ? 
-                this.createCombinedCursor(lastProfile, queryOptions.getSortOptions().otherField()) : lastProfile.id;
+        let nextCursor = queryOptions.hasSortOptions() ? 
+                this.createCombinedCursor(lastProfile, queryOptions.getSortOptions().getField()) : lastProfile.id;
         
         return new ProfileListCursor(nextCursor)
     }

--- a/backend/src/profile/domain/profile-sort.ts
+++ b/backend/src/profile/domain/profile-sort.ts
@@ -1,19 +1,39 @@
-import { Sort } from './enum/sort.enum'
+import { OrderBy } from "src/common/shared/enum/sort-order.enum";
+import { ProfileSortField } from "./enum/sort.enum";
+import { IsEnum, IsNotEmpty } from "class-validator";
 
+/* 프로필 정렬 객체 공통 필드, 메서드 */
 export class ProfileSort {
-    private by?: Sort;
+    @IsNotEmpty()
+    @IsEnum(ProfileSortField)
+    private field: ProfileSortField;
 
-    hasOption(): boolean { return this.by ? true : false; }; // 다른 정렬기준이 있는지
+    @IsNotEmpty()
+    @IsEnum(OrderBy)
+    private orderBy: OrderBy;
 
-    getOption(): Sort { return this.by; };
-    
-    otherField(): string { return this.by === Sort.LowPay ? 'pay' : 'possibleDate'; }; // 다른 정렬 기준 필드
-     
-    otherFieldBy(): "DESC" | "ASC" { return "ASC"; }; // 다른 정렬 기준
+    constructor(field: ProfileSortField, orderBy: OrderBy) {
+        this.field = field;
+        this.orderBy = orderBy;
+    };
 
-    defaultField(): string { return '_id' }; // 기본 _id값 기준(생성일)
+    /* DB 필드에 해당하는 이름 */ 
+    public getField(): ProfileSortField { return this.field; };
+    /* 정렬 기준 */
+    public getOrderBy(): OrderBy { return this.orderBy; };
+};
 
-    defaultFieldBy(): "DESC" { return "DESC"; }; // 기본 최신순
+/* 프로필 아이디로 정렬  */
+export class ProfileIdSort extends ProfileSort {
+    constructor(orderBy: OrderBy) { super( ProfileSortField.ID, orderBy) }
+};
 
-    constructor(by?: Sort) { this.by = by; };
-}
+/* 프로필 일당으로 정렬 */
+export class ProfilePaySort extends ProfileSort {
+    constructor(orderBy: OrderBy) { super(ProfileSortField.PAY, orderBy) }
+};
+
+/* 프로필의 시작 가능일로 정렬 */
+export class ProfileStartDateSort extends ProfileSort {
+    constructor(orderBy: OrderBy) { super(ProfileSortField.STARTDATE, orderBy) };
+};

--- a/backend/src/profile/interface/decorator/sort-option-transformer.decorator.ts
+++ b/backend/src/profile/interface/decorator/sort-option-transformer.decorator.ts
@@ -1,0 +1,15 @@
+import { Transform } from "class-transformer";
+import { ProfileSortField } from "src/profile/domain/enum/sort.enum";
+import { ProfilePaySort, ProfileStartDateSort } from "src/profile/domain/profile-sort";
+
+export const SortOptionTransformer = () => Transform(({ value }) => {
+    if( !value ) return null;
+    const sortOption = JSON.parse(value);
+    switch( sortOption.field ) {
+        case ProfileSortField.PAY:
+            return new ProfilePaySort(sortOption.orderBy);
+        case ProfileSortField.STARTDATE:
+            return new ProfileStartDateSort(sortOption.orderBy);
+    }
+})
+

--- a/backend/src/profile/interface/dto/get-profile-list.dto.ts
+++ b/backend/src/profile/interface/dto/get-profile-list.dto.ts
@@ -1,7 +1,8 @@
 import { Transform, Type, plainToInstance } from "class-transformer";
-import { IsEnum, IsOptional, IsString, ValidateNested } from "class-validator";
-import { Sort } from "src/profile/domain/enum/sort.enum";
+import { IsOptional, IsString, ValidateNested } from "class-validator";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
+import { ProfileSort } from "src/profile/domain/profile-sort";
+import { SortOptionTransformer } from "../decorator/sort-option-transformer.decorator";
 
 export class GetProfileListDto {
     @IsOptional()
@@ -9,8 +10,10 @@ export class GetProfileListDto {
     nextCursor?: string;
 
     @IsOptional()
-    @IsEnum(Sort)
-    sort: Sort;
+    @SortOptionTransformer()
+    @ValidateNested()
+    @Type(() => ProfileSort)
+    sort?: ProfileSort;
 
     @IsOptional()
     @ValidateNested()
@@ -18,5 +21,5 @@ export class GetProfileListDto {
     @Type(() => ProfileFilter)
     filter?: ProfileFilter;
 
-    static of(filter?: ProfileFilter, sort?: Sort) { return { sort, filter }; };
+    static of(filter?: ProfileFilter, sort?: ProfileSort) { return { sort, filter }; };
 }

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -6,15 +6,15 @@ import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto,
 import { TestUser } from "test/unit/user/user.fixtures";
 import { TestCaregiverProfile } from "../../profile.fixtures";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
-import { Sort } from "src/profile/domain/enum/sort.enum";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
-import { ProfileSort } from "src/profile/domain/profile-sort";
+import { ProfilePaySort, ProfileSort } from "src/profile/domain/profile-sort";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
 import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
+import { OrderBy } from "src/common/shared/enum/sort-order.enum";
 
 describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
@@ -59,7 +59,7 @@ describe('Caregiver Profile Mapper Component Test', () => {
 
     describe('toListQueryOptions()', () => {
         it('Cursor, Sort, Filter에 맞게 인스턴스가 생성되는지 확인', () => {
-            const sort = Sort.LowPay;
+            const sort = new ProfilePaySort(OrderBy.ASC);
             const filter = new ProfileFilter();
             const getProfileListDto = GetProfileListDto.of(filter, sort);
 

--- a/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
+++ b/backend/test/unit/profile/application/service/caregiver-profile-service.spec.ts
@@ -42,7 +42,7 @@ describe('간병인 프로필 서비스(CaregiverProfileService) Test', () => {
         it('반환된 데이터와 다음 커서를 생성하여 반환하는지 확인', async () => {
 
             const mockListQueryOption = new ProfileListQueryOptions(
-                new ProfileListCursor(), new ProfileSort(), new ProfileFilter()
+                new ProfileListCursor(), null, new ProfileFilter()
             );
             jest.spyOn(caregiverProfileMapper, 'toListQueryOptions').mockReturnValueOnce(mockListQueryOption); // 옵션 객체
             const profileList = [{}, {}] as CaregiverProfileListData [];

--- a/backend/test/unit/profile/domain/profile-list-cursor.spec.ts
+++ b/backend/test/unit/profile/domain/profile-list-cursor.spec.ts
@@ -1,6 +1,7 @@
 import { ObjectId } from "mongodb";
-import { Sort } from "src/profile/domain/enum/sort.enum";
-import { CaregiverProfileListData, ProfileListDataAsClient } from "src/profile/domain/profile-list-data";
+import { OrderBy } from "src/common/shared/enum/sort-order.enum";
+import { ProfileSortField } from "src/profile/domain/enum/sort.enum";
+import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor"
 import { ProfileSort } from "src/profile/domain/profile-sort";
@@ -42,8 +43,8 @@ describe('프로필 리스트 커서 객체 Test', () => {
 
             it('마지막 프로필의 id와 정렬 옵션의 마지막 값이 조합되어 생성되어야 한다', () => {
                 const profileList = [ { id: 1, pay: 50 } ] as unknown as  CaregiverProfileListData [];
-
-                const queryOptions = new ProfileListQueryOptions(undefined, new ProfileSort(Sort.LowPay), undefined);
+                const sortOption = new ProfileSort(ProfileSortField.PAY, OrderBy.ASC);
+                const queryOptions = new ProfileListQueryOptions(undefined, sortOption, undefined);
                 const expectedCursor = `${profileList[0].pay}_${profileList[0].id}`
                 
                 const result = ProfileListCursor.createNextCursor(profileList, queryOptions);

--- a/backend/test/unit/profile/infra/repository/caregiver-profile-repository.spec.ts
+++ b/backend/test/unit/profile/infra/repository/caregiver-profile-repository.spec.ts
@@ -7,10 +7,10 @@ import { TestCaregiverProfile } from "../../profile.fixtures";
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options";
 import { ProfileQueryFactory } from "src/profile/infra/repository/profile-query.factory";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
-import { ProfileSort } from "src/profile/domain/profile-sort";
+import { ProfilePaySort } from "src/profile/domain/profile-sort";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
 import { Db } from "mongodb";
-import { Sort } from "src/profile/domain/enum/sort.enum";
+import { OrderBy } from "src/common/shared/enum/sort-order.enum";
 
 describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test', () => {
     let testProfile: CaregiverProfile, 
@@ -120,7 +120,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
 
             it('반환된 프로필이 1개인지 확인', async() => {
                 const listQueryOptions = new ProfileListQueryOptions(
-                    new ProfileListCursor(), new ProfileSort(), new ProfileFilter()
+                    new ProfileListCursor(), null, new ProfileFilter()
                 );
                 const result = await caregiverProfileRepository.getProfileList(listQueryOptions);
                 expect(result.length).toBe(1);
@@ -154,7 +154,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
             describe('쿼리에 정렬 옵션이 없고 다음 커서가 없거나 아이디만 있는 경우', () => {
                 it('없으면 최신순으로 5개의 리스트를 가져온다', async() => {
                     const listQueryOptions = new ProfileListQueryOptions(
-                        new ProfileListCursor(), new ProfileSort(), new ProfileFilter()
+                        new ProfileListCursor(), null, new ProfileFilter()
                     );
 
                     const result = await caregiverProfileRepository.getProfileList(listQueryOptions);
@@ -165,7 +165,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
 
                 it('아이디만 있는 경우 해당 아이디를 가진 프로필보다 오래된 프로필들을 반환', async() => {
                     const listQueryOptions = new ProfileListQueryOptions(
-                        new ProfileListCursor(middleProfile.getId()), new ProfileSort(), new ProfileFilter()
+                        new ProfileListCursor(middleProfile.getId()), null, new ProfileFilter()
                     );
 
                     const result = await caregiverProfileRepository.getProfileList(listQueryOptions);
@@ -178,7 +178,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
             describe('쿼리 정렬 옵션이 있는 경우', () => {
                 it('다음 커서가 없으면 최신 순으로 처음부터 반환한다', async () => {
                     const listQueryOptions = new ProfileListQueryOptions(
-                        new ProfileListCursor(), new ProfileSort(Sort.LowPay), new ProfileFilter()
+                        new ProfileListCursor(), new ProfilePaySort(OrderBy.ASC), new ProfileFilter()
                     );
 
                     const result = await caregiverProfileRepository.getProfileList(listQueryOptions);
@@ -191,7 +191,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
 
                 it('조합된 다음 커서가 있으면 파싱해서 이후 프로필을 반환한다', async () => {
                     const listQueryOptions = new ProfileListQueryOptions(
-                        new ProfileListCursor(`${middleNextProfile.getPay()}_${middleNextProfile.getId()}`), new ProfileSort(Sort.LowPay), new ProfileFilter()
+                        new ProfileListCursor(`${middleNextProfile.getPay()}_${middleNextProfile.getId()}`), new ProfilePaySort(OrderBy.ASC), new ProfileFilter()
                     );
                     
                     const result = await caregiverProfileRepository.getProfileList(listQueryOptions);
@@ -209,7 +209,7 @@ describe('간병인 프로필정보 저장소(CaregiverProfileRepository) Test',
                     await mongo.collection(testCollectionName).insertMany([firstProfile, secondProfile, lastProfile]);
 
                     const listQueryOptions = new ProfileListQueryOptions(
-                        new ProfileListCursor(`${samePay}_${lastProfile.getId()}`), new ProfileSort(Sort.LowPay), new ProfileFilter()
+                        new ProfileListCursor(`${samePay}_${lastProfile.getId()}`), new ProfilePaySort(OrderBy.ASC), new ProfileFilter()
                     );
 
                     const result = await caregiverProfileRepository.getProfileList(listQueryOptions);

--- a/backend/test/unit/profile/infra/repository/profile-query-factory.spec.ts
+++ b/backend/test/unit/profile/infra/repository/profile-query-factory.spec.ts
@@ -1,11 +1,11 @@
 import { plainToInstance } from "class-transformer"
 import { ObjectId } from "mongodb"
+import { OrderBy } from "src/common/shared/enum/sort-order.enum"
 import { PossibleDate } from "src/profile/domain/enum/possible-date.enum"
-import { Sort } from "src/profile/domain/enum/sort.enum"
 import { ProfileFilter } from "src/profile/domain/profile-filter"
 import { ProfileListQueryOptions } from "src/profile/domain/profile-list-query-options"
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor"
-import { ProfileSort } from "src/profile/domain/profile-sort"
+import { ProfilePaySort, ProfileSort } from "src/profile/domain/profile-sort"
 import { ProfileQueryFactory } from "src/profile/infra/repository/profile-query.factory"
 import { SEX } from "src/user-auth-common/domain/enum/user.enum"
 
@@ -20,7 +20,7 @@ describe('ProfileQueryFactory Test', () => {
             );
 
             const listQueryOptions = new ProfileListQueryOptions(
-                new ProfileListCursor(), new ProfileSort(), filter
+                new ProfileListCursor(),null, filter
             );
             const expectedPipeline = [
                 {
@@ -60,7 +60,7 @@ describe('ProfileQueryFactory Test', () => {
 
     describe('정렬 조건이 있는 경우', () => {
         it('Next Cursor가 없는 경우(첫 요청) Pipeline 확인', () => {
-            const sortOption = new ProfileSort(Sort.LowPay);
+            const sortOption = new ProfilePaySort(OrderBy.ASC);
             const filter = plainToInstance(
                 ProfileFilter,
                 { startDate: PossibleDate.WITHIN1MONTH }
@@ -105,9 +105,9 @@ describe('ProfileQueryFactory Test', () => {
             const nextProfileId = new ObjectId().toHexString();
             const nextCursor = `${nextPay}_${nextProfileId}`;
             
-            const sortOption = new ProfileSort(Sort.LowPay);
+            const sortOption = new ProfilePaySort(OrderBy.ASC);
             const listQueryOptions = new ProfileListQueryOptions(
-                new ProfileListCursor(nextCursor), new ProfileSort(Sort.LowPay), new ProfileFilter()
+                new ProfileListCursor(nextCursor), sortOption, new ProfileFilter()
             );
 
             const expectedPipeline = [

--- a/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
+++ b/backend/test/unit/profile/interface/dto/get-profile-list-dto.spec.ts
@@ -1,20 +1,21 @@
 import 'reflect-metadata';
 import { validate } from "class-validator";
-import { Sort } from "src/profile/domain/enum/sort.enum"
 import { plainToInstance } from 'class-transformer';
 import { PossibleDate } from 'src/profile/domain/enum/possible-date.enum';
 import { GetProfileListDto } from 'src/profile/interface/dto/get-profile-list.dto';
 import { ProfileFilter } from 'src/profile/domain/profile-filter';
+import { ProfileSortField } from 'src/profile/domain/enum/sort.enum';
+import { OrderBy } from 'src/common/shared/enum/sort-order.enum';
 
 describe('GetProfileListDto Test', () => {
-    describe('sort 필드 Test', () => {
+    describe('ProfileSort Test', () => {
         it('잘못된 Enum 체크', async () => {
-            const wrongSort = 'sortByWrong' as Sort;
-            const sortTestDto = GetProfileListDto.of(undefined, wrongSort);
+            const wrongSort = { field: ProfileSortField.PAY, orderBy: 'reverse' }
+            const sortTestDto = GetProfileListDto.of(undefined, JSON.stringify(wrongSort) as any);
             const instanceDto = plainToInstance(GetProfileListDto, sortTestDto);
             
             const [result] = await validate(instanceDto);
-            expect(result.value).toBe(wrongSort);
+            expect(result.property).toBe('sort');
         });
     })
 
@@ -39,7 +40,7 @@ describe('GetProfileListDto Test', () => {
     })
 
     it('올바르게 입력된 Dto면 패스되는지 확인', async() => {
-        const sort = Sort.LowPay;
+        const sortOption = { field: ProfileSortField.PAY, orderBy: OrderBy.ASC };
         const filter = {
             pay: 10,
             age: 20,
@@ -47,8 +48,7 @@ describe('GetProfileListDto Test', () => {
             area: ['인천'],
             license: ['자격증1']
         };
-        const filterToInstance = plainToInstance(ProfileFilter, filter);
-        const testDto = GetProfileListDto.of(JSON.stringify(filter) as any, sort);
+        const testDto = GetProfileListDto.of(JSON.stringify(filter) as any, JSON.stringify(sortOption) as any);
         const toInstanceDto = plainToInstance(GetProfileListDto, testDto);
 
         const result = await validate(toInstanceDto);

--- a/frontendv2/api/Profile/requestProfileList.jsx
+++ b/frontendv2/api/Profile/requestProfileList.jsx
@@ -63,6 +63,7 @@ export default async function requestProfileList(purpose) {
 }
 
 export function getMainFilterValue(mainFilter) {
+    
     switch (mainFilter) {
         case '기본순':
             return undefined;
@@ -73,9 +74,9 @@ export function getMainFilterValue(mainFilter) {
         case '찜 많은 순':
             return 'HighLike';
         case '일당 낮은 순':
-            return 'LowPay';
+            return { field: 'pay', orderBy: 'ASC' };
         case '시작일 빠른 순':
-            return 'FastStartDate';
+            return { field: 'possibleDate', orderBy: 'ASC' };
     }
 }
 


### PR DESCRIPTION
Refactor #95 

새로운 정렬 조건이 필요할 경우 ProfileSort 클래스를 상속받아 추가하여 DB에서 사용하는 필드 이름만 super()로 호출하고,
클라이언트에서 정렬 기준을 설정하여 넘겨주는것으로 변경