### PR TITLE
[백엔드] ChatRoomRepository에 findByUserId() 추가

### DIFF
--- a/backend/src/chat/domain/entity/application-code.entity.ts
+++ b/backend/src/chat/domain/entity/application-code.entity.ts
@@ -9,7 +9,7 @@ export class ApplicationCode {
     @Column({ name: 'application_id', type: 'int' })
     private applicationId: number
 
-    @OneToOne(() => ChatMessage, (message) => message.applicationCode)
+    @OneToOne(() => ChatMessage, (message) => message.applicationCode, { onDelete: 'CASCADE' })
     @JoinColumn({ referencedColumnName: 'id', name: 'message_id' })
     message: ChatMessage;
     

--- a/backend/src/chat/domain/entity/chat-message.entity.ts
+++ b/backend/src/chat/domain/entity/chat-message.entity.ts
@@ -47,6 +47,11 @@ export class ChatMessage {
             this.isRead = false;
     }
 
+    in(roomId: number): this{
+        this.roomId = roomId;
+        return this;
+    }
+
     withApplicationCode(applicationId: number): this { 
         this.applicationCode = new ApplicationCode(applicationId);
         return this;

--- a/backend/src/chat/domain/repository/chat-room.repository.ts
+++ b/backend/src/chat/domain/repository/chat-room.repository.ts
@@ -2,15 +2,55 @@ import { DataSource, Repository } from "typeorm";
 import { ChatRoom } from "../entity/chat-room.entity";
 import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
 import { Participant } from "../entity/participant.entity";
+import { ChatMessage } from "../entity/chat-message.entity";
+import { RoomListData } from "src/chat/interface/dto/room-list-data";
 
 export interface ChatRoomRepository extends Repository<ChatRoom> {
+    findByUserId(userId: number): Promise<RoomListData []>;
     findByUserIds(memberId1: number, memberId2: number): Promise<ChatRoom>;
 }
 
 export const customRoomRepositoryMethods: Pick<
     ChatRoomRepository,
+    'findByUserId' |
     'findByUserIds'
 > = {
+    async findByUserId(this: Repository<ChatRoom>, userId: number) {
+
+        const fetchRoomIdsQuery = `SELECT room_id FROM chat_room_participant WHERE user_id = ${userId}`;
+        
+        return await this.createQueryBuilder('room')
+                .innerJoin((subQuery) => {
+                    return subQuery
+                        .select([
+                            'room_id as roomId',
+                            'user_id as userId'
+                        ])
+                        .from(Participant, 'members')
+                        .where(`room_id IN (${fetchRoomIdsQuery})`)
+                }, 'members', 'room.id = members.roomId AND members.userId != :userId', { userId })
+                .innerJoin(ChatMessage, 'messages', 'room.id = messages.room_id and messages.is_read = :isRead', { isRead: false })
+                .innerJoin((subQuery) => {
+                    return subQuery
+                        .select([
+                            'applicationCode.id as applicationId',
+                            'applicationMessage.room_id as roomId'
+                        ])
+                        .from(ChatMessage, 'applicationMessage')
+                        .innerJoin('applicationMessage.applicationCode', 'applicationCode')
+                }, 'applicationMessage','room.id = applicationMessage.roomId')
+                .select('room.id as roomId') // 방 아이디
+                .addSelect('members.userId as chatPartnerId') // 채팅 상대방 아이디
+                .addSelect('messages.send_user_id as lastSendUserId') // 마지막 메시지 보낸 사용자 아이디
+                .addSelect('MAX(messages.content) as lastMessage') // 마지막 메시지 내용
+                .addSelect('COUNT(room.id) as unReadMessages') // 읽지 않은 메시지 개수
+                .addSelect('MAX(messages.sended_at) as sendedAt') // 마지막 메시지 보낸 시각
+                .addSelect('MAX(applicationMessage.applicationId) as applicationId') // 신청서 아이디
+                .orderBy('sendedAt', 'DESC') 
+                .groupBy('roomId, userId, lastSendUserId')
+                .getRawMany();
+    },
+
     async findByUserIds(this: Repository<ChatRoom>, memberId1: number, memberId2: number) {
         return await this.createQueryBuilder('room')
             .innerJoin((subQuery) => {

--- a/backend/src/chat/interface/dto/room-list-data.ts
+++ b/backend/src/chat/interface/dto/room-list-data.ts
@@ -1,0 +1,12 @@
+import { Time } from "src/common/shared/type/time.type";
+
+/* DB에서 조회 직후 Interface */
+export interface RoomListData {
+    roomId: number; // 방 번호
+    chatPartnerId: number; // 채팅 상대방 아이디
+    lastSendUserId: number; // 마지막 메시지 보낸 사용자 아이디
+    lastMessage: string; // 마지막 메시지
+    unReadMessages: string; // 읽지 않은 메시지 개수
+    sendedAt: Time; // 마지막 메시지 보낸 날짜
+    applicationId: number; // 해당 방의 최신 신청서 아이디
+}

--- a/backend/test/unit/chat/chat.fixtures.ts
+++ b/backend/test/unit/chat/chat.fixtures.ts
@@ -7,14 +7,14 @@ import { MessageType } from "src/chat/domain/enum/chat-message-type.enum";
 export class ChatFixtures {
 
     static createRoom(memberId1: number, memberId2: number): ChatRoom {
-        const message = new ChatMessage(memberId1, memberId2, MessageType.APPLICATION, ApplicationText.REQUESTED);
+        const message = this.createApplicationMessage(memberId1, memberId2, memberId2);
         const room = ChatRoom.start(new Participant(memberId1), new Participant(memberId2), message);
         return room;
     };
 
     /* 일반 텍스트 형태의 메시지 생성 */
-    static createTextMessage(memberId1: number, memberId2: number): ChatMessage {
-        const message = new ChatMessage(memberId1, memberId2, MessageType.TEXT, '테스트');
+    static createTextMessage(memberId1: number, memberId2: number, text: string = '테스트'): ChatMessage {
+        const message = new ChatMessage(memberId1, memberId2, MessageType.TEXT, text);
         return message;
     }
 

--- a/backend/test/unit/chat/infra/chat-room-repository.spec.ts
+++ b/backend/test/unit/chat/infra/chat-room-repository.spec.ts
@@ -6,19 +6,65 @@ import { TestTypeOrm } from "test/unit/common/database/datebase-setup.fixture";
 import { DataSource } from "typeorm";
 import { ChatFixtures } from "../chat.fixtures";
 import { ApplicationCode } from "src/chat/domain/entity/application-code.entity";
+import { ChatMessageRepository } from "src/chat/domain/repository/chat-message.repository";
 
 describe('ChatRoomRepository(채팅방 저장소) Test', () => {
     let dataSource: DataSource;
     let roomRepository: ChatRoomRepository;
-    
+    let messageRepository: ChatMessageRepository;
+
     beforeAll(async() => {
         dataSource = await TestTypeOrm.withEntities(
             ChatRoom, ChatMessage, Participant, ApplicationCode
         )
         roomRepository = dataSource.getRepository(ChatRoom).extend(customRoomRepositoryMethods);
+        messageRepository = dataSource.getRepository(ChatMessage);
     });
 
     afterAll(async() => await TestTypeOrm.disconnect(dataSource));
+
+    describe('findByUserId(', () => {
+        const memberId = 10;
+        let addMessageRoomId:number;
+
+        /* 시작 전 Dummy Data */
+        beforeAll(async() => {
+            /* 방 3개 생성 */
+            for( let i = 1; i <= 3; i++ ) {
+                const newRoom = ChatFixtures.createRoom(memberId, i);
+                const savedRoom = await roomRepository.save(newRoom);
+                
+                if( i == 2 ) addMessageRoomId = savedRoom.getId();
+            };
+        });
+
+        afterAll(async() => await roomRepository.delete({ }));
+
+        it('사용자가 속한 방을 모두 가져오는지 확인', async() => {
+            const result = await roomRepository.findByUserId(memberId);
+
+            expect(result.length).toBe(3);
+        });
+
+        it('각 방의 최신 메시지와 읽지 않는 메시지 개수를 맞게 가져오는지 확인', async () => {
+            const addMessageText = '추가하는 메시지';
+            const textMessage = 
+                ChatFixtures.createTextMessage(memberId, 100, addMessageText).in(addMessageRoomId);
+            
+            await messageRepository.save(textMessage);
+
+            const result = await roomRepository.findByUserId(memberId);
+            
+            /* 방 목록은 최신 메시지순이므로 메시지 추가한 방이 첫번째에 나타나게됨 */
+            result.map((room, index) => {
+                if( index == 0 ) {
+                    expect(room.lastMessage).toEqual(addMessageText);
+                    expect(room.unReadMessages).toBe('2'); 
+                }
+            });
+
+        })
+    });
 
     describe('findByUserIds()', () => {
         const [memberId1, memberId2] = [1,2];
@@ -28,7 +74,7 @@ describe('ChatRoomRepository(채팅방 저장소) Test', () => {
             await roomRepository.save(testRoom);
         });
 
-        afterAll(async() => await roomRepository.delete({} ));
+        afterAll(async() => await roomRepository.delete({ }));
         
         it('주어진 사용자들이 속한 방을 찾는지 확인', async() => {
             const result = await roomRepository.findByUserIds(memberId1, memberId2);


### PR DESCRIPTION
**findByUserId()**: 요청한 사용자의 채팅방 목록을 반환해주는 메서드
목록에서는 상대방의 이름, 마지막 메시지 내용, 마지막 메시지 날짜, 읽지 않은 메시지 개수, 해당 방의 마지막 신청서 현재 상태가 나타남

- ChatFixtures
    - createTextMessage(): 원하는 메시지 내용으로 생성할 수 있게 파라미터 수정

조회 결과로 UnReadMessages의 타입이 숫자가 아닌 문자열로 반환되는 문제가 있음