### PR TITLE
[백엔드] User Entity와 연관 객체들 OneToOne 관계로 변경

### DIFF
--- a/backend/src/user-auth-common/domain/entity/user-email.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-email.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { User } from "./user.entity";
 import { Time } from "src/common/shared/type/time.type";
 
@@ -7,8 +7,8 @@ export class Email {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @ManyToOne(() => User,(user) => user.email, { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'user_id' })
+    @OneToOne(() => User,(user) => user.email, { onDelete: 'CASCADE' })
+    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
     readonly user: User;
 
     @Column({ type: 'varchar', length: 50, nullable: true })

--- a/backend/src/user-auth-common/domain/entity/user-phone.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-phone.entity.ts
@@ -1,14 +1,14 @@
 import { Time } from "src/common/shared/type/time.type";
 import { User } from "src/user-auth-common/domain/entity/user.entity";
-import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 
 @Entity('user_phone')
 export class Phone {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @ManyToOne(() => User, (user) => user.phone, { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'user_id' })
+    @OneToOne(() => User, (user) => user.phone, { onDelete: 'CASCADE' })
+    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
     readonly user: User;
 
     @Index()

--- a/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user-profile.entity.ts
@@ -1,14 +1,14 @@
 import { User } from "src/user-auth-common/domain/entity/user.entity";
 import { SEX } from "src/user-auth-common/domain/enum/user.enum";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity('user_profile')
 export class UserProfile {
     @PrimaryGeneratedColumn('increment')
     private id: number;
 
-    @ManyToOne(() => User, (user) => user.profile, { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'user_id' })
+    @OneToOne(() => User, (user) => user.profile, { onDelete: 'CASCADE' })
+    @JoinColumn({ referencedColumnName: 'id', name: 'user_id' })
     readonly user: User;
 
     @Column({ type: 'int' })

--- a/backend/src/user-auth-common/domain/entity/user.entity.ts
+++ b/backend/src/user-auth-common/domain/entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { LOGIN_TYPE, ROLE } from "../enum/user.enum";
 import { Phone } from "./user-phone.entity";
 import { UserProfile } from "./user-profile.entity";
@@ -24,14 +24,14 @@ export class User {
     @CreateDateColumn({ name: 'registered_at', type: 'timestamp' })
     private registeredAt: Time;
 
-    @OneToMany(() => Email, (email) => email.user, { lazy: true, cascade: ['insert', 'update'] })
-    email: Promise<Email[]>;
+    @OneToOne(() => Email, (email) => email.user, { lazy: true, cascade: ['insert', 'update'] })
+    email: Promise<Email>;
 
-    @OneToMany(() => Phone, (phone) => phone.user, { lazy: true, cascade: ['insert', 'update'] })
-    phone: Promise<Phone[]>;
+    @OneToOne(() => Phone, (phone) => phone.user, { lazy: true, cascade: ['insert', 'update'] })
+    phone: Promise<Phone>;
 
-    @OneToMany(() => UserProfile, (profile) => profile.user, { lazy: true, cascade: ['insert'] })
-    profile: Promise<UserProfile[]>;
+    @OneToOne(() => UserProfile, (profile) => profile.user, { lazy: true, cascade: ['insert'] })
+    profile: Promise<UserProfile>;
 
     @OneToOne(() => Token, (token) => token.userId, { cascade: ['insert', 'update'] })
     private authentication: Token;
@@ -47,22 +47,22 @@ export class User {
     getRole(): ROLE { return this.role; };
     getAuthentication(): Token { return this.authentication; };
 
-    async getPhone(): Promise<Phone> { return (await this.phone)[0]; };
-    async getEmail(): Promise<Email> { return (await this.email)[0]; };
-    async getProfile(): Promise<UserProfile> { return (await this.profile)[0]; };
+    async getPhone(): Promise<Phone> { return await this.phone; };
+    async getEmail(): Promise<Email> { return await this.email; };
+    async getProfile(): Promise<UserProfile> { return await this.profile; };
 
     withEmail(email: Email): User { 
-        this.email = Promise.resolve([email]); 
+        this.email = Promise.resolve(email); 
         return this;
     };
 
     withProfile(userProfile: UserProfile): User {
-        this.profile = Promise.resolve([userProfile]);
+        this.profile = Promise.resolve(userProfile);
         return this;
     }
 
     withPhone(phone: Phone): User {
-        this.phone = Promise.resolve([phone]);
+        this.phone = Promise.resolve(phone);
         return this;
     };
 


### PR DESCRIPTION
OneToOne 관계에서 Lazy Loading이 안되는 줄 알았지만,
관계의 문제가 아닌 생성자 초기화 문제이므로 다시 수정