### PR TITLE
[백엔드] CareApplication Service arrived() 로직 수정

### DIFF
--- a/backend/src/care-application/application/service/care-application.service.ts
+++ b/backend/src/care-application/application/service/care-application.service.ts
@@ -5,31 +5,41 @@ import { CareApplicationRepository } from "src/care-application/domain/care-appl
 import { ICareAppliedService } from "./icare-applied.service";
 import { CARE_APPLIED_SERVICE } from "src/common/shared/constants";
 import { Transactional } from "typeorm-transactional";
+import { ChatRoom } from "src/chat/domain/entity/chat-room.entity";
+import { ChatRoomRepository } from "src/chat/domain/repository/chat-room.repository";
+import { CareAppliedDto } from "src/care-application/interface/dto/care-applied.dto";
 
 @Injectable()
 export class CareApplicationService {
     constructor(
         @InjectRepository(CareApplication)
         private readonly applicationRepository: CareApplicationRepository,
+        @InjectRepository(ChatRoom)
+        private readonly roomRepository: ChatRoomRepository,
         @Inject(CARE_APPLIED_SERVICE)
         private readonly careAppliedService: ICareAppliedService
     ) { }
 
     /* 간병 신청이 도착했을 때 */
     @Transactional()
-    async arrived(protectorId: number, caregiverId: number) {
-        await this.checkPreApplicationBeCompleted(protectorId, caregiverId);
+    async arrived(protectorId: number, caregiverId: number):Promise<CareAppliedDto> {
+        const previousApplication = await this.applicationRepository.findRecentApplicationFromIds(protectorId, caregiverId);
+
+        if( !previousApplication || previousApplication.isCompleted() ) 
+            return await this.createApplicationAndSend(protectorId, caregiverId);
         
-        /* 신청서 저장 이후 -> 채팅방을 통해 메시지 전송 */
+        return await this.getExistRoomId(protectorId, caregiverId);
+    }
+
+    /* 신청서 저장 이후 -> 채팅방을 통해 메시지 전송 */
+    async createApplicationAndSend(protectorId: number, caregiverId: number) {
         const newApplication = await this.applicationRepository.save(new CareApplication(protectorId, caregiverId));
         return await this.careAppliedService.applied(newApplication);
     }
 
-    /* 이전 신청이 완료되었는지 확인 */
-    private async checkPreApplicationBeCompleted(protectorId: number, caregiverId: number) {
-        const previousApplication =
-            await this.applicationRepository.findRecentApplicationFromIds(protectorId, caregiverId);
-
-        if (previousApplication) previousApplication.validate();
+    /* 기존 채팅방 아이디 return */
+    async getExistRoomId(protectorId: number, caregiverId: number) {
+        const existChatRoom = await this.roomRepository.findByUserIds(protectorId, caregiverId);
+        return { roomId: existChatRoom.getId() };
     }
 }

--- a/backend/src/care-application/domain/care-application.entity.ts
+++ b/backend/src/care-application/domain/care-application.entity.ts
@@ -1,8 +1,6 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { ApplicationStatus } from "../../chat/domain/enum/application-status.enum";
 import { Time } from "src/common/shared/type/time.type";
-import { ConflictException } from "@nestjs/common";
-import { ErrorMessage } from "src/common/shared/enum/error-message.enum";
 
 @Entity('care_application')
 @Index(["protectorId", "caregiverId"])
@@ -39,11 +37,8 @@ export class CareApplication {
     watched() { this.status = ApplicationStatus.WATCHED; };
     rejected() { this.status = ApplicationStatus.REJECTED; };
 
-    /* 해당 사용자가 신청한 내역 중 진행중인 내역이 있는지 */
-    validate(): void {
-        if( 
-            this.status == ApplicationStatus.REQUESTED ||
-            this.status == ApplicationStatus.WATCHED
-        ) throw new ConflictException(ErrorMessage.AlreadyHavePendingApplication);
+    /* 해당 사용자가 가장 최근에 신청한 내역이 완료됐는지 */
+    isCompleted(): boolean {
+        return (this.status == ApplicationStatus.REQUESTED || this.status == ApplicationStatus.WATCHED ) ? false : true;
     }
 }

--- a/backend/src/common/shared/enum/error-message.enum.ts
+++ b/backend/src/common/shared/enum/error-message.enum.ts
@@ -13,5 +13,4 @@ export const enum ErrorMessage {
     NotFoundProfile = '현재 해당 프로필은 비공개, 탈퇴의 이유로 찾을 수 없습니다.',
     DuplicatedLikeProfile = '이미 찜한 프로필입니다.',
     PermissionDeniedForRole = '역할의 권한이 맞지 않아 접근이 거부되었습니다.',
-    AlreadyHavePendingApplication = '이미 진행중인 신청 내역이 존재합니다.'
 }


### PR DESCRIPTION
arrived()의 로직을 이미 신청한 신청서가 완료되지 않았다면 기존 채팅방의 아이디를 반환

CareApplication 객체의 validate()를 isCompleted()로 수정