### PR TITLE
[백엔드] User Entity 연관 객체 Lazy Loading으로 변경

### DIFF
--- a/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
+++ b/backend/src/profile/application/mapper/caregiver-profile.mapper.ts
@@ -14,13 +14,13 @@ import { User } from "src/user-auth-common/domain/entity/user.entity";
 
 @Injectable()
 export class CaregiverProfileMapper {
-    mapFrom(user: User, caregiverRegisterDto: CaregiverRegisterDto): CaregiverProfile {
+    async mapFrom(user: User, caregiverRegisterDto: CaregiverRegisterDto): Promise<CaregiverProfile> {
         const { secondRegister, thirdRegister, lastRegister } = caregiverRegisterDto;
         return new CaregiverProfileBuilder(new ObjectId())
             .userId(user.getId())
             .name(user.getName())
-            .sex(user.getProfile().getSex())
-            .age(this.toDtoAge(user.getProfile().getBirth()))
+            .sex((await user.getProfile()).getSex())
+            .age(this.toDtoAge((await user.getProfile()).getBirth()))
             .weight(secondRegister.weight)
             .career(secondRegister.career)
             .pay(secondRegister.pay)

--- a/backend/src/profile/application/service/caregiver-profile.service.ts
+++ b/backend/src/profile/application/service/caregiver-profile.service.ts
@@ -20,7 +20,7 @@ export class CaregiverProfileService {
     
     /* 회원가입시 새로운 프로필 추가 */
     async addProfile(user: User, caregiverRegisterDto: CaregiverRegisterDto): Promise<void> {
-        const caregiverProfile = this.caregiverProfileMapper.mapFrom(user, caregiverRegisterDto);
+        const caregiverProfile = await this.caregiverProfileMapper.mapFrom(user, caregiverRegisterDto);
         await this.caregiverProfileRepository.save(caregiverProfile);
     } 
 

--- a/backend/src/user-auth-common/domain/entity/user-email.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-email.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { User } from "./user.entity";
 import { Time } from "src/common/shared/type/time.type";
 
@@ -7,11 +7,11 @@ export class Email {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @OneToOne(() => User, { onDelete: 'CASCADE' })
-    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
-    readonly userId: number;
+    @ManyToOne(() => User,(user) => user.email, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'user_id' })
+    readonly user: User;
 
-    @Column({ type: 'varchar', length: 50 })
+    @Column({ type: 'varchar', length: 50, nullable: true })
     private email: string;
 
     @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })

--- a/backend/src/user-auth-common/domain/entity/user-phone.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-phone.entity.ts
@@ -1,15 +1,15 @@
 import { Time } from "src/common/shared/type/time.type";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
-import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 
 @Entity('user_phone')
 export class Phone {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @OneToOne(() => User, { onDelete: 'CASCADE' })
-    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
-    readonly userId: number;
+    @ManyToOne(() => User, (user) => user.phone, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'user_id' })
+    readonly user: User;
 
     @Index()
     @Column({ type :'varchar', length: 11, name: 'phone_number' })

--- a/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
@@ -1,15 +1,15 @@
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity('user_profile')
 export class UserProfile {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @OneToOne(() => User, { onDelete: 'CASCADE' })
-    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
-    readonly userId: number;
+    @ManyToOne(() => User, (user) => user.profile, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'user_id' })
+    readonly user: User;
 
     @Column({ type: 'int' })
     private birth: number;

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -27,8 +27,8 @@ export class User {
     @OneToMany(() => Email, (email) => email.user, { lazy: true, cascade: ['insert', 'update'] })
     email: Promise<Email[]>;
 
-    @OneToOne(() => Phone, (phone) => phone.userId, { cascade: ['insert', 'update'] })
-    private phone: Phone;
+    @OneToMany(() => Phone, (phone) => phone.user, { lazy: true, cascade: ['insert', 'update'] })
+    phone: Promise<Phone[]>;
 
     @OneToMany(() => UserProfile, (profile) => profile.user, { lazy: true, cascade: ['insert'] })
     profile: Promise<UserProfile[]>;
@@ -36,12 +36,10 @@ export class User {
     @OneToOne(() => Token, (token) => token.userId, { cascade: ['insert', 'update'] })
     private authentication: Token;
 
-    constructor(name: string, role: ROLE, loginType: LOGIN_TYPE, phone: Phone, authentication: Token) {
+    constructor(name: string, role: ROLE, loginType: LOGIN_TYPE) {
         this.name = name;
         this.role = role;
         this.loginType = loginType;
-        this.authentication = authentication;
-        this.phone = phone;
     };
 
     getId(): number { return this.id; };
@@ -49,7 +47,7 @@ export class User {
     getRole(): ROLE { return this.role; };
     getAuthentication(): Token { return this.authentication; };
 
-    getPhone(): Phone { return this.phone; };
+    async getPhone(): Promise<Phone> { return (await this.phone)[0]; };
     async getEmail(): Promise<Email> { return (await this.email)[0]; };
     async getProfile(): Promise<UserProfile> { return (await this.profile)[0]; };
 
@@ -62,6 +60,12 @@ export class User {
         this.profile = Promise.resolve([userProfile]);
         return this;
     }
+
+    withPhone(phone: Phone): User {
+        this.phone = Promise.resolve([phone]);
+        return this;
+    };
+
     /* 회원가입시 새로 발급된 인증 */
     setAuthentication(newAuthentication: NewUserAuthentication) {
         this.authentication = new Token(

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -30,19 +30,18 @@ export class User {
     @OneToOne(() => Phone, (phone) => phone.userId, { cascade: ['insert', 'update'] })
     private phone: Phone;
 
-    @OneToOne(() => UserProfile, (profile) => profile.userId, { cascade: ['insert'] })
-    private profile: UserProfile;
+    @OneToMany(() => UserProfile, (profile) => profile.user, { lazy: true, cascade: ['insert'] })
+    profile: Promise<UserProfile[]>;
 
     @OneToOne(() => Token, (token) => token.userId, { cascade: ['insert', 'update'] })
     private authentication: Token;
 
-    constructor(name: string, role: ROLE, loginType: LOGIN_TYPE, phone: Phone, profile: UserProfile, authentication: Token) {
+    constructor(name: string, role: ROLE, loginType: LOGIN_TYPE, phone: Phone, authentication: Token) {
         this.name = name;
         this.role = role;
         this.loginType = loginType;
         this.authentication = authentication;
         this.phone = phone;
-        this.profile = profile;
     };
 
     getId(): number { return this.id; };
@@ -52,12 +51,17 @@ export class User {
 
     getPhone(): Phone { return this.phone; };
     async getEmail(): Promise<Email> { return (await this.email)[0]; };
-    getProfile(): UserProfile { return this.profile; };
+    async getProfile(): Promise<UserProfile> { return (await this.profile)[0]; };
 
     withEmail(email: Email): User { 
         this.email = Promise.resolve([email]); 
         return this;
     };
+
+    withProfile(userProfile: UserProfile): User {
+        this.profile = Promise.resolve([userProfile]);
+        return this;
+    }
     /* 회원가입시 새로 발급된 인증 */
     setAuthentication(newAuthentication: NewUserAuthentication) {
         this.authentication = new Token(

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -21,7 +21,6 @@ export const customUserRepositoryMethods: Pick<
                 .innerJoinAndSelect('user.authentication', 'auth')
                 .innerJoinAndSelect('user.phone', 'phone')
                 .innerJoinAndSelect('user.profile', 'profile')
-                .leftJoinAndSelect('user.email', 'email')
                 .where('user.id = :userId', { userId })
                 .getOne();
         },

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -19,7 +19,6 @@ export const customUserRepositoryMethods: Pick<
         :Promise<User> {
             return await this.createQueryBuilder('user')
                 .innerJoinAndSelect('user.authentication', 'auth')
-                .innerJoinAndSelect('user.phone', 'phone')
                 .where('user.id = :userId', { userId })
                 .getOne();
         },

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -20,7 +20,6 @@ export const customUserRepositoryMethods: Pick<
             return await this.createQueryBuilder('user')
                 .innerJoinAndSelect('user.authentication', 'auth')
                 .innerJoinAndSelect('user.phone', 'phone')
-                .innerJoinAndSelect('user.profile', 'profile')
                 .where('user.id = :userId', { userId })
                 .getOne();
         },

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -16,10 +16,10 @@ export class UserMapper extends UserAuthCommonMapper{
             commonRegisterDto.purpose,
             LOGIN_TYPE.PHONE,
             this.createPhoneByLoginType(LOGIN_TYPE.PHONE, commonRegisterDto.id),
-            new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex),
             null
         )
-        .withEmail(new Email(null));
+        .withEmail(new Email(null))
+        .withProfile(new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex));
 
         return user;
     };

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -11,15 +11,17 @@ import { CommonRegisterForm } from "src/user/interface/dto/register-page";
 @Injectable()
 export class UserMapper extends UserAuthCommonMapper{
     mapFrom(commonRegisterDto: CommonRegisterForm): User {
-        return new User(
+        const user = new User(
             commonRegisterDto.name,
             commonRegisterDto.purpose,
             LOGIN_TYPE.PHONE,
-            this.createEmailByLoginType(LOGIN_TYPE.PHONE),
             this.createPhoneByLoginType(LOGIN_TYPE.PHONE, commonRegisterDto.id),
             new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex),
             null
         )
+        .withEmail(new Email(null));
+
+        return user;
     };
 
     /* 내 정보 -> 내 프로필 조회에 쓰이는 Dto */
@@ -27,15 +29,10 @@ export class UserMapper extends UserAuthCommonMapper{
         return {
             phoneNumber: user.getPhone().getPhoneNumber(),
             role: user.getRole(),
-            email: this.checkEmailVerificationStatus(user.getEmail()),
+            email: this.checkEmailVerificationStatus(await user.getEmail()),
             isPrivate: profile ? profile.getIsPrivate() : undefined, // 간병인일 경우에만 프로필 비공개인지
         }
     }
-
-     /* 이메일로 회원가입(현재는 휴대폰으로만 제공) */
-     private createEmailByLoginType(loginType: LOGIN_TYPE): null | Email {
-        return loginType == LOGIN_TYPE.PHONE ? null : null;
-    };
 
     /* 휴대폰으로 회원가입  */
     private createPhoneByLoginType(loginType: LOGIN_TYPE, phoneNumber: string): null | Phone {

--- a/backend/src/user/application/mapper/user.mapper.ts
+++ b/backend/src/user/application/mapper/user.mapper.ts
@@ -15,11 +15,10 @@ export class UserMapper extends UserAuthCommonMapper{
             commonRegisterDto.name,
             commonRegisterDto.purpose,
             LOGIN_TYPE.PHONE,
-            this.createPhoneByLoginType(LOGIN_TYPE.PHONE, commonRegisterDto.id),
-            null
         )
         .withEmail(new Email(null))
-        .withProfile(new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex));
+        .withProfile(new UserProfile(commonRegisterDto.birth, commonRegisterDto.sex))
+        .withPhone(this.createPhoneByLoginType(LOGIN_TYPE.PHONE, commonRegisterDto.id));
 
         return user;
     };
@@ -27,7 +26,7 @@ export class UserMapper extends UserAuthCommonMapper{
     /* 내 정보 -> 내 프로필 조회에 쓰이는 Dto */
     async toMyProfileDto(user: User, profile?: CaregiverProfile) {
         return {
-            phoneNumber: user.getPhone().getPhoneNumber(),
+            phoneNumber: (await user.getPhone()).getPhoneNumber(),
             role: user.getRole(),
             email: this.checkEmailVerificationStatus(await user.getEmail()),
             isPrivate: profile ? profile.getIsPrivate() : undefined, // 간병인일 경우에만 프로필 비공개인지

--- a/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
+++ b/backend/test/unit/auth/application/guard/jwt-auth-guard.spec.ts
@@ -7,10 +7,9 @@ import { JwtStrategy } from "src/auth/application/guard/jwt/jwt.strategy"
 import { SessionService } from "src/auth/application/service/session.service"
 import { TokenService } from "src/auth/application/service/token.service"
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum"
-import { User } from "src/user-auth-common/domain/entity/user.entity"
 import { MockSessionService, MockTokenService } from "test/unit/__mock__/auth/service.mock"
 import { MockUserAuthCommonService } from "test/unit/__mock__/user-auth-common/service.mock"
-import { TestUser } from "test/unit/user/user.fixtures"
+import { UserFixtures } from "test/unit/user/user.fixtures"
 
 describe('Jwt인증가드(JwtAuthGuard) Test', () => {
     let reflector: Reflector;
@@ -117,7 +116,7 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
 
         describe('handledRequest()', () => {
             it('user가 있는경우 그대로 반환 확인', async () => {
-                const testUser = TestUser.default() as unknown as User;
+                const testUser = UserFixtures.createDefault();
                 const result = jwtGuard.handleRequest(null, testUser, null, null, null);
 
                 expect(result).toEqual(testUser);
@@ -141,7 +140,7 @@ describe('Jwt인증가드(JwtAuthGuard) Test', () => {
         describe('토큰의 유효성 검사를 모두 통과했을 경우', () => {
             
             const testToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxMDAxNjYzOTAyMn0.z0AfSIZ385LfcGiLQg2qeHUFcf0RfckEA7eE9EaOL24";
-            const user = TestUser.default() as unknown as User;
+            const user = UserFixtures.createDefault();
 
             beforeEach(() => jwtStrategy.validate = jest.fn().mockResolvedValueOnce(user));
 

--- a/backend/test/unit/auth/application/service/token-service.spec.ts
+++ b/backend/test/unit/auth/application/service/token-service.spec.ts
@@ -7,7 +7,7 @@ import { ROLE } from "src/user-auth-common/domain/enum/user.enum"
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface"
 import { RefreshToken } from "src/user-auth-common/domain/refresh-token"
 import { MockJwtService } from "test/unit/__mock__/auth/service.mock"
-import { TestUser } from "test/unit/user/user.fixtures"
+import { UserFixtures } from "test/unit/user/user.fixtures"
 
 describe('토큰 서비스(TokenService) Test', () => {
     let tokenService: TokenService;
@@ -42,7 +42,7 @@ describe('토큰 서비스(TokenService) Test', () => {
         tokenService = module.get(TokenService);
     });
 
-    beforeEach(() => userStub = TestUser.default() as unknown as User)
+    beforeEach(() => userStub = UserFixtures.createDefault() );
 
     describe('generateNewUsersToken()', () => {
         it('반환된 객체는 NewUserAuthentication의 인스턴스여야한다', async () => {

--- a/backend/test/unit/core/guard/role-guard.spec.ts
+++ b/backend/test/unit/core/guard/role-guard.spec.ts
@@ -3,7 +3,7 @@ import { Reflector } from "@nestjs/core";
 import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 import { RoleGuard } from "src/core/guard/role.guard";
 import { ROLE } from "src/user-auth-common/domain/enum/user.enum";
-import { TestUser } from "test/unit/user/user.fixtures";
+import { UserFixtures } from "test/unit/user/user.fixtures";
 
 describe('설정한 역할 이외는 접근 제한하는 가드(RoleGuard) Test', () => {
     
@@ -11,7 +11,7 @@ describe('설정한 역할 이외는 접근 제한하는 가드(RoleGuard) Test'
         const mockContext = {
             switchToHttp: () => ({
                 getRequest: () => ({
-                    user: TestUser.default().withRole(ROLE.CAREGIVER) // 접근한 사용자는 간병인
+                    user: UserFixtures.createWithRole(ROLE.CAREGIVER) // 접근한 사용자는 간병인
                 })
             }),
             getHandler: jest.fn()
@@ -31,7 +31,7 @@ describe('설정한 역할 이외는 접근 제한하는 가드(RoleGuard) Test'
         const mockContext = {
             switchToHttp: () => ({
                 getRequest: () => ({
-                    user: TestUser.default().withRole(ROLE.PROTECTOR) // 접근한 사용자는 보호자
+                    user: UserFixtures.createWithRole(ROLE.PROTECTOR) // 접근한 사용자는 보호자
                 })
             }),
             getHandler: jest.fn()

--- a/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
+++ b/backend/test/unit/profile/application/mapper/caregiver-profile-mapper.spec.ts
@@ -3,15 +3,12 @@ import { CaregiverProfile } from "src/profile/domain/entity/caregiver/caregiver-
 import { License } from "src/profile/domain/entity/caregiver/license.entity";
 import { CaregiverRegisterDto } from "src/profile/interface/dto/caregiver-register.dto";
 import { CaregiverInfoForm, CaregiverLastRegisterDto, CaregiverThirdRegisterDto, CommonRegisterForm } from "src/user/interface/dto/register-page";
-import { TestUser } from "test/unit/user/user.fixtures";
+import { UserFixtures } from "test/unit/user/user.fixtures";
 import { TestCaregiverProfile } from "../../profile.fixtures";
-import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { ProfileFilter } from "src/profile/domain/profile-filter";
 import { GetProfileListDto } from "src/profile/interface/dto/get-profile-list.dto";
 import { ProfileListCursor } from "src/profile/domain/profile-list.cursor";
 import { ProfilePaySort, ProfileSort } from "src/profile/domain/profile-sort";
-import { SEX } from "src/user-auth-common/domain/enum/user.enum";
-import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
 import { CaregiverProfileListData } from "src/profile/domain/profile-list-data";
 import { ProfileLikeMetadata } from "src/profile/domain/profile-like-metadata";
 import { OrderBy } from "src/common/shared/enum/sort-order.enum";
@@ -20,15 +17,10 @@ describe('Caregiver Profile Mapper Component Test', () => {
     const profileMapper = new CaregiverProfileMapper();
 
     describe('mapFrom()', () => {
-        const [userId, name, birth, sex, expectedAge] = [1, '테스트', 19980303, SEX.MALE, 25];
-        const user = TestUser
-                    .default()
-                    .withId(userId)
-                    .withName(name)
-                    .withUserProfile(new UserProfile(birth, sex)) as unknown as User;
 
-        it('간병인 회원가입 양식으로부터 프로필로 변환', () => {
-            const mappingResult = profileMapper.mapFrom(user, CaregiverRegisterDto.of(
+        it('간병인 회원가입 양식으로부터 프로필로 변환', async () => {
+            const user = UserFixtures.createDefault(); // 나이 25살
+            const mappingResult = await profileMapper.mapFrom(user, CaregiverRegisterDto.of(
                 {} as CommonRegisterForm,
                 createSecondRegisterForm(),
                 createThirdRegisterForm(),
@@ -37,9 +29,9 @@ describe('Caregiver Profile Mapper Component Test', () => {
 
             expect(mappingResult).toBeInstanceOf(CaregiverProfile);
             expect(mappingResult.getId()).not.toBeNull();
-            expect(mappingResult.getUserId()).toBe(userId);
-            expect(mappingResult.getAge()).toBe(expectedAge);
-            expect(mappingResult.getSex()).toBe(sex);
+            expect(mappingResult.getUserId()).toBe(user.getId());
+            expect(mappingResult.getAge()).toBe(25);
+            expect(mappingResult.getSex()).toBe((await user.getProfile()).getSex());
 
             mappingResult.getLicenseList()
                 .map(license => {

--- a/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
+++ b/backend/test/unit/rank/application/profile-view-rank-service.spec.ts
@@ -6,7 +6,7 @@ import { User } from "src/user-auth-common/domain/entity/user.entity"
 import { UUIDUtil } from "src/util/uuid.util"
 import { MockProfileViewRankRepository } from "test/unit/__mock__/rank/rank-repository.mock"
 import { MockProfileViewRankManager } from "test/unit/__mock__/rank/rank-service.mock"
-import { TestUser } from "test/unit/user/user.fixtures"
+import { UserFixtures } from "test/unit/user/user.fixtures"
 
 describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
     let profileViewRankRepository: ProfileViewRankRepository;
@@ -26,7 +26,7 @@ describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
     })
 
     describe('increment()', () => {
-        const [profileId, viewUser] = [UUIDUtil.generateOrderedUuid(), TestUser.default()];
+        const [profileId, viewUser] = [UUIDUtil.generateOrderedUuid(), UserFixtures.createDefault()];
 
         beforeEach(() => jest.clearAllMocks());
         
@@ -36,7 +36,7 @@ describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
             const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
             const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
 
-            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+            await profileViewRankService.increment(profileId, viewUser);
 
             expect(rankSpy).not.toHaveBeenCalled();
             expect(recordSpy).not.toHaveBeenCalled();
@@ -48,7 +48,7 @@ describe('프로필 조회 랭킹 서비스(ProfileViewRankService)', () => {
             const rankSpy = jest.spyOn(profileViewRankRepository, 'increment');
             const recordSpy = jest.spyOn(profileViewRankManager, 'recordUserAction');
             
-            await profileViewRankService.increment(profileId, viewUser as unknown as User);
+            await profileViewRankService.increment(profileId, viewUser);
 
             expect(rankSpy).toHaveBeenCalledWith(profileId);
             expect(recordSpy).toHaveBeenCalledWith(profileId, viewUser.getId());

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -22,8 +22,8 @@ describe('UserMapper Component Test', () => {
             expect(mapResult.getEmail()).toBeInstanceOf(Promise);
             expect(mapResult.getName()).toBe(name);
             expect(mapResult.getRole()).toBe(role);
-            expect(mapResult.getProfile().getBirth()).toBe(birth);
-            expect(mapResult.getProfile().getSex()).toBe(sex);
+            expect((await mapResult.getProfile()).getBirth()).toBe(birth);
+            expect((await mapResult.getProfile()).getSex()).toBe(sex);
             expect(mapResult.getAuthentication()).toBe(null);
         });
     });

--- a/backend/test/unit/user/application/mapper/user.mapper.spec.ts
+++ b/backend/test/unit/user/application/mapper/user.mapper.spec.ts
@@ -18,13 +18,13 @@ describe('UserMapper Component Test', () => {
 
             expect(mapResult).toBeInstanceOf(User);
             
-            expect(mapResult.getPhone().getPhoneNumber()).toBe(phoneNumber);
+            expect((await mapResult.getPhone()).getPhoneNumber()).toBe(phoneNumber);
             expect(mapResult.getEmail()).toBeInstanceOf(Promise);
             expect(mapResult.getName()).toBe(name);
             expect(mapResult.getRole()).toBe(role);
             expect((await mapResult.getProfile()).getBirth()).toBe(birth);
             expect((await mapResult.getProfile()).getSex()).toBe(sex);
-            expect(mapResult.getAuthentication()).toBe(null);
+            expect(mapResult.getAuthentication()).toBe(undefined);
         });
     });
 
@@ -60,7 +60,7 @@ describe('UserMapper Component Test', () => {
 
                 const result = await userMapper.toMyProfileDto(testUser, testProfile);
 
-                expect(result.phoneNumber).toBe(testUser.getPhone().getPhoneNumber());
+                expect(result.phoneNumber).toBe((await testUser.getPhone()).getPhoneNumber());
                 expect(result.email).toBe(null);
                 expect(result.role).toBe(ROLE.CAREGIVER);
                 expect(result.isPrivate).toBe(false);

--- a/backend/test/unit/user/infra/repository/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/user-repository.spec.ts
@@ -8,12 +8,12 @@ import { UUIDUtil } from "src/util/uuid.util"
 import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture"
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
-import { TestUser } from "../../user.fixtures"
-import { SEX } from "src/user-auth-common/domain/enum/user.enum"
+import {UserFixtures } from "../../user.fixtures"
 
 describe('사용자 저장소(UserRepository) Test', () => {
     let userRepository: UserRepository;
     let module: TestingModule;
+    
     beforeAll(async() => {
         module = await Test.createTestingModule({
             imports: [
@@ -26,48 +26,48 @@ describe('사용자 저장소(UserRepository) Test', () => {
         userRepository = userRepository.extend(customUserRepositoryMethods);
     })
 
-    afterAll(async() => module.close() );
+    afterAll(async() => await module.close() );
 
+    afterEach(async() => await userRepository.delete({ }));
 
     describe('findById()', () => {
         it('일치하는 사용자 id로 조회했을 때 반환되는지 확인', async() => {
-            const [phoneNumber, refreshKey, refreshToken] = ['01022221111', UUIDUtil.generateOrderedUuid(), 'refresh'];
-            const [birth, sex] = [20020101, SEX.MALE]
-
-            const token = new Token(null, refreshKey, refreshToken);
-            const userProfile = new UserProfile(birth, sex);
-            const testUser = TestUser.default().withPhoneNumber(phoneNumber).withToken(token).withUserProfile(userProfile);
-            
-            const savedId = (await userRepository.save(testUser as unknown as User)).getId();
+            const testUser = UserFixtures.createDefault();            
+            const savedId = (await userRepository.save(testUser)).getId();
             const result = await userRepository.findById(savedId);
-            
-            expect(result.getId()).toBe(savedId);
-            expect(result.getAuthentication().getRefreshKey()).toBe(refreshKey);
-            expect(result.getAuthentication().getRefreshToken()).toBe(refreshToken);
-            expect(result.getPhone().getPhoneNumber()).toBe(phoneNumber);
-            expect(result.getEmail()).toBe(null);
-            expect(result.getProfile().getBirth()).toBe(birth);
-            expect(result.getProfile().getSex()).toBe(sex);
 
-            await userRepository.delete({ id: savedId })
+            expect(result.getId()).toBe(savedId);
+            expect(result.getName()).toBe(testUser.getName());
+            expect(result.getRole()).toBe(testUser.getRole());
+            expect(result.getProfile()).toEqual(testUser.getProfile());
+            expect(result.getAuthentication().getAccessToken()).toBe(undefined); // AccessToken은 DB에 저장 x
+            expect(result.getAuthentication().getRefreshKey()).toBe(testUser.getAuthentication().getRefreshKey());
+            expect(result.getAuthentication().getRefreshToken()).toBe(testUser.getAuthentication().getRefreshToken())
+        })
+
+        it('Email Lazy Loading 확인', async() => {
+            const testEmail = 'test@naver.com';
+            const testWithEmailUser = UserFixtures.createWithEmail(testEmail);
+            const savedId = (await userRepository.save(testWithEmailUser)).getId();
+
+            const result = await userRepository.findById(savedId);
+
+            expect(result.getEmail()).toBeInstanceOf(Promise);
+            expect(await result.getEmail()).toBeInstanceOf(Email);
         })
     });
 
     describe('findByRefreshKey()', () => {
-        it('일치하는 RefreshKey가 있을 때 Authentication Entity까지 로드되는지 확인', async() => {
-            const [testUuid, testRefreshToken] = [UUIDUtil.generateOrderedUuid(), 'refreshToken'];
+        it('일치하는 RefreshKey로 찾는지 확인', async() => {
+            const testRefreshKey = UUIDUtil.generateOrderedUuid();
+            const testUser = UserFixtures.createWithRefreshKey(testRefreshKey);
             
-            const token = new Token(null, testUuid, testRefreshToken);
-            const testUser = TestUser.default().withToken(token);
+            await userRepository.save(testUser);
 
-            const id = (await userRepository.save(testUser as unknown as User)).getId();
-            const findResult = await userRepository.findByRefreshKey(testUuid);
+            const findResult = await userRepository.findByRefreshKey(testRefreshKey);
 
             expect(findResult.getAuthentication()).not.toBe(null);
-            expect(findResult.getAuthentication().getRefreshKey()).toBe(testUuid);
-            expect(findResult.getAuthentication().getRefreshToken()).toBe(testRefreshToken);
-            
-            await userRepository.delete({ id })
+            expect(findResult.getAuthentication().getRefreshKey()).toBe(testRefreshKey);        
         });
     });
 })

--- a/backend/test/unit/user/infra/repository/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/user-repository.spec.ts
@@ -61,14 +61,25 @@ describe('사용자 저장소(UserRepository) Test', () => {
 
         it('UserProfile Lazy Loading 확인', async() => {
             const [birth, sex] = [19980101, SEX.FEMALE];
-            const testWithEmailUser = UserFixtures.createWithProfile(birth, sex);
-            const savedId = (await userRepository.save(testWithEmailUser)).getId();
+            const testUser = UserFixtures.createWithProfile(birth, sex);
+            const savedId = (await userRepository.save(testUser)).getId();
 
             const result = await userRepository.findById(savedId);
 
             expect(result.getProfile()).toBeInstanceOf(Promise);
             expect((await result.getProfile()).getBirth()).toBe(birth);
             expect((await result.getProfile()).getSex()).toBe(sex);
+        });
+
+        it('Phone Lazy Loading 확인', async() => {
+            const phoneNumber = '01011223344';
+            const testUser = UserFixtures.createWithPhone(phoneNumber);
+            const savedId = (await userRepository.save(testUser)).getId();
+
+            const result = await userRepository.findById(savedId);
+
+            expect(result.getPhone()).toBeInstanceOf(Promise);
+            expect((await result.getPhone()).getPhoneNumber()).toBe(phoneNumber);
         })
     });
 
@@ -85,4 +96,18 @@ describe('사용자 저장소(UserRepository) Test', () => {
             expect(findResult.getAuthentication().getRefreshKey()).toBe(testRefreshKey);        
         });
     });
+
+    describe('findByPhoneNumber()', () => {
+        it('맞는 값 찾는지 확인', async() => {
+            const phoneNumber = '01022991101';
+            const testUser = UserFixtures.createWithPhone(phoneNumber);
+
+            const savedId = (await userRepository.save(testUser)).getId();
+
+            const result = await userRepository.findByPhoneNumber(phoneNumber);
+            
+            expect(result.getId()).toBe(savedId);
+        })
+        
+    })
 })

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -6,87 +6,111 @@ import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.ent
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface";
+import { RefreshToken } from "src/user-auth-common/domain/refresh-token";
 
 /* Setting 되어있는 기본 사용자 객체 */
 export class UserFixtures {
     /* 기본 사용자 */
     static createDefault(): User {
-        return new User(
-            this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withAuthentication()
-        )
-        .withEmail(this.emptyEmail())
-        .withProfile(this.defaulthProfile());
+        const user = this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone())
+
+        user.setAuthentication(this.withDefaultAuth());
+
+        return user;
     }
 
     /* 설정한 역할을 가진 사용자 */
     static createWithRole(role: ROLE): User {
-        return new User(
-            this.withName(), this.withRole(role), this.withLoginType(),
-            this.withPhone(), this.withAuthentication()
-        )
-        .withEmail(this.emptyEmail())
-        .withProfile(this.defaulthProfile());
+        const user = this.withRole(role)
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone())
+
+        user.setAuthentication(this.withDefaultAuth());
+
+        return user;
     };
 
     /* 설정한 Email을 가지는 사용자 */
     static createWithEmail(email: string): User {
-        return new User(
-            this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withAuthentication()
-        )
-        .withEmail(new Email(email))
-        .withProfile(this.defaulthProfile());
+        const user = this.withDefaultInfo()
+            .withEmail(new Email(email))
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone())
+
+        user.setAuthentication(this.withDefaultAuth());
+
+        return user;
     };
 
     /* 설정한 프로필을 가지는 사용자 */
     static createWithProfile(birth: number, sex: SEX): User {
-        return new User(
-            this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withAuthentication()
-        )
-        .withEmail(this.emptyEmail())
-        .withProfile(new UserProfile(birth, sex));
+        const user = this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(new UserProfile(birth, sex))
+            .withPhone(this.defaultPhone());
+
+        user.setAuthentication(this.withDefaultAuth());
+
+        return user;
     }
 
     /* 설정한 전화번호 가지는 사용자 */
     static createWithPhone(phone: string): User {
-        return new User(
-            this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(phone), this.withAuthentication()
-        )
-        .withEmail(this.emptyEmail())
-        .withProfile(this.defaulthProfile());
+        const user = this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(new Phone(phone));
+
+        user.setAuthentication(this.withDefaultAuth());
+
+        return user;
     }
 
     /* 설정한 RefreshKey 가지는 사용자 */
     static createWithRefreshKey(refreshKey: string): User {
-        return new User(
-            this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withAuthentication(this.withAccessToken(), refreshKey, this.withRefreshToken())
-        )
-        .withEmail(this.emptyEmail())
-        .withProfile(this.defaulthProfile());
+        const user = this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone());
+
+        user.setAuthentication(this.withRefreshKeyAuth(refreshKey));
+
+        return user;
     }
 
-    private static withName(name: string = '테스트'): string { return name; };
-    private static withPhone(phone: string = '01011111111'): Phone { return new Phone(phone); };
-    private static withRole(role: ROLE = ROLE.CAREGIVER): ROLE { return role; };
-    private static withLoginType(type: LOGIN_TYPE = LOGIN_TYPE.PHONE): LOGIN_TYPE { return type; };
-    
+    private static withDefaultInfo(): User { return new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE); };
+    private static withRole(role: ROLE): User { return new User('테스트', role, LOGIN_TYPE.PHONE); };
+
     private static emptyEmail(): Email { return new Email(null) };
     private static defaulthProfile(): UserProfile { return new UserProfile(19980101, SEX.MALE); };
-    
-    private static withAccessToken(accessToken: string = 'testAccessToken'): string { return accessToken; };
-    private static withRefreshKey(refreshKey: string = 'aeee4c6ffa88bc50822cab3ce4d783c9'): string { return refreshKey; };
-    private static withRefreshToken(refreshToken: string = 'testRefreshToken'): string { return refreshToken; };
+    private static defaultPhone(): Phone { return new Phone('01011223344') };
 
-    private static withAuthentication(
-        accessToken = this.withAccessToken(),
-        refreshKey = this.withRefreshKey(),
-        refreshToken = this.withRefreshToken()
-    ): Token { 
-        return new Token(accessToken, refreshKey, refreshToken) 
+    private static defaultAccessToken(): string { return 'defaultAccessToken'; };
+    private static defaultRefreshKey(): string { return 'aeee4c6ffa88bc50822cab3ce4d783c9'; };
+    private static defaultRefreshToken(): string { return 'defaultRefreshToken'; };
+
+    private static withDefaultAuth() {
+        return new NewUserAuthentication(
+            this.defaultAccessToken(),
+            new RefreshToken(
+                this.defaultRefreshKey(),
+                this.defaultRefreshToken()
+            )
+        )
+    }
+
+    private static withRefreshKeyAuth(refreshKey: string) {
+        return new NewUserAuthentication(
+            this.defaultAccessToken(),
+            new RefreshToken(
+                refreshKey,
+                this.defaultRefreshToken()
+            )
+        )
     }
 }
 
@@ -112,10 +136,11 @@ export class TestUser {
         this.authentication = token;
     };
 
-    static default() { return new TestUser(
-        '테스트', LOGIN_TYPE.PHONE, ROLE.CAREGIVER, 
-        new Phone('01011223344'), new UserProfile(19980101, SEX.MALE), 
-        new Token('accessToken', 'refreshKey', 'refreshToken')
+    static default() {
+        return new TestUser(
+            '테스트', LOGIN_TYPE.PHONE, ROLE.CAREGIVER,
+            new Phone('01011223344'), new UserProfile(19980101, SEX.MALE),
+            new Token('accessToken', 'refreshKey', 'refreshToken')
         )
     };
 
@@ -180,9 +205,9 @@ export class TestUser {
     /* 인증을 새로 갱신할 때 전체 값만 변경 */
     refreshAuthentication(refreshedAuthentication: NewUserAuthentication) {
         this.authentication.refreshAuthentication(
-            refreshedAuthentication.accessToken, 
+            refreshedAuthentication.accessToken,
             refreshedAuthentication.refreshToken.getKey(),
             refreshedAuthentication.refreshToken.getToken()
         );
     }
- }
+}

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -13,52 +13,69 @@ export class UserFixtures {
     static createDefault(): User {
         return new User(
             this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withProfile(), this.withAuthentication()
+            this.withPhone(), this.withAuthentication()
         )
-        .withEmail(new Email(null));
+        .withEmail(this.emptyEmail())
+        .withProfile(this.defaulthProfile());
     }
 
     /* 설정한 역할을 가진 사용자 */
     static createWithRole(role: ROLE): User {
         return new User(
             this.withName(), this.withRole(role), this.withLoginType(),
-            this.withPhone(), this.withProfile(), this.withAuthentication()
+            this.withPhone(), this.withAuthentication()
         )
-        .withEmail(new Email(null));
+        .withEmail(this.emptyEmail())
+        .withProfile(this.defaulthProfile());
     };
 
     /* 설정한 Email을 가지는 사용자 */
     static createWithEmail(email: string): User {
         return new User(
             this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withProfile(), this.withAuthentication()
+            this.withPhone(), this.withAuthentication()
         )
-        .withEmail(new Email(email));
+        .withEmail(new Email(email))
+        .withProfile(this.defaulthProfile());
     };
+
+    /* 설정한 프로필을 가지는 사용자 */
+    static createWithProfile(birth: number, sex: SEX): User {
+        return new User(
+            this.withName(), this.withRole(), this.withLoginType(),
+            this.withPhone(), this.withAuthentication()
+        )
+        .withEmail(this.emptyEmail())
+        .withProfile(new UserProfile(birth, sex));
+    }
 
     /* 설정한 전화번호 가지는 사용자 */
     static createWithPhone(phone: string): User {
         return new User(
             this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(phone), this.withProfile(), this.withAuthentication()
+            this.withPhone(phone), this.withAuthentication()
         )
-        .withEmail(new Email(null));
+        .withEmail(this.emptyEmail())
+        .withProfile(this.defaulthProfile());
     }
 
     /* 설정한 RefreshKey 가지는 사용자 */
     static createWithRefreshKey(refreshKey: string): User {
         return new User(
             this.withName(), this.withRole(), this.withLoginType(),
-            this.withPhone(), this.withProfile(), this.withAuthentication(this.withAccessToken(), refreshKey, this.withRefreshToken())
+            this.withPhone(), this.withAuthentication(this.withAccessToken(), refreshKey, this.withRefreshToken())
         )
-        .withEmail(new Email(null));
+        .withEmail(this.emptyEmail())
+        .withProfile(this.defaulthProfile());
     }
 
     private static withName(name: string = '테스트'): string { return name; };
     private static withPhone(phone: string = '01011111111'): Phone { return new Phone(phone); };
     private static withRole(role: ROLE = ROLE.CAREGIVER): ROLE { return role; };
     private static withLoginType(type: LOGIN_TYPE = LOGIN_TYPE.PHONE): LOGIN_TYPE { return type; };
-    private static withProfile(birth: number = 19980303, sex: SEX = SEX.FEMALE): UserProfile { return new UserProfile(birth, sex); };
+    
+    private static emptyEmail(): Email { return new Email(null) };
+    private static defaulthProfile(): UserProfile { return new UserProfile(19980101, SEX.MALE); };
     
     private static withAccessToken(accessToken: string = 'testAccessToken'): string { return accessToken; };
     private static withRefreshKey(refreshKey: string = 'aeee4c6ffa88bc50822cab3ce4d783c9'): string { return refreshKey; };

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -22,6 +22,14 @@ export class UserFixtures {
         return user;
     }
 
+    /* 새로 가입한 사용자 */
+    static createNewUser(): User {
+        return this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone());
+    }
+
     /* 설정한 역할을 가진 사용자 */
     static createWithRole(role: ROLE): User {
         const user = this.withRole(role)
@@ -80,6 +88,18 @@ export class UserFixtures {
         user.setAuthentication(this.withRefreshKeyAuth(refreshKey));
 
         return user;
+    };
+
+    /* 설정한 RefreshToken을 가지는 사용자 */
+    static createWithRefreshToken(refreshToken: string): User {
+        const user = this.withDefaultInfo()
+            .withEmail(this.emptyEmail())
+            .withProfile(this.defaulthProfile())
+            .withPhone(this.defaultPhone());
+
+        user.setAuthentication(this.withRefreshToken(refreshToken));
+
+        return user; 
     }
 
     private static withDefaultInfo(): User { return new User('테스트', ROLE.CAREGIVER, LOGIN_TYPE.PHONE); };
@@ -112,102 +132,14 @@ export class UserFixtures {
             )
         )
     }
-}
 
-
-export class TestUser {
-    id: number;
-    name: string;
-    sex: SEX;
-    loginType: LOGIN_TYPE;
-    role: ROLE;
-    phone: Phone;
-    email: Promise<Email[]>;
-    profile: UserProfile;
-    authentication: Token;
-    registeredAt: Time;
-
-    constructor(name: string, loginType: LOGIN_TYPE, role: ROLE, phone: Phone, profile: UserProfile, token: Token) {
-        this.name = name;
-        this.loginType = loginType;
-        this.role = role;
-        this.phone = phone;
-        this.profile = profile;
-        this.authentication = token;
-    };
-
-    static default() {
-        return new TestUser(
-            '테스트', LOGIN_TYPE.PHONE, ROLE.CAREGIVER,
-            new Phone('01011223344'), new UserProfile(19980101, SEX.MALE),
-            new Token('accessToken', 'refreshKey', 'refreshToken')
+    private static withRefreshToken(refreshToken: string) {
+        return new NewUserAuthentication(
+            this.defaultAccessToken(),
+            new RefreshToken(
+                this.defaultRefreshKey(),
+                refreshToken
+            )
         )
-    };
-
-    withId(id: number): this {
-        this.id = id;
-        return this;
-    };
-
-    withName(name: string): this {
-        this.name = name;
-        return this;
-    }
-
-    withSex(sex: SEX): this {
-        this.sex = sex;
-        return this;
-    }
-
-    withRole(role: ROLE): this {
-        this.role = role;
-        return this;
-    }
-
-    withPhoneNumber(phoneNumber: string): this {
-        this.phone = new Phone(phoneNumber);
-        return this;
-    };
-
-    withEmail(email: string): this {
-        this.email = Promise.resolve([new Email(email)]);
-        return this;
-    };
-
-    withUserProfile(profile: UserProfile): this {
-        this.profile = profile;
-        return this;
-    }
-
-    withToken(token: Token): this {
-        this.authentication = token;
-        return this;
-    };
-
-    getId(): number { return this.id; };
-    getName(): string { return this.name; };
-    getRole(): ROLE { return this.role; };
-    getAuthentication(): Token { return this.authentication; };
-
-    getPhone(): Phone { return this.phone; };
-    async getEmail(): Promise<Email[]> { return this.email; };
-    getProfile(): UserProfile { return this.profile; };
-
-    /* 회원가입시 새로 발급된 인증 */
-    setAuthentication(newAuthentication: NewUserAuthentication) {
-        this.authentication = new Token(
-            newAuthentication.accessToken,
-            newAuthentication.refreshToken.getKey(),
-            newAuthentication.refreshToken.getToken()
-        );
-    };
-
-    /* 인증을 새로 갱신할 때 전체 값만 변경 */
-    refreshAuthentication(refreshedAuthentication: NewUserAuthentication) {
-        this.authentication.refreshAuthentication(
-            refreshedAuthentication.accessToken,
-            refreshedAuthentication.refreshToken.getKey(),
-            refreshedAuthentication.refreshToken.getToken()
-        );
     }
 }

--- a/backend/test/unit/user/user.fixtures.ts
+++ b/backend/test/unit/user/user.fixtures.ts
@@ -3,8 +3,76 @@ import { Token } from "src/user-auth-common/domain/entity/auth-token.entity";
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity";
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity";
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity";
+import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { LOGIN_TYPE, ROLE, SEX } from "src/user-auth-common/domain/enum/user.enum";
 import { NewUserAuthentication } from "src/user-auth-common/domain/interface/new-user-authentication.interface";
+
+/* Setting 되어있는 기본 사용자 객체 */
+export class UserFixtures {
+    /* 기본 사용자 */
+    static createDefault(): User {
+        return new User(
+            this.withName(), this.withRole(), this.withLoginType(),
+            this.withPhone(), this.withProfile(), this.withAuthentication()
+        )
+        .withEmail(new Email(null));
+    }
+
+    /* 설정한 역할을 가진 사용자 */
+    static createWithRole(role: ROLE): User {
+        return new User(
+            this.withName(), this.withRole(role), this.withLoginType(),
+            this.withPhone(), this.withProfile(), this.withAuthentication()
+        )
+        .withEmail(new Email(null));
+    };
+
+    /* 설정한 Email을 가지는 사용자 */
+    static createWithEmail(email: string): User {
+        return new User(
+            this.withName(), this.withRole(), this.withLoginType(),
+            this.withPhone(), this.withProfile(), this.withAuthentication()
+        )
+        .withEmail(new Email(email));
+    };
+
+    /* 설정한 전화번호 가지는 사용자 */
+    static createWithPhone(phone: string): User {
+        return new User(
+            this.withName(), this.withRole(), this.withLoginType(),
+            this.withPhone(phone), this.withProfile(), this.withAuthentication()
+        )
+        .withEmail(new Email(null));
+    }
+
+    /* 설정한 RefreshKey 가지는 사용자 */
+    static createWithRefreshKey(refreshKey: string): User {
+        return new User(
+            this.withName(), this.withRole(), this.withLoginType(),
+            this.withPhone(), this.withProfile(), this.withAuthentication(this.withAccessToken(), refreshKey, this.withRefreshToken())
+        )
+        .withEmail(new Email(null));
+    }
+
+    private static withName(name: string = '테스트'): string { return name; };
+    private static withPhone(phone: string = '01011111111'): Phone { return new Phone(phone); };
+    private static withRole(role: ROLE = ROLE.CAREGIVER): ROLE { return role; };
+    private static withLoginType(type: LOGIN_TYPE = LOGIN_TYPE.PHONE): LOGIN_TYPE { return type; };
+    private static withProfile(birth: number = 19980303, sex: SEX = SEX.FEMALE): UserProfile { return new UserProfile(birth, sex); };
+    
+    private static withAccessToken(accessToken: string = 'testAccessToken'): string { return accessToken; };
+    private static withRefreshKey(refreshKey: string = 'aeee4c6ffa88bc50822cab3ce4d783c9'): string { return refreshKey; };
+    private static withRefreshToken(refreshToken: string = 'testRefreshToken'): string { return refreshToken; };
+
+    private static withAuthentication(
+        accessToken = this.withAccessToken(),
+        refreshKey = this.withRefreshKey(),
+        refreshToken = this.withRefreshToken()
+    ): Token { 
+        return new Token(accessToken, refreshKey, refreshToken) 
+    }
+}
+
 
 export class TestUser {
     id: number;
@@ -13,7 +81,7 @@ export class TestUser {
     loginType: LOGIN_TYPE;
     role: ROLE;
     phone: Phone;
-    email: Email;
+    email: Promise<Email[]>;
     profile: UserProfile;
     authentication: Token;
     registeredAt: Time;
@@ -60,7 +128,7 @@ export class TestUser {
     };
 
     withEmail(email: string): this {
-        this.email = new Email(email);
+        this.email = Promise.resolve([new Email(email)]);
         return this;
     };
 
@@ -80,7 +148,7 @@ export class TestUser {
     getAuthentication(): Token { return this.authentication; };
 
     getPhone(): Phone { return this.phone; };
-    getEmail(): Email { return this.email; };
+    async getEmail(): Promise<Email[]> { return this.email; };
     getProfile(): UserProfile { return this.profile; };
 
     /* 회원가입시 새로 발급된 인증 */


### PR DESCRIPTION
Resolved #76 

Phone, Email, Profile Entity들 @OneToOne -> @OneToMany 관계로 변경 후 Lazy Loading

Authentication Entity는 대부분의 Api에 인증단계를 거치므로 Eager Loading(Join)

