### PR TITLE
[백엔드] 내 채팅 방 조회 E2E Test 오류 수정

### DIFF
--- a/backend/src/chat/application/service/chat-room.service.ts
+++ b/backend/src/chat/application/service/chat-room.service.ts
@@ -28,6 +28,8 @@ export class ChatRoomService {
         /* 사용자가 속한 방 목록 조회 */
         const roomList = await this.roomRepository.findByUserId(userId); 
 
+        if( !roomList ) return null;
+
         /* 각 방의 상대방 닉네임, 최신의 신청서 상태를 조회하기 위해 id들 Set */
         const [applicationIdList, partnerIdList] = this.getApplicationAndPartnerIdList(roomList); 
 

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -30,7 +30,8 @@ import { ChatRoomRepositoryProvider } from "./domain/repository/chat-room.reposi
         ChatRoomRepositoryProvider
     ],
     exports: [
-        CARE_APPLIED_SERVICE
+        CARE_APPLIED_SERVICE,
+        ChatRoomRepositoryProvider
     ]
 })
 export class ChatModule {}

--- a/backend/src/chat/domain/repository/chat-room.repository.ts
+++ b/backend/src/chat/domain/repository/chat-room.repository.ts
@@ -6,7 +6,7 @@ import { ChatMessage } from "../entity/chat-message.entity";
 import { RoomListData } from "src/chat/interface/dto/room-list-data";
 
 export interface ChatRoomRepository extends Repository<ChatRoom> {
-    findByUserId(userId: number): Promise<RoomListData []>;
+    findByUserId(userId: number): Promise<RoomListData []> | null;
     findByUserIds(memberId1: number, memberId2: number): Promise<ChatRoom>;
 }
 
@@ -19,7 +19,7 @@ export const customRoomRepositoryMethods: Pick<
 
         const fetchRoomIdsQuery = `SELECT room_id FROM chat_room_participant WHERE user_id = ${userId}`;
         
-        return await this.createQueryBuilder('room')
+        const roomList = await this.createQueryBuilder('room')
                 .innerJoin((subQuery) => {
                     return subQuery
                         .select([
@@ -49,6 +49,7 @@ export const customRoomRepositoryMethods: Pick<
                 .orderBy('sendedAt', 'DESC') 
                 .groupBy('roomId, userId, lastSendUserId')
                 .getRawMany();
+        return !roomList.length ? null : roomList;
     },
 
     async findByUserIds(this: Repository<ChatRoom>, memberId1: number, memberId2: number) {

--- a/backend/test/unit/chat/infra/chat-room-repository.spec.ts
+++ b/backend/test/unit/chat/infra/chat-room-repository.spec.ts
@@ -62,7 +62,13 @@ describe('ChatRoomRepository(채팅방 저장소) Test', () => {
                     expect(room.unReadMessages).toBe('2'); 
                 }
             });
+        });
 
+        it('조회된 방이 없는 경우 null을 반환하는지 확인', async() => {
+            const notExistUserId = 1000000;
+            const result = await roomRepository.findByUserId(notExistUserId);
+
+            expect(result).toBe(null);
         })
     });
 


### PR DESCRIPTION
참가한 채팅 방이 없는 경우 null 값 체크를 하지 않아 채팅 방을 가지고 로직을 수행하는 부분에서 null 예외가 발생

ChatRoomRepository의 findByUserId() 메서드에서 데이터가 없는 경우 null로 반환하도록 수정