### PR TITLE
[백엔드] TypeORM Repository Test Connection DataSource로 변경

### DIFF
--- a/backend/test/unit/chat/infra/chat-room-repository.spec.ts
+++ b/backend/test/unit/chat/infra/chat-room-repository.spec.ts
@@ -5,6 +5,7 @@ import { ChatRoomRepository, customRoomRepositoryMethods } from "src/chat/domain
 import { TestTypeOrm } from "test/unit/common/database/datebase-setup.fixture";
 import { DataSource } from "typeorm";
 import { ChatFixtures } from "../chat.fixtures";
+import { ApplicationCode } from "src/chat/domain/entity/application-code.entity";
 
 describe('ChatRoomRepository(채팅방 저장소) Test', () => {
     let dataSource: DataSource;
@@ -12,7 +13,7 @@ describe('ChatRoomRepository(채팅방 저장소) Test', () => {
     
     beforeAll(async() => {
         dataSource = await TestTypeOrm.withEntities(
-            ChatRoom, ChatMessage, Participant
+            ChatRoom, ChatMessage, Participant, ApplicationCode
         )
         roomRepository = dataSource.getRepository(ChatRoom).extend(customRoomRepositoryMethods);
     });

--- a/backend/test/unit/profile/infra/repository/profile-like-history-repo.spec.ts
+++ b/backend/test/unit/profile/infra/repository/profile-like-history-repo.spec.ts
@@ -1,26 +1,19 @@
-import { Test, TestingModule } from "@nestjs/testing"
-import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm"
 import { ObjectId } from "mongodb"
 import { ProfileLike } from "src/profile/domain/entity/profile-like"
 import { ProfileLikeHistoryRepository, customProfileLikeHistoryMethods } from "src/profile/domain/repository/iprofile-like-history.repository"
-import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture"
+import { TestTypeOrm } from "test/unit/common/database/datebase-setup.fixture"
+import { DataSource } from "typeorm"
 
 describe('ProfileLikeHistoryRepository(찜 내역 저장소) Test', () => {
     let historyRepository: ProfileLikeHistoryRepository;
-    let module: TestingModule;
+    let dataSource: DataSource;
     
     beforeAll(async() => {
-        module = await Test.createTestingModule({
-            imports: [
-                TypeOrmModule.forRoot(TestTypeOrmOptions),
-                TypeOrmModule.forFeature([ProfileLike])
-            ]
-        }).compile();
-        historyRepository = module.get(getRepositoryToken(ProfileLike));
-        historyRepository = historyRepository.extend(customProfileLikeHistoryMethods)
+        dataSource = await TestTypeOrm.withEntities(ProfileLike);
+        historyRepository = dataSource.getRepository(ProfileLike).extend(customProfileLikeHistoryMethods);
     });
 
-    afterAll(async() => await module.close());
+    afterAll(async() => await TestTypeOrm.disconnect(dataSource));
 
     describe('findByProfileAndUserId()', () => {
         let profileId: string, userId: number;

--- a/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
+++ b/backend/test/unit/rank/infra/profile-view-record-repo.spec.ts
@@ -1,30 +1,22 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm";
 import { ObjectId } from "mongodb";
 import { ProfileViewRecord } from "src/rank/domain/entity/profile-view-record.entity";
 import { IActionRecordRepository } from "src/rank/domain/iaction-record.repository"
 import { profileViewRecordRepoMethods } from "src/rank/infra/profile-view-record.repository";
-import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture";
+import { TestTypeOrm } from "test/unit/common/database/datebase-setup.fixture";
+import { DataSource } from "typeorm";
 
 describe('프로필 조회 기록 저장소(ProfileViewRecordRepository', () => {
     let profileViewRecordRepository: IActionRecordRepository<ProfileViewRecord>;
-    let module: TestingModule;
+    let dataSource: DataSource;
 
     beforeAll(async() => {
-        module = await Test.createTestingModule({
-            imports: [
-                TypeOrmModule.forRoot(TestTypeOrmOptions),
-                TypeOrmModule.forFeature([ProfileViewRecord])
-            ]
-        }).compile();
-
-        profileViewRecordRepository = module.get(getRepositoryToken(ProfileViewRecord));
-        profileViewRecordRepository = profileViewRecordRepository.extend(profileViewRecordRepoMethods);
+        dataSource = await TestTypeOrm.withEntities(ProfileViewRecord);
+        profileViewRecordRepository = dataSource.getRepository(ProfileViewRecord).extend(profileViewRecordRepoMethods);
     });
 
     afterAll(async() => {
         await profileViewRecordRepository.clear();
-        await module.close();
+        await TestTypeOrm.disconnect(dataSource);
     });
 
     describe('findRecordByActionAndUser', () => {

--- a/backend/test/unit/user/infra/repository/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/user-repository.spec.ts
@@ -1,33 +1,25 @@
-import { Test, TestingModule } from "@nestjs/testing"
-import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm"
 import { Token } from "src/user-auth-common/domain/entity/auth-token.entity"
 import { Phone } from "src/user-auth-common/domain/entity/user-phone.entity"
 import { UserProfile } from "src/user-auth-common/domain/entity/user-profile.entity"
 import { UserRepository, customUserRepositoryMethods } from "src/user-auth-common/domain/repository/user.repository"
 import { UUIDUtil } from "src/util/uuid.util"
-import { TestTypeOrmOptions } from "test/unit/common/database/datebase-setup.fixture"
+import { TestTypeOrm } from "test/unit/common/database/datebase-setup.fixture"
 import { Email } from "src/user-auth-common/domain/entity/user-email.entity"
 import { User } from "src/user-auth-common/domain/entity/user.entity"
 import {UserFixtures } from "../../user.fixtures"
 import { SEX } from "src/user-auth-common/domain/enum/user.enum"
+import { DataSource } from "typeorm"
 
 describe('사용자 저장소(UserRepository) Test', () => {
     let userRepository: UserRepository;
-    let module: TestingModule;
+    let dataSource: DataSource;
     
     beforeAll(async() => {
-        module = await Test.createTestingModule({
-            imports: [
-                TypeOrmModule.forRoot(TestTypeOrmOptions),
-                TypeOrmModule.forFeature([User, Phone, Email, UserProfile, Token])
-            ],
-        }).compile();
-        
-        userRepository = module.get(getRepositoryToken(User));
-        userRepository = userRepository.extend(customUserRepositoryMethods);
+        dataSource = await TestTypeOrm.withEntities(User, Phone, Email, UserProfile, Token);
+        userRepository = dataSource.getRepository(User).extend(customUserRepositoryMethods);
     })
 
-    afterAll(async() => await module.close() );
+    afterAll(async() => await TestTypeOrm.disconnect(dataSource) );
 
     afterEach(async() => await userRepository.delete({ }));
 


### PR DESCRIPTION
기존 Testing Module 생성 방식에서 사용할 Entity와 함께 Test