### PR TITLE
[백엔드] 데이터와 함께 Throw하는 Custom Conflict Exception 추가

### DIFF
--- a/backend/src/common/exception/all-exception.filter.ts
+++ b/backend/src/common/exception/all-exception.filter.ts
@@ -6,21 +6,23 @@ export class AllExceptionsFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost): void {
 
     const response = host.switchToHttp().getResponse();
-    let statusCode: number, message: string;
+    let statusCode: number, message: string, data: string;
 
     /* 400번대면 custom 매세지를 이외에는 표시되는 매세지로 */
     if (exception instanceof HttpException) {
       statusCode = exception.getStatus();
       message = exception['response']['message'] instanceof Array ?
-            exception['response']['message'][0] : exception['response']['message']
+            exception['response']['message'][0] : exception['response']['message'];
+      data = exception['response']?.data;
     } else {
       statusCode = 500;
       message = exception['message'];
     }
 
-    response.status(statusCode).send({ statusCode, message })
+    response.status(statusCode).send({ statusCode, message, data })
   }
 }
+
 
 export const GlobalScopedExceptionFilter: any = {
     provide: APP_FILTER,

--- a/backend/src/common/exception/resource-conflict.exception.ts
+++ b/backend/src/common/exception/resource-conflict.exception.ts
@@ -1,0 +1,15 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+
+/* 409에러와 함께 데이터를 넘겨주어야 하는 경우  */
+export class ResourceConflictException extends HttpException {
+    constructor(resourceId: any) {
+        super(
+            {
+                status: HttpStatus.CONFLICT,
+                message: 'Conflict',
+                data: resourceId
+            },
+            HttpStatus.CONFLICT
+        );
+    };
+}

--- a/backend/test/unit/common/exception/all-exception-filter.spec.ts
+++ b/backend/test/unit/common/exception/all-exception-filter.spec.ts
@@ -1,0 +1,59 @@
+import { ArgumentsHost, BadRequestException, HttpStatus } from "@nestjs/common";
+import { AllExceptionsFilter } from "src/common/exception/all-exception.filter"
+import { ResourceConflictException } from "src/common/exception/resource-conflict.exception";
+
+describe('AllExceptionFilter(오류 Catch) Test', () => {
+    let exceptionFilter: AllExceptionsFilter, mockHost: any;
+
+    beforeAll(() => {
+        exceptionFilter = new AllExceptionsFilter();
+
+        const mockResponse = {
+            status: jest.fn(() => mockResponse),
+            send: jest.fn()
+        };
+
+        mockHost = {
+            switchToHttp: () => ({
+                getResponse: () => mockResponse
+            })
+        } as ArgumentsHost;
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    describe('Custom Data가 있는 경우', () => {
+        describe('ResourceConflictException()', () => {
+            it('충돌한 ResourceId가 반환되는지 확인', () => {
+                const resourceId = 1;
+                const resoucreConflictException = new ResourceConflictException(resourceId);
+
+                exceptionFilter.catch(resoucreConflictException, mockHost);
+
+                const responseAfterCatchException = mockHost.switchToHttp().getResponse();
+
+                expect(responseAfterCatchException.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+                expect(responseAfterCatchException.send).toHaveBeenCalledWith({
+                    statusCode: HttpStatus.CONFLICT,
+                    data: resourceId,
+                    message: 'Conflict'
+                });
+            });
+        });
+    });
+
+    describe('Custom Data가 없는 경우', () => {
+        it('response 객체에 data 필드가 없는지 확인', () => {
+            const exception = new BadRequestException();
+
+            exceptionFilter.catch(exception, mockHost);
+
+            const responseAfterCatchException = mockHost.switchToHttp().getResponse();
+
+            expect(responseAfterCatchException.send).toHaveBeenCalledWith({
+                statusCode: HttpStatus.BAD_REQUEST,
+                message: 'Bad Request'
+            });
+        })
+    })
+})


### PR DESCRIPTION
ResourceConflictException(): HttpException을 상속받아 중복되는 ResoucreId로 생성자 초기화를 함

기존에 있던 Global Exception Handler인 AllExceptionsFilter에서는 data 필드가 있는 경우에만 response와 함께 넘겨줌