### PR TITLE
[백엔드] 125번 이슈 해결

### DIFF
--- a/backend/src/chat/domain/repository/chat-room.repository.ts
+++ b/backend/src/chat/domain/repository/chat-room.repository.ts
@@ -4,6 +4,7 @@ import { getDataSourceToken, getRepositoryToken } from "@nestjs/typeorm";
 import { Participant } from "../entity/participant.entity";
 import { ChatMessage } from "../entity/chat-message.entity";
 import { RoomListData } from "src/chat/interface/dto/room-list-data";
+import { plainToInstance } from "class-transformer";
 
 export interface ChatRoomRepository extends Repository<ChatRoom> {
     findByUserId(userId: number): Promise<RoomListData []> | null;
@@ -49,7 +50,7 @@ export const customRoomRepositoryMethods: Pick<
                 .orderBy('sendedAt', 'DESC') 
                 .groupBy('roomId, userId, lastSendUserId')
                 .getRawMany();
-        return !roomList.length ? null : roomList;
+        return !roomList.length ? null : plainToInstance(RoomListData, roomList);
     },
 
     async findByUserIds(this: Repository<ChatRoom>, memberId1: number, memberId2: number) {

--- a/backend/src/chat/interface/dto/get-room-list.dto.ts
+++ b/backend/src/chat/interface/dto/get-room-list.dto.ts
@@ -6,7 +6,7 @@ export interface GetRoomListDto {
     chatPartnerName: string; // 상대방 유저 이름
     lastSendUserId: number; // 마지막 메시지 보낸 사용자 아이디
     lastMessage: string; // 마지막 메시지
-    unReadMessages: string; // 읽지 않은 메시지 개수
+    unReadMessages: number; // 읽지 않은 메시지 개수
     sendedAt: Time; // 마지막 메시지 보낸 시간
     applicationId: number; // 신청서 아이디
     recentApplicationStatus: string; // 해당 방의 마지막 신청서 상태

--- a/backend/src/chat/interface/dto/room-list-data.ts
+++ b/backend/src/chat/interface/dto/room-list-data.ts
@@ -1,3 +1,4 @@
+import { Transform } from "class-transformer";
 import { Time } from "src/common/shared/type/time.type";
 
 /* DB에서 조회 직후 Interface */
@@ -6,8 +7,10 @@ export class RoomListData {
     chatPartnerId: number; // 채팅 상대방 아이디
     lastSendUserId: number; // 마지막 메시지 보낸 사용자 아이디
     lastMessage: string; // 마지막 메시지
-    unReadMessages: string; // 읽지 않은 메시지 개수
+    @Transform(({ value }) => parseInt(value))
+    unReadMessages: number; // 읽지 않은 메시지 개수
     sendedAt: Time; // 마지막 메시지 보낸 날짜
+    @Transform(({ value }) => parseInt(value))
     applicationId: number; // 해당 방의 최신 신청서 아이디
 
     static of(roomId: number, userId: number, applicationId: number): RoomListData {
@@ -16,7 +19,7 @@ export class RoomListData {
             chatPartnerId: userId,
             lastSendUserId: 1,
             lastMessage: '테스트 문자',
-            unReadMessages: '1',
+            unReadMessages: 1,
             sendedAt: new Date(),
             applicationId
         }

--- a/backend/src/user-auth-common/domain/repository/user.repository.ts
+++ b/backend/src/user-auth-common/domain/repository/user.repository.ts
@@ -43,7 +43,7 @@ export const customUserRepositoryMethods: Pick<
 
         async findNamesByIds(this: Repository<User>, userIdList: number[]) {
             return await this.createQueryBuilder()
-                .select('name')
+                .select(['id', 'name'])
                 .where('id IN (:...userIds)', { userIds: userIdList })
                 .getRawMany();
         },

--- a/backend/test/unit/care-application/infra/care-application-repo.spec.ts
+++ b/backend/test/unit/care-application/infra/care-application-repo.spec.ts
@@ -58,8 +58,9 @@ describe('CareApplicationRepository(간병 신청서) Test', () => {
         it('신청서들의 상태를 맞게 가져오는지 확인', async () => {
             const result = await applicationRepository.findStatusByIds(applicationIdList);
 
-            result.map( ({ status }, index) => {
-                expect(status).toBe(testApplicaiontList[index].getStatus());
+            result.map( ( application, index) => {
+                expect(application.status).toBe(testApplicaiontList[index].getStatus());
+                expect(Number.isInteger(application.id)).toBe(true);
             });
         })
     })

--- a/backend/test/unit/chat/infra/chat-room-repository.spec.ts
+++ b/backend/test/unit/chat/infra/chat-room-repository.spec.ts
@@ -54,12 +54,12 @@ describe('ChatRoomRepository(채팅방 저장소) Test', () => {
             await messageRepository.save(textMessage);
 
             const result = await roomRepository.findByUserId(memberId);
-            
+
             /* 방 목록은 최신 메시지순이므로 메시지 추가한 방이 첫번째에 나타나게됨 */
             result.map((room, index) => {
                 if( index == 0 ) {
                     expect(room.lastMessage).toEqual(addMessageText);
-                    expect(room.unReadMessages).toBe('2'); 
+                    expect(room.unReadMessages).toBe(2); 
                 }
             });
         });

--- a/backend/test/unit/user/infra/repository/user-repository.spec.ts
+++ b/backend/test/unit/user/infra/repository/user-repository.spec.ts
@@ -117,8 +117,9 @@ describe('사용자 저장소(UserRepository) Test', () => {
         it('아이디에 해당하는 사용자들의 이름을 가져오는지 확인', async () => {
             const result = await userRepository.findNamesByIds(idList);
 
-            result.map( ({name}) => {
-                expect(testNameList.indexOf(name)).not.toBe(-1);
+            result.map( (user) => {
+                expect(testNameList.indexOf(user.name)).not.toBe(-1);
+                expect(user).toHaveProperty('id');
             })
         });
     });


### PR DESCRIPTION
**Fixed #125**

-  상대방 이름이 넘어오지 않는 오류: Select에서 'id' 컬럼을 제외하고 반환하여 이후 Map을 통해 찾는 과정에서 찾지 못함
    - 'id' 컬럼을 추가하여 해결

- 최신 신청서의 상태가 넘어오지 않는 오류: 집계 함수를 사용하여 applicationId의 타입이 string으로 반환되어 Map을 통해 찾는 과정에서 찾지 못함
    - Transform을 통해 Number 타입으로 통일시켜줌